### PR TITLE
Fix Day 1 schedule weekend check bug

### DIFF
--- a/daily-missions.html
+++ b/daily-missions.html
@@ -978,14 +978,14 @@ function render() {
     document.getElementById('header-emoji').textContent = '\uD83C\uDFAF';
   }
 
-  // Weekend check
-  if (dayOfWeek === 0 || dayOfWeek === 6) {
+  var schedule = currentChild === 'jj' ? JJ_SCHEDULE : BUGGSY_SCHEDULE;
+  var dayData = schedule[dayOfWeek];
+
+  // Weekend check — but allow Day 1 (key 0) to pass through
+  if (!dayData && (dayOfWeek === 0 || dayOfWeek === 6)) {
     renderWeekend(container);
     return;
   }
-
-  var schedule = currentChild === 'jj' ? JJ_SCHEDULE : BUGGSY_SCHEDULE;
-  var dayData = schedule[dayOfWeek];
   if (!dayData) {
     renderWeekend(container);
     return;


### PR DESCRIPTION
## Summary
- `dayOfWeek=0` (Day 1 Setup) was hitting the weekend guard before schedule lookup
- Now checks if schedule data exists for the day before falling through to weekend screen
- GAS already deployed @374

## Test plan
- [x] `thompsonfams.com/daily-missions` shows Day 1 Setup (not "No missions today")
- [x] Dashboard, Baseline, Power Scan all load from LAUNCH buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)