### PR TITLE
Track 1.5: ThePulse KidsHub parity — port TheVein full card layout

### DIFF
--- a/ThePulse.html
+++ b/ThePulse.html
@@ -1243,9 +1243,9 @@ function _renderKidsWidget(data) {
     var s = kid.stats || {};
     var req = kid.requiredStatus || {};
     var avatar = key === 'buggsy' ? 'https://i.ibb.co/Y7rjjNDg/1773710329577.png' : 'https://i.ibb.co/N2Qn0J0Q/1773720439302.png';
-    var completedCount = req.done || s.completedCount || 0;
-    var totalTasks = req.total || s.totalTasks || 0;
-    var pct = totalTasks > 0 ? Math.round(completedCount / totalTasks * 100) : (s.completionPct || 100);
+    var completedCount = (req.done != null) ? req.done : ((s.completedCount != null) ? s.completedCount : 0);
+    var totalTasks = (req.total != null) ? req.total : ((s.totalTasks != null) ? s.totalTasks : 0);
+    var pct = totalTasks > 0 ? Math.round(completedCount / totalTasks * 100) : (s.completionPct != null ? s.completionPct : 100);
     var earnedPoints = s.earnedPoints || 0;
     var pendingCount = s.pendingCount || 0;
     var st = kid.screenTime || {};


### PR DESCRIPTION
## Track 1.5 — Deploy Manifest (Gate 4)
```
grep -n "buildKidCard" ThePulse.html           → function definition + 2 call sites (buggsy + jj)
grep -n "kids-grid" ThePulse.html              → CSS definition + div.kids-grid in body.innerHTML
grep -n "kid-next-reward" ThePulse.html        → present inside buildKidCard
grep -n "kids-budget-footer" ThePulse.html     → present in budgetHTML assembly
grep -n "kid-avatar" ThePulse.html             → CSS class + img.kid-avatar in buildKidCard
grep -n "tbm-version.*v61" ThePulse.html       → <meta name="tbm-version" content="v61">
grep -n "TBM_VERSION.*v61" ThePulse.html       → var TBM_VERSION = 'v61';
```

## Track 1.5 — Feature Verification Checklist (Gate 5)
```
# ThePulse KidsHub Parity
# Spec: Track 1 Pre-QA Code Prompts — April 6 2026
# New items: 9

## New (this build)
- [ ] ThePulse KidsHub section uses .kids-grid (2-column layout, not compact rows)
- [ ] Each card shows kid avatar via .kid-avatar class (not inline 32px style)
- [ ] Each card shows earned points in .kid-points with RINGS/STARS label below
- [ ] Each card shows task progress bar (.kid-prog-wrap) with "X / Y done" + percentage
- [ ] Each card shows bank balance as .kid-stat-pill labeled "Bank"
- [ ] Each card shows TV Bank minutes as .kid-stat-pill
- [ ] Each card shows next reward in .kid-next-reward or "Max reward unlocked!"
- [ ] .kids-budget-footer (3 columns: Owed MTD, Approved, ~Weekly Rate) present below cards
- [ ] ThePulse warm palette active: .kid-card.buggsy background amber-tinted, .kid-card.jj pink-tinted (CSS vars, not TheVein hex values)
- [ ] ES5 clean in modified section: no arrow functions, no const/let, no template literals
- [ ] ThePulse v61: meta tag and TBM_VERSION both read "v61"
```

https://claude.ai/code/session_01NEY1uLwW6xDjg2zVTMgjCX