### PR TITLE
feat: HYG-12 — Pushover priority tiering (AlertEngine v9, KidsHub v50)

### DIFF
--- a/.github/workflows/deploy-and-notify.yml
+++ b/.github/workflows/deploy-and-notify.yml
@@ -157,7 +157,7 @@ jobs:
             --form-string "message=Deploy ...${DEPLOY_SHORT}${VER_PART} — ${SMOKE_LINE} — Commit ${SHA_SHORT} — ${TIMESTAMP} — Go look" \
             --form-string "url=${RUN_URL}" \
             --form-string "url_title=View run" \
-            --form-string "priority=0" \
+            --form-string "priority=-2" \
             https://api.pushover.net/1/messages.json
 
       - name: Pushover — deploy failed
@@ -190,5 +190,5 @@ jobs:
             --form-string "message=${FAIL_MSG}" \
             --form-string "url=${RUN_URL}" \
             --form-string "url_title=View failed run" \
-            --form-string "priority=1" \
+            --form-string "priority=2" \
             https://api.pushover.net/1/messages.json

--- a/Alertenginev1.js
+++ b/Alertenginev1.js
@@ -1,12 +1,12 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// AlertEngine.gs v8 — Push Notifications via Pushover API
+// AlertEngine.gs v9 — Push Notifications via Pushover API
 // WRITES TO: (Pushover API only — no sheet writes)
 // READS FROM: 💻🧮 Helpers (for config)
 // Replaces dead AT&T email-to-SMS gateway (killed June 17, 2025)
 // ════════════════════════════════════════════════════════════════════
 
-function getAlertEngineVersion() { return 8; }
+function getAlertEngineVersion() { return 9; }
 
 // v4: openById migration — trigger-safe spreadsheet accessor
 var _aeSS = null;
@@ -14,6 +14,24 @@ function getAESS_() {
   if (!_aeSS) _aeSS = SpreadsheetApp.openById('1_jn-I4IfsqgnVOFiS38SVVzNJ0MAJtu2645iU5k0U9c');
   return _aeSS;
 }
+
+// ── PUSHOVER PRIORITY TIERS ─────────────────────────────────────
+// HYG-12: Use these constants for all sendPush_() priority arguments.
+// Never pass bare integers — name the intent.
+var PUSHOVER_PRIORITY = {
+  DEPLOY_OK:          -2,  // silent — CI PR comments confirm deploys
+  HYGIENE_REPORT_LOW: -1,  // quiet delivery — weekly stale sweeps
+  CHORE_APPROVAL:      0,  // normal — chore/ask/approval notifications
+  BACKLOG_STALE:       0,  // normal — backlog age warnings
+  CLAUDE_MD_BLOAT:     0,  // normal — CLAUDE.md growth trigger (HYG-04)
+  TILLER_STALE:        1,  // high (vibrate) — Tiller freshness breach
+  CLOSE_OVERDUE:       1,  // high — month-close gate (escalates to 2 on day 21+)
+  SECRET_EXPIRING:     1,  // high — secrets audit
+  SYSTEM_ERROR:        1,  // high — GAS ErrorLog new entries
+  PROD_DOWN:           2,  // emergency + ack — production outage
+  DEPLOY_FAIL:         2,  // emergency + ack — deploy pipeline blocked
+  GATE_BREACH:         2   // emergency + ack — hard gate violation
+};
 
 // ── PUSHOVER CONFIG ─────────────────────────────────────────────
 // Script Properties: PUSHOVER_TOKEN, PUSHOVER_USER_LT, PUSHOVER_USER_JT
