### PR TITLE
Fix P1: pass multiplier=0 to all skip/clear override call sites

### DIFF
--- a/KidsHub.html
+++ b/KidsHub.html
@@ -2431,7 +2431,7 @@ function bOverride(taskID, e) {
   google.script.run
     .withSuccessHandler(function(){ _actionInFlight = false; loadKidData(); })
     .withFailureHandler(function(err){ _actionInFlight = false; showBXP({clientX:window.innerWidth/2,clientY:window.innerHeight/2}, '❌ OOPS!'); t.completed = false; t.parentApproved = false; updateBuggsy(); })
-    .khOverrideTaskSafe(t.rowIndex, t.taskID);
+    .khOverrideTaskSafe(t.rowIndex, t.taskID, 0);
 }
 function bReset(mode, child) {
   if (!confirm('Reset ' + mode + ' quests for ' + child + '?')) return;
@@ -2933,7 +2933,7 @@ function jjOverride(taskID, e) {
   google.script.run
     .withSuccessHandler(function(){ _actionInFlight = false; loadKidData(); })
     .withFailureHandler(function(err){ _actionInFlight = false; jjStarPop({clientX:window.innerWidth/2,clientY:window.innerHeight/2}, 'Oops! Try again 💕'); t.completed = false; t.parentApproved = false; updateJJ(); })
-    .khOverrideTaskSafe(t.rowIndex, t.taskID);
+    .khOverrideTaskSafe(t.rowIndex, t.taskID, 0);
 }
 function jjReset(mode, child) { if(!confirm('Reset '+mode+' for JJ?'))return; google.script.run.withSuccessHandler(function(){loadKidData();}).withFailureHandler(function(e){ console.log('Reset failed: ' + (e && e.message ? e.message : 'unknown')); }).khResetTasksSafe(mode, child); }
 function jjConfetti(n) {

--- a/TheVein.html
+++ b/TheVein.html
@@ -2856,7 +2856,7 @@ function _kidsOverride(rowIndex, el, taskID) {
       console.error('Vein override failed:', err);
       initKidsWidget();
     })
-    .khOverrideTaskSafe(rowIndex, taskID);
+    .khOverrideTaskSafe(rowIndex, taskID, 0);
 }
 function _renderKidsWidget(data) {
   if (!data || data.error) {


### PR DESCRIPTION
## Fix P1 — Deploy Manifest (Gate 4)
```
grep -n "khOverrideTaskSafe(rowIndex, taskID, 0)" TheVein.html    → expected: 1 match at ~2859
grep -n "khOverrideTaskSafe(t.rowIndex, t.taskID, 0)" KidsHub.html → expected: 2 matches at ~2434 + ~2936
grep -n "khOverrideTaskSafe(p.ri, p.tid, mult)" KidsHub.html       → expected: 1 match (unchanged, already correct)
```

## Fix P1 — Feature Verification Checklist (Gate 5)
```
# P1 Override multiplier fix for PR #61
# Finding: skip call sites passed no multiplier; khOverrideTask() defaulted to 1 (full points)
# New items: 3

## New (this build)
- [ ] TheVein.html _kidsOverride() passes 0 as multiplier: .khOverrideTaskSafe(rowIndex, taskID, 0)
- [ ] KidsHub.html Buggsy clear path passes 0: .khOverrideTaskSafe(t.rowIndex, t.taskID, 0)
- [ ] KidsHub.html JJ clear path passes 0: .khOverrideTaskSafe(t.rowIndex, t.taskID, 0)
- [ ] KidsHub.html:3845 parent-approve path unchanged: still passes mult variable
- [ ] UI "Skip (0 pts)?" label and backend validMult=0 now agree — no points awarded on skip
```

https://claude.ai/code/session_01NEY1uLwW6xDjg2zVTMgjCX