### PR TITLE
Pipeline: Full CI/CD automation — Codex review + Playwright regression + GAS deploy + Pushover

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -1,0 +1,217 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to review
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: codex-pr-review-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Codex PR Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build PR diff
+        id: diff
+        run: |
+          git fetch origin main --depth=1
+          git diff origin/main...HEAD -- '*.js' '*.html' > pr_diff.txt
+          DIFF_BYTES=$(wc -c < pr_diff.txt)
+          echo "diff_bytes=$DIFF_BYTES" >> "$GITHUB_OUTPUT"
+          # Truncate to 12000 chars — keeps well under gpt-4o 128k context, costs ~$0.01/review
+          head -c 12000 pr_diff.txt > pr_diff_send.txt
+          if [ "$DIFF_BYTES" -gt 12000 ]; then
+            echo "truncated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "truncated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Send to OpenAI gpt-4o
+        id: review
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "verdict=SKIP" >> "$GITHUB_OUTPUT"
+            echo "## ⚠️ Codex PR Review: SKIPPED" > review_comment.md
+            echo "" >> review_comment.md
+            echo "**Missing secret:** \`OPENAI_API_KEY\` — configure it in repo Settings → Secrets." >> review_comment.md
+            exit 0
+          fi
+
+          python3 - <<'PY'
+          import json, os, sys, time, urllib.request, urllib.error
+
+          diff = open('pr_diff_send.txt').read()
+          truncated = os.environ.get('TRUNCATED', 'false') == 'true'
+
+          system_prompt = """You are a senior code reviewer for TBM (TillerBudgetMaster), a Google Apps Script \
++ HtmlService household finance and kids-chore system. Review the PR diff against these rules:
+
+P1 — CRITICAL (fail the check):
+1. No hardcoded sheet names with emoji prefixes — must use TAB_MAP from DataEngine.gs
+2. No SpreadsheetApp.getActiveSpreadsheet() — must use openById(SSID)
+3. No lock.tryLock() — must use waitLock(30000)
+4. No ES6 syntax in .html files (no let/const, no => arrows, no template literals ``, no ??, no ?., no async/await, no destructuring, no .includes(), no .find())
+5. Every google.script.run call must have a .withFailureHandler() chained
+6. Version must be bumped in all 3 locations: line-3 header comment, getter function, EOF comment
+
+P2 — WARNINGS (note but do not fail):
+7. No duplicate constants — global GAS scope is shared; never redeclare SSID, TAB_MAP, etc.
+8. New google.script.run calls must also be added to smoke test wiring check
+9. logError_() pattern used for error logging (not console.error or Logger.log for errors)
+
+Respond in this exact format:
+**Critical Violations (P1):** [list each with file and line if visible, or "None"]
+**Warnings (P2):** [list each or "None"]
+**Verdict:** PASS or FAIL"""
+
+          user_content = f"PR diff to review{' (truncated at 12000 chars)' if truncated else ''}:\n\n{diff}"
+
+          payload = {
+              "model": "gpt-4o",
+              "messages": [
+                  {"role": "system", "content": system_prompt},
+                  {"role": "user", "content": user_content}
+              ],
+              "max_tokens": 1200,
+              "temperature": 0
+          }
+
+          headers = {
+              "Content-Type": "application/json",
+              "Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"
+          }
+
+          last_error = None
+          for attempt in range(4):
+              try:
+                  req = urllib.request.Request(
+                      "https://api.openai.com/v1/chat/completions",
+                      data=json.dumps(payload).encode(),
+                      headers=headers,
+                      method="POST"
+                  )
+                  with urllib.request.urlopen(req, timeout=60) as resp:
+                      result = json.load(resp)
+                      with open('codex_response.json', 'w') as f:
+                          json.dump(result, f)
+                      sys.exit(0)
+              except urllib.error.HTTPError as e:
+                  last_error = e
+                  if e.code == 429 and attempt < 3:
+                      wait = 2 ** (attempt + 1)
+                      print(f"Rate limited (429), retrying in {wait}s...", file=sys.stderr)
+                      time.sleep(wait)
+                  elif e.code == 401:
+                      print("OpenAI auth failed — check OPENAI_API_KEY secret.", file=sys.stderr)
+                      with open('codex_response.json', 'w') as f:
+                          json.dump({"error": "auth_expired"}, f)
+                      sys.exit(0)
+                  else:
+                      print(f"OpenAI API error {e.code}: {e}", file=sys.stderr)
+                      with open('codex_response.json', 'w') as f:
+                          json.dump({"error": str(e)}, f)
+                      sys.exit(0)
+              except Exception as e:
+                  last_error = e
+                  if attempt < 3:
+                      time.sleep(2 ** (attempt + 1))
+
+          with open('codex_response.json', 'w') as f:
+              json.dump({"error": str(last_error)}, f)
+          PY
+
+          python3 - <<'PY' > review_comment.md
+          import json, os
+
+          data = json.load(open('codex_response.json'))
+          truncated = os.environ.get('TRUNCATED', 'false') == 'true'
+          trunc_note = '\n\n> ⚠️ Diff truncated at 12 000 chars — large PR, review may be partial.' if truncated else ''
+
+          if 'error' in data:
+              err = data['error']
+              if err == 'auth_expired':
+                  print("## ⚠️ Codex PR Review: AUTH ERROR\n\n`OPENAI_API_KEY` secret has expired or is invalid. Update it in repo Settings → Secrets." + trunc_note)
+              else:
+                  print(f"## ⚠️ Codex PR Review: API ERROR\n\nCould not reach OpenAI: `{err}`\n\nCheck workflow logs." + trunc_note)
+          else:
+              content = data['choices'][0]['message']['content']
+              verdict = 'FAIL' if '**Verdict:** FAIL' in content else 'PASS'
+              icon = '✅' if verdict == 'PASS' else '❌'
+              print(f"## {icon} Codex PR Review: {verdict}{trunc_note}\n\n{content}")
+          PY
+
+          VERDICT=$(python3 -c "
+          import json
+          data = json.load(open('codex_response.json'))
+          if 'error' in data:
+              print('ERROR')
+          else:
+              c = data['choices'][0]['message']['content']
+              print('FAIL' if '**Verdict:** FAIL' in c else 'PASS')
+          ")
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+
+      - name: Post review comment on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body = '⚠️ Codex review output could not be read. Check workflow logs.';
+            try { body = fs.readFileSync('review_comment.md', 'utf8'); } catch (e) {}
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Codex PR Review')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail check on critical violations
+        if: steps.review.outputs.verdict == 'FAIL'
+        run: |
+          echo "Codex found P1 critical violations — merge blocked."
+          exit 1

--- a/.github/workflows/deploy-and-notify.yml
+++ b/.github/workflows/deploy-and-notify.yml
@@ -1,0 +1,127 @@
+name: Deploy and Notify
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'cloudflare-worker.js'
+      - 'wrangler.toml'
+      - '**.md'
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: GAS Deploy + Smoke + Pushover
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate required secrets
+        env:
+          CLASP_CREDENTIALS_JSON: ${{ secrets.CLASP_CREDENTIALS_JSON }}
+          GAS_DEPLOYMENT_ID: ${{ secrets.GAS_DEPLOYMENT_ID }}
+          GAS_DEPLOY_URL: ${{ secrets.GAS_DEPLOY_URL }}
+        run: |
+          MISSING=""
+          [ -z "$CLASP_CREDENTIALS_JSON" ] && MISSING="$MISSING CLASP_CREDENTIALS_JSON"
+          [ -z "$GAS_DEPLOYMENT_ID" ]      && MISSING="$MISSING GAS_DEPLOYMENT_ID"
+          [ -z "$GAS_DEPLOY_URL" ]         && MISSING="$MISSING GAS_DEPLOY_URL"
+          if [ -n "$MISSING" ]; then
+            echo "::error::Missing required secrets:$MISSING"
+            exit 1
+          fi
+
+      - name: Install clasp
+        env:
+          CLASP_CREDENTIALS_JSON: ${{ secrets.CLASP_CREDENTIALS_JSON }}
+        run: |
+          npm install -g @google/clasp
+          printf '%s' "$CLASP_CREDENTIALS_JSON" > "$HOME/.clasprc.json"
+          chmod 600 "$HOME/.clasprc.json"
+
+      - name: clasp push
+        id: push
+        run: clasp push --force
+
+      - name: clasp deploy
+        id: deploy
+        env:
+          GAS_DEPLOYMENT_ID: ${{ secrets.GAS_DEPLOYMENT_ID }}
+        run: |
+          clasp deploy -i "$GAS_DEPLOYMENT_ID"
+          echo "deployed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Run smoke test
+        id: smoke
+        env:
+          GAS_DEPLOY_URL: ${{ secrets.GAS_DEPLOY_URL }}
+        run: |
+          echo "Hitting smoke test endpoint..."
+          RESPONSE="$(curl -sS -L --max-time 120 "${GAS_DEPLOY_URL}?action=runTests")"
+          OVERALL="$(python3 -c "
+          import json, sys
+          try:
+              d = json.loads(sys.argv[1])
+              print(d.get('overall', 'UNKNOWN'))
+          except Exception:
+              print('PARSE_ERROR')
+          " "$RESPONSE" 2>/dev/null || echo 'ERROR')"
+
+          echo "Smoke result: $OVERALL"
+          echo "overall=$OVERALL" >> "$GITHUB_OUTPUT"
+
+          if [ "$OVERALL" != "PASS" ]; then
+            echo "::error::Smoke tests returned: $OVERALL"
+            exit 1
+          fi
+
+      - name: Pushover — deploy success
+        if: success()
+        env:
+          PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}
+          PUSHOVER_APP_TOKEN: ${{ secrets.PUSHOVER_APP_TOKEN }}
+        run: |
+          if [ -z "$PUSHOVER_USER_KEY" ] || [ -z "$PUSHOVER_APP_TOKEN" ]; then
+            echo "Pushover secrets not set — skipping success notification."
+            exit 0
+          fi
+          SHA_SHORT="${GITHUB_SHA:0:7}"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          curl -sS \
+            --form-string "token=${PUSHOVER_APP_TOKEN}" \
+            --form-string "user=${PUSHOVER_USER_KEY}" \
+            --form-string "title=TBM Deploy: Live ✅" \
+            --form-string "message=Commit ${SHA_SHORT} is live. Smoke passed. Go verify the surfaces." \
+            --form-string "url=${RUN_URL}" \
+            --form-string "url_title=View run" \
+            --form-string "priority=0" \
+            https://api.pushover.net/1/messages.json
+
+      - name: Pushover — deploy failed
+        if: failure()
+        env:
+          PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}
+          PUSHOVER_APP_TOKEN: ${{ secrets.PUSHOVER_APP_TOKEN }}
+        run: |
+          if [ -z "$PUSHOVER_USER_KEY" ] || [ -z "$PUSHOVER_APP_TOKEN" ]; then
+            echo "Pushover secrets not set — skipping failure notification."
+            exit 0
+          fi
+          SHA_SHORT="${GITHUB_SHA:0:7}"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          curl -sS \
+            --form-string "token=${PUSHOVER_APP_TOKEN}" \
+            --form-string "user=${PUSHOVER_USER_KEY}" \
+            --form-string "title=TBM Deploy: BLOCKED ❌" \
+            --form-string "message=Commit ${SHA_SHORT} — deploy or smoke failed. Nothing is broken live. Check the run." \
+            --form-string "url=${RUN_URL}" \
+            --form-string "url_title=View failed run" \
+            --form-string "priority=1" \
+            https://api.pushover.net/1/messages.json