@@ -194,7 +212,7 @@ function checkPendingApprovals() {
       var title = pending.length + ' task' + (pending.length > 1 ? 's' : '') + ' waiting for approval';
       var body = lines.join('\n');
 
-      var sent = sendPush_(title, body, 'BOTH', 0, getParentDashUrl_());
+      var sent = sendPush_(title, body, 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL, getParentDashUrl_());
 
       if (sent) {
         console.log('ALERT_SENT', JSON.stringify({
@@ -265,7 +283,7 @@ function checkPendingAsks() {
         body += '\n' + pending.length + ' total asks waiting';
       }
 
-      sendPush_(title, body, 'BOTH', 0, getParentDashUrl_());
+      sendPush_(title, body, 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL, getParentDashUrl_());
     }
 
     props.setProperty('ALERT_LAST_ASKS', String(pending.length));
@@ -313,7 +331,7 @@ function checkSystemErrors() {
       var body = newErrors.slice(0, 3).join('\n');
       if (newErrors.length > 3) body += '\n+' + (newErrors.length - 3) + ' more';
 
-      sendPush_(title, body, 'LT', 1); // priority 1 = high for errors
+      sendPush_(title, body, 'LT', PUSHOVER_PRIORITY.SYSTEM_ERROR);
 
       // Update last error timestamp to most recent
       var latestTS = String(data[data.length - 1][tsCol] || '');
@@ -482,7 +500,7 @@ function diagnoseAlertEngine() {
   results.push('');
   results.push('--- PUSH TEST ---');
   var diagText = results.join('\n');
-  var ok = sendPush_('TBM Diagnostic', diagText, 'LT', -1); // low priority
+  var ok = sendPush_('TBM Diagnostic', diagText, 'LT', PUSHOVER_PRIORITY.HYGIENE_REPORT_LOW);
   results.push(ok ? 'Diagnostic push sent ✅' : 'Diagnostic push FAILED ❌');
 
   var output = results.join('\n');
@@ -639,5 +657,5 @@ function dailyHealthCheck() {
 }
 
 // ════════════════════════════════════════════════════════════════════
-// END OF FILE — AlertEngine v8
+// END OF FILE — AlertEngine v9
 // ════════════════════════════════════════════════════════════════════

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,11 +329,31 @@ HTML modules served via Cloudflare use the `google.script.run` shim which POSTs 
 | Version reporting | GASHardening.gs → `getDeployedVersions()` |
 | Cache read/write | Code.gs → `getCachedPayload_()`, `setCachedPayload_()` |
 | Workbook reference | `openById(SSID)` — NEVER `getActiveSpreadsheet()` |
-| Push notifications | AlertEngine.gs → `sendPush_()` (recipients: LT, JT, BOTH) |
+| Push notifications | AlertEngine.gs → `sendPush_()` (recipients: LT, JT, BOTH) — use `PUSHOVER_PRIORITY.*` constants, never bare integers |
 | KH heartbeat | KidsHub.gs → `stampKHHeartbeat_()` after every write |
 | Lock acquisition | `waitLock(30000)` — NEVER `tryLock()` |
 | Smoke + regression | Code.gs → `?action=runTests` returns combined JSON |
 | New `google.script.run` call | Must have `withFailureHandler()`. Must add Safe wrapper to smoke test check. Must run audit-source.sh. |
+
+---
+
+## Alert Tiers (HYG-12)
+All `sendPush_()` calls must use a named constant from `PUSHOVER_PRIORITY` in AlertEngine.gs. No bare integers.
+
+| Constant | Value | Behavior | Use for |
+|----------|-------|----------|---------|
+| `DEPLOY_OK` | -2 | Silent | Successful deploys (CI PR comments confirm) |
+| `HYGIENE_REPORT_LOW` | -1 | Quiet delivery | Weekly stale sweeps, diagnostics |
+| `CHORE_APPROVAL` | 0 | Normal sound | Chore/ask/approval notifications |
+| `BACKLOG_STALE` | 0 | Normal sound | Backlog age warnings |
+| `CLAUDE_MD_BLOAT` | 0 | Normal sound | CLAUDE.md growth trigger (HYG-04) |
+| `TILLER_STALE` | 1 | Vibrate (high) | Tiller freshness breach |
+| `CLOSE_OVERDUE` | 1 | Vibrate (high) | Month-close gate day 6–20 (escalates to 2 on day 21+) |
+| `SECRET_EXPIRING` | 1 | Vibrate (high) | Secrets audit |
+| `SYSTEM_ERROR` | 1 | Vibrate (high) | GAS ErrorLog new entries |
+| `PROD_DOWN` | 2 | Emergency + ack | Production outage |
+| `DEPLOY_FAIL` | 2 | Emergency + ack | Deploy pipeline blocked |
+| `GATE_BREACH` | 2 | Emergency + ack | Hard gate violation |
 
 ---
 

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v49 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v50 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 49; }
+function getKidsHubVersion() { return 50; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -1348,7 +1348,7 @@ function khCompleteTask(rowIndex, expectedTaskID) {
     try {
       if (typeof sendPush_ === 'function') {
         var childDisplay = child.charAt(0).toUpperCase() + child.slice(1).toLowerCase();
-        sendPush_('Chore Completed', childDisplay + ' completed "' + task + '" — needs approval', 'BOTH', 0);
+        sendPush_('Chore Completed', childDisplay + ' completed "' + task + '" — needs approval', 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL);
       }
     } catch(e) {
       console.log('KH_PUSH_FAIL', JSON.stringify({
@@ -3584,7 +3584,7 @@ function submitHomework_(data) {
     try {
       if (typeof sendPush_ === 'function') {
         var childDisplay = childLower.charAt(0).toUpperCase() + childLower.slice(1);
-        sendPush_(childDisplay + ' submitted ' + (data.subject || 'homework'), 'Needs your review on Parent Dashboard', 'BOTH', 0);
+        sendPush_(childDisplay + ' submitted ' + (data.subject || 'homework'), 'Needs your review on Parent Dashboard', 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL);
       }
     } catch(e) { /* non-blocking */ }
   }
@@ -3713,7 +3713,7 @@ function approveHomework_(rowIndex, action, notes) {
     try {
       if (typeof sendPush_ === 'function') {
         var childDisplay = child.charAt(0).toUpperCase() + child.slice(1);
-        sendPush_(childDisplay + ': Writing approved! +' + rings + ' rings', String(notes || 'Great work!'), 'BOTH', 0);
+        sendPush_(childDisplay + ': Writing approved! +' + rings + ' rings', String(notes || 'Great work!'), 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL);
       }
     } catch(e) { /* non-blocking */ }
   }
@@ -3896,5 +3896,5 @@ function getDesignUnlockedSafe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v49
+// END OF FILE — KidsHub.gs v50
 // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Adds `PUSHOVER_PRIORITY` constant block to `AlertEngine.gs` — 12 named tiers, no more bare integers
- Updates all 7 hardcoded `sendPush_()` callers in AlertEngine + KidsHub to use named constants
- Updates `deploy-and-notify.yml`: deploy success `0→-2` (silent), deploy fail `1→2` (emergency+ack)
- Adds **Alert Tiers** table to `CLAUDE.md` under Pattern Registry

## Constants locked
| Constant | Value | Behavior |
|----------|-------|----------|
| `DEPLOY_OK` | -2 | Silent |
| `HYGIENE_REPORT_LOW` | -1 | Quiet |
| `CHORE_APPROVAL` / `BACKLOG_STALE` / `CLAUDE_MD_BLOAT` | 0 | Normal |
| `TILLER_STALE` / `CLOSE_OVERDUE` / `SECRET_EXPIRING` / `SYSTEM_ERROR` | 1 | High (vibrate) |
| `PROD_DOWN` / `DEPLOY_FAIL` / `GATE_BREACH` | 2 | Emergency + ack |

## Deploy proof
- Deploy @432 — smoke: PASS, KidsHub confirmed v50 live

## Acceptance test
Trigger one alert at each tier, confirm phone behavior matches (silent / normal / high / emergency-with-ack).

## Why first
Every other Wave 1 hygiene job (HYG-01 through HYG-10) calls `sendPush_()` and must reference these constants. This PR is the foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)