### PR TITLE
fix: Codex review diff — all file types + empty-diff guard

### DIFF
--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -217,6 +217,19 @@ def main():
     api_key = os.environ.get("OPENAI_API_KEY", "")
     diff_file = os.environ.get("DIFF_FILE", "pr_diff_send.txt")
     truncated = os.environ.get("TRUNCATED", "false") == "true"
+    empty_diff = os.environ.get("EMPTY_DIFF", "false") == "true"
+
+    # Files changed but diff is empty (e.g. binary-only PR) — INCONCLUSIVE
+    if empty_diff:
+        write_github_output("verdict", "INCONCLUSIVE")
+        with open("review_comment.md", "w") as f:
+            f.write(
+                COMMENT_MARKER + "\n"
+                "## ⚠️ Codex PR Review: INCONCLUSIVE — Empty Diff\n\n"
+                "PR has changed files but the text diff is empty (binary-only or "
+                "all changes in non-diffable files). Manual Codex audit required.\n"
+            )
+        return
 
     # No API key — INCONCLUSIVE, not a silent skip
     if not api_key:

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -69,15 +69,24 @@ jobs:
         id: diff
         run: |
           git fetch origin main --depth=1
-          git diff origin/main...HEAD -- '*.js' '*.html' '*.yml' '*.yaml' '*.py' '*.json' '*.md' > pr_diff.txt
+          # Diff ALL text files — no extension filter. Binary files are excluded by git diff default.
+          git diff origin/main...HEAD > pr_diff.txt
           DIFF_BYTES=$(wc -c < pr_diff.txt)
+          CHANGED_COUNT=$(git diff --name-only origin/main...HEAD | wc -l)
           echo "diff_bytes=$DIFF_BYTES" >> "$GITHUB_OUTPUT"
+          echo "changed_count=$CHANGED_COUNT" >> "$GITHUB_OUTPUT"
           # Truncate to 12000 chars — keeps well under gpt-4o 128k context, costs ~$0.01/review
           head -c 12000 pr_diff.txt > pr_diff_send.txt
           if [ "$DIFF_BYTES" -gt 12000 ]; then
             echo "truncated=true" >> "$GITHUB_OUTPUT"
           else
             echo "truncated=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Force INCONCLUSIVE when files changed but diff is empty (binary-only PR)
+          if [ "$CHANGED_COUNT" -gt 0 ] && [ "$DIFF_BYTES" -eq 0 ]; then
+            echo "empty_diff=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "empty_diff=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Send to OpenAI gpt-4o
@@ -86,6 +95,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DIFF_FILE: pr_diff_send.txt
           TRUNCATED: ${{ steps.diff.outputs.truncated }}
+          EMPTY_DIFF: ${{ steps.diff.outputs.empty_diff }}
         run: python3 .github/scripts/codex_review.py
 
       - name: Post review comment on PR


### PR DESCRIPTION
## Summary
- Removes file extension filter from `git diff` — all text files are now reviewed (.gs, .toml, .sh, .txt, .claspignore, .gitignore, etc.)
- Detects PRs where files changed but the text diff is empty (binary-only) and forces INCONCLUSIVE
- Addresses P1 from [PR #86 post-merge review](https://github.com/blucsigma05/tbm-apps-script/pull/86#issuecomment-4202279665)

## Test plan
- [ ] Verify lint-gate passes
- [ ] Trigger on a PR that only changes `.claspignore` — should produce a non-empty diff now
- [ ] Confirm empty-diff guard fires INCONCLUSIVE for binary-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)