--- a/.github/workflows/playwright-regression.yml
+++ b/.github/workflows/playwright-regression.yml
@@ -1,0 +1,172 @@
+name: Playwright Regression
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: playwright-regression-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    name: Playwright E2E Regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Playwright + Chromium
+        run: |
+          npm install -D @playwright/test
+          npx playwright install --with-deps chromium
+
+      - name: Run E2E regression
+        id: playwright
+        env:
+          TBM_BASE_URL: https://thompsonfams.com
+          TBM_PIN: ${{ secrets.TBM_PIN }}
+        run: |
+          SPEC="tests/tbm/tbm-e2e-safe.spec.js"
+          if [ ! -f "$SPEC" ]; then
+            echo "::warning::Spec file $SPEC not found — skipping Playwright run."
+            echo "## ⚠️ Playwright Regression: SKIPPED" > playwright-comment.md
+            echo "" >> playwright-comment.md
+            echo "Spec file \`$SPEC\` not found in repo." >> playwright-comment.md
+            echo "verdict=SKIP" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Run with JSON reporter; capture exit code without failing immediately
+          npx playwright test "$SPEC" \
+            --reporter=json \
+            --output=test-results \
+            2>&1 | tee playwright-output.txt
+          PW_EXIT=$?
+          echo "pw_exit=$PW_EXIT" >> "$GITHUB_OUTPUT"
+
+          python3 - <<'PY' > playwright-comment.md
+          import json, os
+
+          pw_exit = int(os.environ.get('PW_EXIT', '1'))
+          output_txt = ''
+          try:
+              output_txt = open('playwright-output.txt').read()
+          except Exception:
+              pass
+
+          # Try to parse JSON reporter output from stdout
+          json_data = None
+          for line in output_txt.splitlines():
+              line = line.strip()
+              if line.startswith('{') and '"stats"' in line:
+                  try:
+                      json_data = json.loads(line)
+                      break
+                  except Exception:
+                      pass
+
+          if json_data:
+              stats = json_data.get('stats', {})
+              passed = stats.get('expected', 0)
+              failed = stats.get('unexpected', 0)
+              skipped = stats.get('skipped', 0)
+              duration_ms = stats.get('duration', 0)
+              verdict = 'PASS' if failed == 0 else 'FAIL'
+              icon = '✅' if verdict == 'PASS' else '❌'
+              lines = [
+                  f'## {icon} Playwright Regression: {verdict}',
+                  '',
+                  f'**{passed} passed · {failed} failed · {skipped} skipped** ({duration_ms}ms)',
+                  '',
+                  '_Tested against: https://thompsonfams.com_',
+              ]
+              if failed > 0:
+                  lines.append('')
+                  lines.append('### Failures')
+                  for suite in json_data.get('suites', []):
+                      for spec in suite.get('specs', []):
+                          for test in spec.get('tests', []):
+                              if test.get('status') != 'expected':
+                                  title = spec.get('title', '?')
+                                  status = test.get('status', '?')
+                                  lines.append(f'- **{title}**: {status}')
+                                  for result in test.get('results', []):
+                                      err = result.get('error', {})
+                                      if err.get('message'):
+                                          lines.append(f'  `{err["message"][:200]}`')
+              print('\n'.join(lines))
+          else:
+              verdict = 'FAIL' if pw_exit != 0 else 'PASS'
+              icon = '✅' if verdict == 'PASS' else '❌'
+              snippet = output_txt[-800:] if output_txt else '(no output)'
+              print(f'## {icon} Playwright Regression: {verdict}\n\nCould not parse JSON results.\n\n```\n{snippet}\n```')
+          PY
+
+          echo "verdict=$([ $PW_EXIT -eq 0 ] && echo PASS || echo FAIL)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload screenshots and traces on failure
+        if: steps.playwright.outputs.pw_exit != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-screenshots-${{ github.run_id }}
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Post results comment on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body = '⚠️ Playwright results could not be read. Check workflow logs.';
+            try { body = fs.readFileSync('playwright-comment.md', 'utf8'); } catch (e) {}
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Playwright Regression')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail check on test failures
+        if: steps.playwright.outputs.verdict == 'FAIL'
+        run: |
+          echo "Playwright found failures — merge blocked."
+          exit 1


