### PR TITLE
fix: PR #39 + #40 review findings

### DIFF
--- a/KidsHub.html
+++ b/KidsHub.html
@@ -1889,7 +1889,7 @@ function buildBuggsyLoadingScreen() {
   // Flying rings
   // Gold + blue rings — 3 gold, 2 blue, 1 orange, 0 red
   var ringEmojis = ['\uD83D\uDFE1','\uD83D\uDFE1','\uD83D\uDD35','\uD83D\uDFE0','\uD83D\uDFE1','\uD83D\uDD35'];
-  for (var ri = 0; ri < 9; ri++) {
+  for (var ri = 0; ri < 6; ri++) {
     var ring = document.createElement('div');
     ring.style.cssText = 'position:absolute;font-size:' + (Math.floor(Math.random()*16+12)) + 'px;opacity:0;pointer-events:none;top:' + (Math.random()*85+5) + '%;animation:bFlyRing ' + (Math.random()*2+1) + 's linear ' + (Math.random()*4) + 's infinite;';
     ring.textContent = ringEmojis[ri%ringEmojis.length];
@@ -3511,7 +3511,7 @@ function pBatchApprove(child) {
       if (eduEl) eduEl.textContent = 'Education data unavailable';
     }
     // Load education queue
-    if (typeof google !== 'undefined' && google.script && google.script['run']) {
+    if (typeof google !== 'undefined' && google.script && google.script.run) {
       google.script.run
         .withSuccessHandler(function(eduData) {
           _v2RenderEducation(eduData);

--- a/SparkleLearning.html
+++ b/SparkleLearning.html
@@ -659,7 +659,7 @@ function autoMatchAudio(text) {
   var positives = ['awesome', 'super', 'great job', 'yes', 'you found', 'beautiful', 'amazing', 'wonderful', 'perfect', 'nice'];
   for (var p = 0; p < positives.length; p++) {
     if (t.indexOf(positives[p]) !== -1) {
-      var idx = Math.floor(Math.random() * 8) + 1;
+      var idx = Math.floor(Math.random() * 4) + 1;
       return 'jj_feedback_correct' + idx + '.mp3';
     }
   }
@@ -717,7 +717,8 @@ function autoMatchAudio(text) {
 
   // Instruction patterns
   if (t.indexOf('pick a game') !== -1) { return 'jj_instruction_pick_game.mp3'; }
-  if (t.indexOf('what comes next') !== -1 || t.indexOf('what color') !== -1) { return 'jj_instruction_what_next.mp3'; }
+  if (t.indexOf('what color') !== -1) { return 'jj_instruction_what_color.mp3'; }
+  if (t.indexOf('what comes next') !== -1) { return 'jj_instruction_what_next.mp3'; }
   if (t.indexOf('tap each') !== -1 || t.indexOf('count') !== -1) { return 'jj_instruction_count.mp3'; }
   if (t.indexOf('build the name') !== -1 || t.indexOf('spell') !== -1) { return 'jj_instruction_name_game.mp3'; }
 


### PR DESCRIPTION
## Summary
- **SparkleLearning.html**: Constrain audio matcher to preloaded clips (1-4, not 1-8), fix "what color" mapping to correct clip
- **KidsHub.html**: Fix ENV-006B guard to use consistent dot notation, fix loading ring loop to match 3+2+1=6 spec

## Changes (4 edits, 2 files)

### SparkleLearning.html
- `autoMatchAudio()` positive feedback: `Math.random() * 8` → `Math.random() * 4` (clips 5-8 aren't preloaded)
- Split combined condition: "what color" → `jj_instruction_what_color.mp3` (was incorrectly using `what_next`)
- Sanity checked all matcher outputs against phrases.json: **zero mismatches**

### KidsHub.html
- ENV-006B guard: `google.script['run']` → `google.script.run` (matches actual call on next line)
- Loading ring loop: `ri < 9` → `ri < 6` (ringEmojis array has exactly 6 entries: 3 gold, 2 blue, 1 orange)

## Risks
- Audio: clips `jj_feedback_correct5-8` exist in phrases.json but are now unreachable from autoMatchAudio(). No user-visible impact — they were never guaranteed preloaded anyway.
- Ring count: visual change from 9 → 6 rings in Buggsy loading screen. Matches spec, but may look slightly different from what was last deployed.

## Test plan
- [ ] Load SparkleLearn, trigger positive feedback — verify Nia audio plays (clips 1-4 only)
- [ ] Load SparkleLearn, trigger "what color" prompt — verify correct audio
- [ ] Load Buggsy board — verify loading screen shows 6 rings (3 gold, 2 blue, 1 orange)
- [ ] Load parent dashboard — verify education queue loads without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)