### PR TITLE
Code Quality Audit R1: 10 fixes — Code.gs v62 + DataEngine.gs v80

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,6 +1,6 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// Code.gs v61 — Apps Script Router (TBM Consolidated)
+// Code.gs v62 — Apps Script Router (TBM Consolidated)
 // WRITES TO: (routes only — delegates to DataEngine, KidsHub, etc.)
 // READS FROM: (routes only — delegates to DataEngine, KidsHub, etc.)
 // ════════════════════════════════════════════════════════════════════
@@ -9,7 +9,7 @@
 // All .gs files share GAS global scope, so DE's TAB_MAP is available here.
 // DO NOT redeclare var TAB_MAP in this file.
 
-function getCodeVersion() { return 61; }
+function getCodeVersion() { return 62; }
 
 // v37 FIX 5: ES5-safe left-pad helper — replaces String.padStart()
 function leftPad2_(n) {
@@ -179,7 +179,7 @@ function bustCache() {
 /** Read KH heartbeat timestamp from Helpers!Z1. Lightweight single-cell read. */
 function getKHLastModified() {
   try {
-    var ss = SpreadsheetApp.getActiveSpreadsheet();
+    var ss = SpreadsheetApp.openById(SSID);
     var hn = typeof TAB_MAP !== 'undefined' ? (TAB_MAP['Helpers'] || 'Helpers') : 'Helpers';
     var sh = ss.getSheetByName(hn);
     if (sh) {
@@ -287,7 +287,8 @@ function doPost(e) {
     return ContentService.createTextOutput(JSON.stringify(result))
       .setMimeType(ContentService.MimeType.JSON);
   } catch (err) {
-    return ContentService.createTextOutput(JSON.stringify({ error: err.message }))
+    if (typeof logError_ === 'function') logError_('doPost', err);
+    return ContentService.createTextOutput(JSON.stringify({ error: 'Request failed' }))
       .setMimeType(ContentService.MimeType.JSON);
   }
 }
@@ -313,7 +314,8 @@ function serveData(e) {
         'facts': 'fact-sprint', 'reading': 'reading-module',
         'writing': 'writing-module',
         'investigation': 'investigation-module', 'daily-missions': 'daily-missions',
-        'baseline': 'BaselineDiagnostic'
+        'baseline': 'BaselineDiagnostic',
+        'power-scan': 'wolfkid-power-scan'
       };
       var filename = routes[page] || 'ThePulse';
       try {
@@ -532,7 +534,7 @@ function getDataSafe(paramsOrStart, endArg, debtArg) {
       var cached = getCachedPayload_(cacheKey);
       if (cached) return cached;
     }
-    try { SpreadsheetApp.getActiveSpreadsheet().getSheetByName(TAB_MAP['Helpers'] || 'Helpers').getRange('Z1').setValue(new Date().toISOString()); } catch(e) { if (typeof logError_ === 'function') logError_('getDataSafe_heartbeat', e); }
+    try { SpreadsheetApp.openById(SSID).getSheetByName(TAB_MAP['Helpers'] || 'Helpers').getRange('Z1').setValue(new Date().toISOString()); } catch(e) { if (typeof logError_ === 'function') logError_('getDataSafe_heartbeat', e); }
     var raw = getData(start, end, true);
     var result = JSON.parse(JSON.stringify(raw));
     if (isCurrentMonth) {
@@ -753,7 +755,7 @@ function getSubscriptionDataSafe(start, end) {
 // ── KidsHub write wrappers ───────────────────────────────────────
 function _khDiag_(label, args, e) {
   try {
-    var ss = SpreadsheetApp.getActiveSpreadsheet();
+    var ss = SpreadsheetApp.openById(SSID);
     var hn = typeof TAB_MAP !== 'undefined' ? (TAB_MAP['KH_History'] || 'KH_History') : 'KH_History';
     var sh = ss ? ss.getSheetByName(hn) : null;
     if (sh) sh.appendRow(['ERROR_DIAG', label, JSON.stringify(args), e.message, 0, 0, 0, 'error', '',
@@ -1187,7 +1189,7 @@ function getBoardDataSafe() {
 // ════════════════════════════════════════════════════════════════════
 
 function getMERGateStatus() {
-  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var ss = SpreadsheetApp.openById(SSID);
   var qa = ss.getSheetByName(TAB_MAP['QA_Gates']);
   if (!qa) return { error: true, message: 'QA_Gates sheet not found' };
   var data = qa.getRange('A1:G15').getValues();
@@ -1232,7 +1234,7 @@ function getAllVaultData() {
 }
 function readVaultSheet(sheetName) {
   try {
-    var ss = SpreadsheetApp.getActiveSpreadsheet();
+    var ss = SpreadsheetApp.openById(SSID);
     var sheet = ss.getSheetByName(TAB_MAP[sheetName] || sheetName);
     if (!sheet) return [];
     var data = sheet.getDataRange().getValues();
@@ -1264,7 +1266,7 @@ function getVaultDataSafe() {
 // ════════════════════════════════════════════════════════════════════
 
 function healthCheck() {
-  Logger.log('═══ Code.gs v49 Health Check ═══');
+  Logger.log('═══ Code.gs v62 Health Check ═══');
 
   var fns = [
     'doGet', 'servePage', 'serveData', 'getDataSafe', 'getMonthsSafe',
@@ -1323,7 +1325,12 @@ function healthCheck() {
     // v53: Feedback + Audio + Notion write-backs
     'setupFeedbackSheet', 'submitFeedbackSafe',
     'getAudioBatchSafe',
-    'logHomeworkCompletionSafe', 'logSparkleProgressSafe'
+    'logHomeworkCompletionSafe', 'logSparkleProgressSafe',
+    // v62: Education + Batch + PowerScan
+    'awardRingsSafe', 'getKHLastModifiedSafe', 'khBatchApproveSafe',
+    'runTestsSafe', 'seedStaarRlaSprintSafe',
+    'savePowerScanResultsSafe', 'logQuestionResultSafe',
+    'getWeeklyProgressSafe'
   ];
   var allOk = true;
   for (var fi = 0; fi < fns.length; fi++) {
@@ -1335,7 +1342,10 @@ function healthCheck() {
   }
 
   Logger.log('─── HTML Files (2-Surface Architecture) ───');
-  var activeFiles = ['TheVein', 'ThePulse', 'Vault', 'KidsHub', 'TheSpine', 'TheSoul', 'StoryLibrary'];
+  var activeFiles = ['TheVein', 'ThePulse', 'Vault', 'KidsHub', 'TheSpine', 'TheSoul', 'StoryLibrary',
+    'HomeworkModule', 'SparkleLearning', 'fact-sprint', 'reading-module', 'writing-module',
+    'wolfkid-power-scan', 'investigation-module', 'daily-missions', 'BaselineDiagnostic',
+    'StoryReader', 'ComicStudio', 'ProgressReport', 'WolfkidCER', 'DesignDashboard'];
   for (var ai = 0; ai < activeFiles.length; ai++) {
     var fname = activeFiles[ai];
     try {
@@ -1405,7 +1415,7 @@ function healthCheck() {
   }
 
   Logger.log('─── Legacy Checks ───');
-  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var ss = SpreadsheetApp.openById(SSID);
   var pe = ss.getSheetByName(TAB_MAP['Partner_Export'] || 'Partner_Export');
   Logger.log('  Partner_Export: ' + (pe ? '✓ (' + pe.getLastRow() + ' rows)' : '✗ NOT FOUND'));
 
@@ -1577,7 +1587,7 @@ function reconcileVeinPulseSafe() {
 // 8. RECONCILE STATUS SHEET + TRIGGER
 // ════════════════════════════════════════════════════════════════════
 function writeReconcileStatus_(result) {
-  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var ss = SpreadsheetApp.openById(SSID);
   var tabName = TAB_MAP['RECONCILE_STATUS'] || 'RECONCILE_STATUS';
   var sheet = ss.getSheetByName(tabName);
   if (!sheet) {
@@ -1596,7 +1606,7 @@ function writeReconcileStatus_(result) {
 function getReconcileStatusSafe() {
   return withMonitor_('getReconcileStatusSafe', function() {
     try {
-      var ss = SpreadsheetApp.getActiveSpreadsheet();
+      var ss = SpreadsheetApp.openById(SSID);
       var sheet = ss.getSheetByName(TAB_MAP['RECONCILE_STATUS'] || 'RECONCILE_STATUS');
       if (!sheet) return { lastReconcileAt: null, lastReconcileStatus: 'UNKNOWN', lastReconcileVersions: '' };
       return {
@@ -1624,4 +1634,4 @@ function removeReconciliationTrigger() {
     }
   }
 }
-// END OF FILE — Code.gs v58
+// END OF FILE — Code.gs v62

--- a/Dataengine.js
+++ b/Dataengine.js
@@ -1,10 +1,10 @@
 // ════════════════════════════════════════════════════════════════════
-// DATA ENGINE v79 — Dynamic KPI Computation from Raw Tiller Data
-// WRITES TO: 💻🧮 Dashboard_Export, 💻🧮 Debt_Export, 💻🧮 DebtModel, 💻🧮 Cascade Proof, 💻🧮 Cascade Month-by-Month, 💻🧮 Cascade Payoff Schedule
+// DATA ENGINE v80 — Dynamic KPI Computation from Raw Tiller Data
+// WRITES TO: 💻🧮 Dashboard_Export, 💻🧮 Debt_Export, 💻🧮 DebtModel, 💻🧮 Cascade Proof, 💻🧮 Cascade Month-by-Month, 💻🧮 Cascade Payoff Schedule, 📋 Board_Config, 💻 MealPlan
 // READS FROM: 🔒 Transactions, 🔒 Balance History, 🔒 Categories, 💻🧮 Budget_Data, 💻🧮 Helpers, 💻🧮 DebtModel, 💻🧮 BankRec, 💻🧮 Budget_Rules
 // ════════════════════════════════════════════════════════════════════
 
-function getDataEngineVersion() { return 79; }
+function getDataEngineVersion() { return 80; }
 
 // ════════════════════════════════════════════════════════════════════
 //
@@ -66,7 +66,7 @@ function de_testGetDebtByType_() {
  * Diagnostic — run this to see exactly what Balance History + Debt_Export contain.
  */
 function diagBalanceSheet() {
-  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var ss = getDESS_();
 
   var bh = ss.getSheetByName(TAB_MAP['Balance History']);
   var headers = bh.getRange(1, 1, 1, 15).getValues()[0];
@@ -225,9 +225,7 @@ var TAB_MAP = {
   'Feedback':         '💻 Feedback',
   'MealPlan':         '💻 MealPlan',
   // 📋 Board Config
-  'Board_Config':     '📋 Board_Config',
-  // 💻 Meal Plan (v78)
-  'MealPlan':         '💻 MealPlan'
+  'Board_Config':     '📋 Board_Config'
 };
 
 // v73: Request-scoped sheet data cache — same pattern as KidsHub v25.
@@ -1172,7 +1170,7 @@ function getMonthFractions(startDate, endDate) {
     var rangeEnd = endDate < monthEnd ? endDate : monthEnd;
     var coveredDays = Math.floor((rangeEnd - rangeStart) / 86400000) + 1;
     var fraction = Math.min(1, Math.max(0, coveredDays / daysInMonth));
-    var ym = y + '-' + String(m + 1).padStart(2, '0');
+    var ym = y + '-' + leftPad2_(m + 1);
     fractions[ym] = fraction;
     cursor = new Date(y, m + 1, 1);
   }
@@ -1188,7 +1186,7 @@ function formatDate(d) {
   if (!d) return null;
   if (typeof d === 'string') return d;
   if (d instanceof Date) {
-    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+    return d.getFullYear() + '-' + leftPad2_(d.getMonth() + 1) + '-' + leftPad2_(d.getDate());
   }
   return String(d);
 }
@@ -1427,7 +1425,7 @@ function getLOCCapacity() {
     if (!txDate) continue;
     if (typeof txDate === 'string') txDate = new Date(txDate);
     if (!(txDate instanceof Date) || isNaN(txDate.getTime())) continue;
-    var ym = txDate.getFullYear() + '-' + String(txDate.getMonth() + 1).padStart(2, '0');
+    var ym = txDate.getFullYear() + '-' + leftPad2_(txDate.getMonth() + 1);
     if (!drawsByMonth[ym]) drawsByMonth[ym] = 0;
     drawsByMonth[ym] += txAmt;
   }
@@ -1442,7 +1440,7 @@ function getLOCCapacity() {
     drawHistory.push({ ym: ym, label: label, amount: roundTo(drawsByMonth[ym], 2) });
   }
 
-  var currentYM = now.getFullYear() + '-' + String(now.getMonth() + 1).padStart(2, '0');
+  var currentYM = now.getFullYear() + '-' + leftPad2_(now.getMonth() + 1);
   var recentDraws = [];
   for (var r = drawHistory.length - 1; r >= 0 && recentDraws.length < 3; r--) {
     if (drawHistory[r].ym === currentYM) continue;
@@ -1633,7 +1631,7 @@ function getCashFlowForecast() {
     if (!txDate || !txCat) continue;
     if (typeof txDate === 'string') txDate = new Date(txDate);
     if (!(txDate instanceof Date) || isNaN(txDate.getTime())) continue;
-    var ym = txDate.getFullYear() + '-' + String(txDate.getMonth() + 1).padStart(2, '0');
+    var ym = txDate.getFullYear() + '-' + leftPad2_(txDate.getMonth() + 1);
     if (!monthActuals[ym]) monthActuals[ym] = { income: 0, opex: 0 };
     if (EARNED_CATS.indexOf(txCat) >= 0 && txAmt > 0) monthActuals[ym].income += txAmt;
     if (txAmt < 0 && XFER_CATS.indexOf(txCat) < 0) monthActuals[ym].opex += Math.abs(txAmt);
@@ -1641,7 +1639,7 @@ function getCashFlowForecast() {
 
   var MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
   var dec2026 = monthBudgets['2026-12'] || {};
-  var currentMonth = now.getFullYear() + '-' + String(now.getMonth() + 1).padStart(2, '0');
+  var currentMonth = now.getFullYear() + '-' + leftPad2_(now.getMonth() + 1);
 
   // v30 FIX: Budget_Data stores ALL amounts as positive. Must use category name to determine income vs expense.
   var CFF_INCOME_CATS = ['JT Income', 'LT Income', 'Bonus Income', 'Other Income', 'Interest Income', 'Loan Proceeds'];
@@ -1668,7 +1666,7 @@ function getCashFlowForecast() {
   // v26: If dec 2026 is empty, scan backward for last populated month
   if (baseIncome === 0 || baseExpense === 0) {
     for (var _fb = 11; _fb >= 0; _fb--) {
-      var _fbYM = '2026-' + String(_fb + 1).padStart(2, '0');
+      var _fbYM = '2026-' + leftPad2_(_fb + 1);
       if (monthBudgets[_fbYM]) {
         var _fbSplit = cffSplitBudget(monthBudgets[_fbYM]);
         if (baseIncome === 0 && _fbSplit.income > 0) baseIncome = _fbSplit.income;
@@ -1689,7 +1687,7 @@ function getCashFlowForecast() {
 
   for (var yr = 2026; yr <= 2027; yr++) {
     for (var mo = 1; mo <= 12; mo++) {
-      var ym = yr + '-' + String(mo).padStart(2, '0');
+      var ym = yr + '-' + leftPad2_(mo);
       var label = MONTHS[mo - 1] + ' ' + yr;
       var projDate = new Date(yr, mo - 1, 15);
       var events = [];
@@ -1732,8 +1730,8 @@ function getCashFlowForecast() {
 
   return {
     months: months,
-    sofiJTPayoff: sofiJTPayoff.getFullYear() + '-' + String(sofiJTPayoff.getMonth() + 1).padStart(2, '0'),
-    sofiLTPayoff: sofiLTPayoff.getFullYear() + '-' + String(sofiLTPayoff.getMonth() + 1).padStart(2, '0'),
+    sofiJTPayoff: sofiJTPayoff.getFullYear() + '-' + leftPad2_(sofiJTPayoff.getMonth() + 1),
+    sofiLTPayoff: sofiLTPayoff.getFullYear() + '-' + leftPad2_(sofiLTPayoff.getMonth() + 1),
     cashPositiveYM: cashPositiveYM,
     // v26: Server-canonical cash-flow-positive date — kills hardcoded childcareDrop in WT/DS
     cashFlowPositiveDate: cashPositiveYM ? cashPositiveYM + '-01' : null,
@@ -2017,7 +2015,7 @@ function getSimulatorData() {
   var now = new Date();
   var y = now.getFullYear();
   var m = now.getMonth(); // 0-indexed
-  var ym = y + '-' + String(m + 1).padStart(2, '0');
+  var ym = y + '-' + leftPad2_(m + 1);
 
   var partnerBucketMap = getPartnerBucketMap();
   var BUCKET_KEYS = {
@@ -2487,7 +2485,7 @@ function getWeeklyTrackerData() {
   var y = now.getFullYear();
   var m = now.getMonth();
 
-  function pad(n) { return String(n).padStart(2, '0'); }
+  function pad(n) { return leftPad2_(n); }
   function fmtDate(d) { return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()); }
   function monthDays(yr, mo) { return new Date(yr, mo + 1, 0).getDate(); }
 
@@ -2541,9 +2539,9 @@ function getWeeklyTrackerData() {
 function verifyDataEngineFixes() {
   var now = new Date();
   var y = now.getFullYear();
-  var m = String(now.getMonth() + 1).padStart(2, '0');
+  var m = leftPad2_(now.getMonth() + 1);
   var start = y + '-' + m + '-01';
-  var end = y + '-' + m + '-' + String(now.getDate()).padStart(2, '0');
+  var end = y + '-' + m + '-' + leftPad2_(now.getDate());
 
   var data = getData(start, end, true);
   var deployedVersion = (data._meta && data._meta.version) ? data._meta.version : '?';
@@ -3212,7 +3210,7 @@ function _boardFormatEvent(evt, calName) {
   var m = start.getMinutes();
   var ampm = h >= 12 ? 'PM' : 'AM';
   var h12 = h % 12 || 12;
-  var timeStr = isAllDay ? 'All day' : h12 + ':' + String(m).padStart(2, '0') + ' ' + ampm;
+  var timeStr = isAllDay ? 'All day' : h12 + ':' + leftPad2_(m) + ' ' + ampm;
   return {
     title:        evt.getTitle(),
     timeStr:      timeStr,
@@ -3261,7 +3259,7 @@ function de_openMeteoIcon_(code) {
 // ════════════════════════════════════════════════════════════════════
 
 function setupBoardConfig() {
-  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var ss = getDESS_();
   var existing = ss.getSheetByName('📋 Board_Config');
   if (existing) {
     Logger.log('📋 Board_Config already exists — no action taken.');
@@ -3384,4 +3382,4 @@ function de_buildSoulMoment_(boardPayload, kidsPayload) {
   return moments[idx];
 }
 
-// END OF FILE — DataEngine v79
+// END OF FILE — DataEngine v80


### PR DESCRIPTION
## Summary
Code quality audit score 78→95+ target. 10 fixes across 2 files.

| Fix | Sev | Description |
|-----|-----|-------------|
| F01 | 2 | Replace all `getActiveSpreadsheet()` with `openById(SSID)` in Code.gs (8 instances) |
| F02 | 2 | Version consistency — Code.gs header/getter/EOF all v62 |
| F03 | 2 | Replace all `padStart()` with `leftPad2_()` in DataEngine.gs (15 instances) |
| F04 | 3 | Remove duplicate MealPlan key in TAB_MAP |
| F05 | 3 | Replace `getActiveSpreadsheet()` with `getDESS_()` in DataEngine.gs |
| F06 | 3 | Add power-scan to htmlSource routes |
| F07 | 4 | Update healthCheck() — add 8 missing functions + 14 HTML files |
| F08 | 4 | Add Board_Config + MealPlan to WRITES TO header |
| F09 | 4 | doPost catch — logError_() + mask error message |
| F10 | — | DataEngine.gs version bump to v80 |

## Test plan
- [ ] `getKHLastModified()` from editor returns non-empty string
- [ ] `getMERGateStatus()` returns object with total > 0
- [ ] `grep -c "getActiveSpreadsheet" Code.js` = 0
- [ ] `grep -c "padStart" Dataengine.js` = 0
- [ ] `?action=runTests` all runtime PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)