### PR DESCRIPTION
## Summary

Adds 3 new GitHub Actions workflows per pipeline automation spec. No existing workflows removed — see Cleanup Notes below for LT review before any deletions.

---

## Gate 4 — Deploy Manifest

```bash
# codex-pr-review.yml — exists and has required steps
grep -n "name: Codex PR Review" .github/workflows/codex-pr-review.yml
# expected: 1: name: Codex PR Review

grep -n "gpt-4o" .github/workflows/codex-pr-review.yml
# expected: match on model line

grep -n "OPENAI_API_KEY" .github/workflows/codex-pr-review.yml
# expected: 2 matches (env block + missing-key check)

grep -n "Fail check on critical violations" .github/workflows/codex-pr-review.yml
# expected: match on final step name

grep -n "Post review comment on PR" .github/workflows/codex-pr-review.yml
# expected: match

grep -n "cancel-in-progress: true" .github/workflows/codex-pr-review.yml
# expected: match

# playwright-regression.yml — exists and has required steps
grep -n "name: Playwright Regression" .github/workflows/playwright-regression.yml
# expected: 1: name: Playwright Regression

grep -n "tbm-e2e-safe.spec.js" .github/workflows/playwright-regression.yml
# expected: match

grep -n "TBM_PIN" .github/workflows/playwright-regression.yml
# expected: match (secret ref)

grep -n "Upload screenshots" .github/workflows/playwright-regression.yml
# expected: match

grep -n "Post results comment on PR" .github/workflows/playwright-regression.yml
# expected: match

grep -n "Fail check on test failures" .github/workflows/playwright-regression.yml
# expected: match

# deploy-and-notify.yml — exists and has required steps
grep -n "name: Deploy and Notify" .github/workflows/deploy-and-notify.yml
# expected: 1: name: Deploy and Notify

grep -n "clasp push --force" .github/workflows/deploy-and-notify.yml
# expected: match

grep -n "clasp deploy -i" .github/workflows/deploy-and-notify.yml
# expected: match

grep -n "action=runTests" .github/workflows/deploy-and-notify.yml
# expected: match (smoke test URL)

grep -n "PUSHOVER" .github/workflows/deploy-and-notify.yml
# expected: 4+ matches (both success and failure steps)

grep -n "Pushover — deploy success" .github/workflows/deploy-and-notify.yml
# expected: match

grep -n "Pushover — deploy failed" .github/workflows/deploy-and-notify.yml
# expected: match

grep -n "paths-ignore" .github/workflows/deploy-and-notify.yml
# expected: match (cloudflare-worker.js excluded)
```

