### PR TITLE
fix: Day 1 detection stuck on KH_MissionState (KidsHub v49)

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -5,7 +5,9 @@ node_modules/**
 *.jsx
 generate-audio.js
 cloudflare-worker.js
+uptime-worker.js
 wrangler.toml
+wrangler-uptime.toml
 phrases.json
 audit-source.sh
 audit-wiring.sh

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v48 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v49 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 48; }
+function getKidsHubVersion() { return 49; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -3813,11 +3813,19 @@ function checkDay1_(child) {
   if (child !== 'buggsy' && child !== 'jj') {
     return { isDay1: false };
   }
+  // Check KH_History for any education events
   var data = readSheet_('KH_History');
   for (var i = 0; i < data.length; i++) {
     var rowChild = String(data[i][2] || '').toLowerCase();
     var eventType = String(data[i][7] || '').toLowerCase();
     if (rowChild === child && eventType === 'education') {
+      return { isDay1: false };
+    }
+  }
+  // Also check KH_MissionState — any prior mission record means setup is done
+  var missions = readSheet_('KH_MissionState');
+  for (var j = 0; j < missions.length; j++) {
+    if (String(missions[j][0] || '').toLowerCase() === child) {
       return { isDay1: false };
     }
   }
@@ -3888,5 +3896,5 @@ function getDesignUnlockedSafe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v48
+// END OF FILE — KidsHub.gs v49
 // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- `checkDay1_()` only checked `KH_History` for `education` events, but Buggsy's April 2nd setup (baseline + power-scan) wrote completion records to `KH_MissionState`, not to `KH_History`
- Result: every visit to `/daily-missions` showed **Sunday — Day 1 Setup** instead of today's real curriculum
- Fix: add a second check on `KH_MissionState` — any prior row for that child means setup is already done
- Bonus: added `uptime-worker.js` and `wrangler-uptime.toml` to `.claspignore` so the CF Worker file stops being pushed to GAS (was breaking `runTests`)

## Deploy proof
- Deploy @428 — smoke: PASS, regression: PASS, KidsHub confirmed v49
- Verified via `?action=runTests` → `overall: PASS`

## Test plan
- [ ] Visit `/buggsy` daily-missions — should show **MONDAY — MATH** with Homework + Fact Sprint
- [ ] Visit `/jj` daily-missions — should show Monday letters curriculum
- [ ] Verify Day 1 flow still works for a brand-new child (no KH_MissionState rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)