### PR TITLE
fix: AlertEngine — close missing brace in testPushoverTiers()

### DIFF
--- a/Alertenginev1.js
+++ b/Alertenginev1.js
@@ -683,6 +683,8 @@ function testPushoverTiers() {
     if (i < tiers.length - 1) { Utilities.sleep(3000); }
   }
   Logger.log('Done. Verify phone matched all 5 expectations.');
+}
+
 // ── HYG-09: TILLER FRESHNESS CHECK ──────────────────────────────────
 // Called via ?action=tillerFreshness (Code.gs router) — no Pushover from here.
 // Returns freshness JSON for CF Worker scheduled handler to act on.


### PR DESCRIPTION
## Summary
- Missing `}` closing brace in `testPushoverTiers()` — introduced during #79 merge conflict resolution where `checkTillerFreshness_()` comment was inserted immediately after the last Logger.log line without the function's closing brace
- Caused `SyntaxError: Unexpected end of input` at line 722, blocking `clasp push`
- Single character fix, no logic change

## Test plan
- [x] `node --check Alertenginev1.js` → SYNTAX OK
- [x] `node --check *.js` → ALL CLEAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)