---

## Gate 5 — Feature Verification Checklist

### codex-pr-review.yml
- [ ] Triggers on `pull_request` to main (opened, reopened, synchronize, ready_for_review) AND `workflow_dispatch` with `pr` input
- [ ] Skips draft PRs and fork PRs (same-repo guard)
- [ ] `cancel-in-progress: true` on concurrency group per PR number
- [ ] Diffs only `*.js` and `*.html` files against `origin/main`
- [ ] Truncates diff to 12 000 chars, sets `truncated=true` output if over
- [ ] System prompt encodes all 6 P1 rules and 3 P2 rules exactly as spec'd
- [ ] Retries on 429 up to 4 attempts with exponential backoff (2s, 4s, 8s, 16s)
- [ ] Handles expired/invalid key: writes `auth_expired` JSON, skips gracefully (no crash)
- [ ] Upserts bot comment (finds existing "Codex PR Review" comment, updates vs creates)
- [ ] `verdict=FAIL` → step exits 1, blocks merge; `verdict=PASS` → no failure
- [ ] Graceful skip when `OPENAI_API_KEY` secret absent — comment says "configure in Settings → Secrets"
- [ ] Truncation note appended to comment when diff was truncated

### playwright-regression.yml
- [ ] Triggers on `pull_request` to main AND `workflow_dispatch`
- [ ] Skips draft PRs and fork PRs
- [ ] `cancel-in-progress: true` on concurrency group
- [ ] Installs `@playwright/test` + Chromium only (not full browser suite)
- [ ] `TBM_BASE_URL=https://thompsonfams.com` hardcoded; `TBM_PIN` from secret
- [ ] Spec file check: if `tests/tbm/tbm-e2e-safe.spec.js` not found, posts SKIPPED comment and exits 0
- [ ] Uses `--reporter=json` and captures exit code without `set -e` killing the step
- [ ] Parses JSON stats: passed / failed / skipped / duration displayed in comment
- [ ] Falls back to raw output snippet if JSON parse fails
- [ ] Screenshots uploaded as artifact `playwright-screenshots-$run_id` on failure (7-day retention, `if-no-files-found: ignore`)
- [ ] Upserts bot comment on PR (finds existing "Playwright Regression" comment)
- [ ] `verdict=FAIL` → final step exits 1, blocks merge

