### PR TITLE
feat: TheSpine Coming Up — 7-day calendar lookahead (DataEngine v85, TheSpine v48)"

### DIFF
--- a/Dataengine.js
+++ b/Dataengine.js
@@ -1,10 +1,10 @@
 // ════════════════════════════════════════════════════════════════════
-// DATA ENGINE v84 — Dynamic KPI Computation from Raw Tiller Data
+// DATA ENGINE v85 — Dynamic KPI Computation from Raw Tiller Data
 // WRITES TO: 💻🧮 Dashboard_Export, 💻🧮 Debt_Export, 💻🧮 DebtModel, 💻🧮 Cascade Proof, 💻🧮 Cascade Month-by-Month, 💻🧮 Cascade Payoff Schedule, 📋 Board_Config
 // READS FROM: 🔒 Transactions, 🔒 Balance History, 🔒 Categories, 💻🧮 Budget_Data, 💻🧮 Helpers, 💻🧮 DebtModel, 💻🧮 BankRec, 💻🧮 Budget_Rules, 💻 MealPlan
 // ════════════════════════════════════════════════════════════════════
 
-function getDataEngineVersion() { return 84; }
+function getDataEngineVersion() { return 85; }
 
 // ════════════════════════════════════════════════════════════════════
 //
@@ -3030,33 +3030,35 @@ function getBoardData() {
   var moreCount = hasMore ? events.length - 3 : 0;
   events = events.slice(0, 3);
 
-  // ── 5. Tomorrow preview (after 3 PM — matches Spine client threshold) ──
-  var tomorrowPreview = null;
-  if (hour >= 15) {
-    try {
-      var tmrStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0);
-      var tmrEnd   = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 23, 59, 59);
-      var tmrEvents = [];
-      var defTmr = CalendarApp.getDefaultCalendar().getEvents(tmrStart, tmrEnd);
-      for (var ti = 0; ti < defTmr.length; ti++) tmrEvents.push(_boardFormatEvent(defTmr[ti], 'Default'));
-      for (var tci = 0; tci < calNames.length; tci++) {
-        var tCals = CalendarApp.getCalendarsByName(calNames[tci]);
-        for (var tcj = 0; tcj < tCals.length; tcj++) {
-          var tCalEvts = tCals[tcj].getEvents(tmrStart, tmrEnd);
-          for (var tce = 0; tce < tCalEvts.length; tce++) tmrEvents.push(_boardFormatEvent(tCalEvts[tce], calNames[tci]));
+  // ── 5. 7-day upcoming events (all day, all calendars except finance) ──
+  var upcomingEvents = [];
+  var tomorrowPreview = null; // kept for backward-compat; clients should use upcomingEvents
+  try {
+    var upDayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    for (var ud = 1; ud <= 7; ud++) {
+      var upStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() + ud, 0, 0, 0);
+      var upEnd   = new Date(now.getFullYear(), now.getMonth(), now.getDate() + ud, 23, 59, 59);
+      var upLabel = ud === 1 ? 'Tomorrow' : upDayNames[upStart.getDay()];
+      var upEvts  = [];
+      var upDef = CalendarApp.getDefaultCalendar().getEvents(upStart, upEnd);
+      for (var udi = 0; udi < upDef.length; udi++) upEvts.push(_boardFormatEvent(upDef[udi], 'Default'));
+      for (var uci = 0; uci < calNames.length; uci++) {
+        if (calNames[uci] === 'Bills and Financial') continue; // skip finance events
+        var uCals = CalendarApp.getCalendarsByName(calNames[uci]);
+        for (var ucj = 0; ucj < uCals.length; ucj++) {
+          var uCalEvts = uCals[ucj].getEvents(upStart, upEnd);
+          for (var uce = 0; uce < uCalEvts.length; uce++) upEvts.push(_boardFormatEvent(uCalEvts[uce], calNames[uci]));
         }
       }
-      tmrEvents.sort(function(a, b) { return (a.startHour * 60 + a.startMin) - (b.startHour * 60 + b.startMin); });
-      if (tmrEvents.length > 0) {
-        tomorrowPreview = {
-          count: tmrEvents.length,
-          first: tmrEvents[0].title,
-          firstTime: tmrEvents[0].timeStr
-        };
+      upEvts.sort(function(a, b) { return (a.startHour * 60 + a.startMin) - (b.startHour * 60 + b.startMin); });
+      for (var uei = 0; uei < upEvts.length; uei++) {
+        if (upcomingEvents.length >= 3) break;
+        upcomingEvents.push({ title: upEvts[uei].title, timeStr: upLabel });
       }
-    } catch(e) {
-      if (typeof logError_ === 'function') logError_('de_getBoardData_Tomorrow', e);
+      if (upcomingEvents.length >= 3) break;
     }
+  } catch(e) {
+    if (typeof logError_ === 'function') logError_('de_getBoardData_UpcomingEvents', e);
   }
 
   // ── 6. KidsHub chore status ───────────────────────────────────────
@@ -3135,6 +3137,7 @@ function getBoardData() {
     weather:          weather,
     events:           events,
     eventsMore:       moreCount,
+    upcomingEvents:   upcomingEvents,
     tomorrowPreview:  tomorrowPreview,
     choreStatus:      choreStatus,
     familyNote:       familyNote,
@@ -3401,4 +3404,4 @@ function de_buildSoulMoment_(boardPayload, kidsPayload) {
   return moments[idx];
 }
 
-// END OF FILE — DataEngine v84
+// END OF FILE — DataEngine v85

--- a/TheSpine.html
+++ b/TheSpine.html
@@ -4,8 +4,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0">
-<meta name="tbm-version" content="TheSpine v47">
-<title>TheSpine v47 — Office Ambient Display</title>
+<meta name="tbm-version" content="TheSpine v48">
+<title>TheSpine v48 — Office Ambient Display</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
@@ -989,15 +989,7 @@ function renderBoard(b){
   document.getElementById('weatherMain').textContent = icon + ' ' + (typeof temp === 'number' ? Math.round(temp) + '\u00B0' : temp);
   document.getElementById('weatherSub').textContent = cond;
   renderEventGroup('todayEvents', b.events || []);
-  var tmr = b.tomorrowPreview;
-  var tmrArr = [];
-  if (tmr && tmr.first) {
-    tmrArr.push({ title: tmr.first, timeStr: tmr.firstTime || '' });
-    if (tmr.count > 1) {
-      tmrArr.push({ title: '+ ' + (tmr.count - 1) + ' more', timeStr: '' });
-    }
-  }
-  renderEventGroup('upcomingList', tmrArr);
+  renderEventGroup('upcomingList', b.upcomingEvents || []);
   var staleBanner = document.getElementById('staleBanner');
   if(staleBanner){
     if(b.spineStale){ staleBanner.classList.add('visible'); } else { staleBanner.classList.remove('visible'); }


### PR DESCRIPTION
## Gate 4 — Deploy Manifest

```bash
grep -n "upcomingEvents" Dataengine.js
# expected: 5+ matches — declaration, loop push, return field

grep -n "getDataEngineVersion.*85\|return 85" Dataengine.js
# expected: match on getter

grep -n "DATA ENGINE v85\|DataEngine v85" Dataengine.js
# expected: header line + EOF line

grep -n "upcomingEvents" TheSpine.html
# expected: 1 match — renderEventGroup('upcomingList', b.upcomingEvents || [])

grep -n "TheSpine v48" TheSpine.html
# expected: meta tag + title tag
```

## Gate 5 — Feature Verification Checklist

- [ ] DataEngine v85 in all 3 locations: header, `getDataEngineVersion()` returns 85, EOF comment
- [ ] `getBoardData_` returns `upcomingEvents` array at any hour of day (no `hour >= 15` gate)
- [ ] Each item has `title` (event name) and `timeStr` (day label: "Tomorrow" / "Mon" / "Tue" etc.)
- [ ] Max 3 events returned, scanning days 1–7 in order
- [ ] Events from "Bills and Financial" calendar excluded server-side
- [ ] `tomorrowPreview` field still present in return (as null) — backward compat
- [ ] TheSpine v48: meta tag and title both read v48
- [ ] Coming Up panel shows STAAR Testing (Apr 8) when viewed on Apr 6 — "No events queued" no longer shown for a week with upcoming events
- [ ] Today at a Glance unchanged — still today-only

https://claude.ai/code/session_01NEY1uLwW6xDjg2zVTMgjCX