### PR TITLE
feat: audit-pass label override for Codex PR Review

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -10,7 +10,7 @@ name: Codex PR Review
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, synchronize, ready_for_review, labeled]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
   workflow_dispatch:
     inputs:
       pr:
@@ -60,13 +60,14 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
-      # Manual audit override — if audit-pass label is present, skip the entire review.
-      # This allows merging when Codex throws a false positive after manual audit confirms PASS.
+      # Manual audit override — only activates on the label-add event itself.
+      # New pushes (synchronize) always run the full review, even if label is present.
+      # Removing the label (unlabeled) also runs the full review.
       - name: Check for audit-pass override
         id: override
-        if: contains(github.event.pull_request.labels.*.name, 'audit-pass')
+        if: github.event.action == 'labeled' && github.event.label.name == 'audit-pass'
         run: |
-          echo "audit-pass label found — manual audit override in effect."
+          echo "audit-pass label just added — manual audit override in effect."
           echo "overridden=true" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Adds `audit-pass` label as a manual override for the Codex PR Review required check
- When label is present, workflow re-runs but skips: OpenAI call, comment posting, integrity check, and failure gates
- Codex stays a required check — real findings still block merges

## How it works
1. Codex runs on PR, finds issue (real or false positive), posts FAIL
2. You read the findings, do manual audit
3. If false positive: post manual PASS comment, add `audit-pass` label
4. Label triggers re-run (`labeled` event type added to trigger)
5. Override step detects label, skips all review steps → check passes
6. PR is mergeable

## Why
PR #96 was blocked by a false positive (Codex flagged HTML string building as a missing `withFailureHandler`). No way to merge without changing branch protection settings.

## Test plan
- [ ] Open a test PR, let Codex run and fail
- [ ] Add `audit-pass` label — verify workflow re-runs and passes
- [ ] Remove label, push new commit — verify Codex runs normally
- [ ] Verify `audit-pass` label doesn't skip Pre-flight Lint (separate job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)