### deploy-and-notify.yml
- [ ] Triggers on push to `main` only; excludes `cloudflare-worker.js`, `wrangler.toml`, `**.md`, `.github/**`
- [ ] Also triggers on `workflow_dispatch`
- [ ] Upfront secret validation: fails immediately with `::error::` if any of `CLASP_CREDENTIALS_JSON`, `GAS_DEPLOYMENT_ID`, `GAS_DEPLOY_URL` missing
- [ ] `clasp push --force` runs before deploy
- [ ] `clasp deploy -i $GAS_DEPLOYMENT_ID` (uses existing deployment ID, never creates new)
- [ ] Smoke test hits `${GAS_DEPLOY_URL}?action=runTests`, parses `overall` field
- [ ] Smoke exits 1 with `::error::` if result is not `PASS`
- [ ] Success Pushover: priority=0, title="TBM Deploy: Live ✅", includes commit SHA (7 chars) and run URL
- [ ] Failure Pushover: priority=1, title="TBM Deploy: BLOCKED ❌", message says "Nothing is broken live"
- [ ] Pushover steps skip gracefully (exit 0) when `PUSHOVER_USER_KEY`/`PUSHOVER_APP_TOKEN` absent

---

## Required Secrets (configure before merging)

| Secret | Used by |
|--------|---------|
| `CLASP_CREDENTIALS_JSON` | deploy-and-notify |
| `GAS_DEPLOYMENT_ID` | deploy-and-notify |
| `GAS_DEPLOY_URL` | deploy-and-notify |
| `OPENAI_API_KEY` | codex-pr-review |
| `TBM_PIN` | playwright-regression |
| `PUSHOVER_USER_KEY` | deploy-and-notify |
| `PUSHOVER_APP_TOKEN` | deploy-and-notify |

`GEMINI_API_KEY` — not used by these 3 workflows directly; reserved for future Gemini lane if retained.

---

## Cleanup Notes (LT decides before merge)

**Stale candidates** (depend on `PIPELINE_*` secrets not in new secret list):
- `review-watcher.yml` — relay notification for pipeline status
- `review-fixer.yml` — auto-fixer loop; uses `PIPELINE_BOT_TOKEN` for elevated pushes

**Active, keep as-is:**
- `deploy-worker.yml` — deploys Cloudflare Worker via `CLOUDFLARE_API_TOKEN`; `deploy-and-notify.yml` does NOT cover Worker deploys
- `ci.yml` — hits `?action=runTests` GAS smoke endpoint; separate from Playwright

**Pending decision:**
- `gemini-review.yml` exists locally but not on `origin/main`; if `codex-pr-review.yml` is the primary AI review lane, decide whether Gemini stays as a parallel reviewer or is dropped

**DO NOT MERGE until:** (1) secrets verified in repo Settings, (2) cleanup decisions made above.

https://claude.ai/code/session_01NEY1uLwW6xDjg2zVTMgjCX