### PR TITLE
DesignDashboard server save + education submit fixes

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,6 +1,6 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// Code.gs v66 — Apps Script Router (TBM Consolidated)
+// Code.gs v67 — Apps Script Router (TBM Consolidated)
 // WRITES TO: (routes only — delegates to DataEngine, KidsHub, etc.)
 // READS FROM: (routes only — delegates to DataEngine, KidsHub, etc.)
 // ════════════════════════════════════════════════════════════════════
@@ -9,7 +9,7 @@
 // All .gs files share GAS global scope, so DE's TAB_MAP is available here.
 // DO NOT redeclare var TAB_MAP in this file.
 
-function getCodeVersion() { return 66; }
+function getCodeVersion() { return 67; }
 
 // v37 FIX 5: ES5-safe left-pad helper — replaces String.padStart()
 function leftPad2_(n) {
@@ -404,7 +404,8 @@ function serveData(e) {
         'getEducationQueueSafe': getEducationQueueSafe,
         'approveHomeworkSafe': approveHomeworkSafe,
         'getDailyScheduleSafe': getDailyScheduleSafe,
-        'checkDay1Safe': checkDay1Safe
+        'checkDay1Safe': checkDay1Safe,
+        'saveDesignChoicesSafe': saveDesignChoicesSafe
       };
 
       if (!fn || !API_WHITELIST[fn]) {
@@ -1607,4 +1608,4 @@ function removeReconciliationTrigger() {
     }
   }
 }
-// END OF FILE — Code.gs v66
+// END OF FILE — Code.gs v67

--- a/DesignDashboard.html
+++ b/DesignDashboard.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="tbm-version" content="v2">
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   @keyframes fadeUp {
@@ -542,8 +543,38 @@ function updateDashName(el) {
 }
 
 function lockItIn() {
-  state.submitted = true;
-  render();
+  var payload = {
+    child: 'buggsy',
+    theme: state.theme,
+    dashName: state.dashName,
+    mascot: state.mascot,
+    sectionHomework: state.sectionHomework,
+    sectionChores: state.sectionChores,
+    sectionRewards: state.sectionRewards,
+    date: new Date().toISOString()
+  };
+
+  if (TBM_TEST_MODE) {
+    console.log('[TEST MODE] saveDesignChoicesSafe skipped', payload);
+    state.submitted = true;
+    render();
+    return;
+  }
+
+  if (typeof google !== 'undefined' && google.script && google.script.run) {
+    google.script.run
+      .withSuccessHandler(function() {
+        state.submitted = true;
+        render();
+      })
+      .withFailureHandler(function(err) {
+        alert('Save failed — ' + (err && err.message ? err.message : 'unknown error') + '. Try again.');
+      })
+      .saveDesignChoicesSafe(payload);
+  } else {
+    state.submitted = true;
+    render();
+  }
 }
 
 /* ===== RENDER ===== */

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v43 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v44 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 43; }
+function getKidsHubVersion() { return 44; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -3801,5 +3801,22 @@ function checkDay1Safe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v43
+// ── DESIGN CHOICES ──────────────────────────────────────────────
+function saveDesignChoices_(payload) {
+  var child = String(payload && payload.child || '').toLowerCase();
+  if (child !== 'buggsy' && child !== 'jj') {
+    return { error: true, message: 'Invalid child' };
+  }
+  var props = PropertiesService.getScriptProperties();
+  props.setProperty('DESIGN_CHOICES_' + child, JSON.stringify(payload));
+  return { status: 'ok' };
+}
+
+function saveDesignChoicesSafe(payload) {
+  return withMonitor_('saveDesignChoicesSafe', function() {
+    return JSON.parse(JSON.stringify(saveDesignChoices_(payload)));
+  });
+}
+
+// END OF FILE — KidsHub.gs v44
 // ════════════════════════════════════════════════════════════════════

--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -303,7 +303,8 @@ function getShimScript() {
 '    "saveMissionStateSafe","getMissionStateSafe",\n' +
 '    "submitHomeworkSafe","getEducationQueueSafe","approveHomeworkSafe",\n' +
 '    "getDailyScheduleSafe",\n' +
-'    "checkDay1Safe"\n' +
+'    "checkDay1Safe",\n' +
+'    "saveDesignChoicesSafe"\n' +
 '  ];\n' +
 '\n' +
 '  for (var i = 0; i < FNS.length; i++) {\n' +


### PR DESCRIPTION
## Summary
- **DesignDashboard**: `lockItIn()` was purely client-side — choices never saved. Now calls `saveDesignChoicesSafe()` which stores to Script Properties
- **BaselineDiagnostic**: `logHomeworkCompletion` → `logHomeworkCompletionSafe` (fixed in PR #27, already merged)
- New server function + API whitelist + CF Worker FNS entries

## Test plan
- [ ] `/dashboard` → complete wizard → Lock It In → no error alert = saved
- [ ] `/baseline?child=jj` → complete → submit → "Saved successfully"
- [ ] Verify Script Properties has `DESIGN_CHOICES_buggsy` key after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)