### PR TITLE
fix: uptime worker quiet window + 45s timeout

### DIFF
--- a/uptime-worker.js
+++ b/uptime-worker.js
@@ -17,7 +17,8 @@
 
 var PUSHOVER_API = 'https://api.pushover.net/1/messages.json';
 var THROTTLE_MS  = 60 * 60 * 1000; // 1 hour between persistent-DOWN reminders
-var FETCH_TIMEOUT_MS = 20000;       // 20-second timeout per check
+var FETCH_TIMEOUT_MS = 45000;       // 45-second timeout — GAS cold starts need headroom
+var QUIET_BEFORE_UTC = 14;          // Skip checks before 14:00 UTC (9:00 AM Central)
 
 // ── Scheduled entry point ────────────────────────────────────────────────────
 
@@ -43,6 +44,13 @@ addEventListener('fetch', function(event) {
 // ── Core logic ───────────────────────────────────────────────────────────────
 
 function runChecks(event) {
+  // Quiet window — no checks before 9 AM Central (14:00 UTC)
+  var hourUTC = new Date().getUTCHours();
+  if (hourUTC < QUIET_BEFORE_UTC) {
+    console.log('Quiet window (' + hourUTC + ':00 UTC < ' + QUIET_BEFORE_UTC + ':00 UTC) — skipping checks');
+    return Promise.resolve();
+  }
+
   var endpoints = parseEndpoints();
   if (!endpoints.length) {
     console.error('UPTIME_ENDPOINTS not configured');


### PR DESCRIPTION
## Summary
- **Quiet window**: Skip all uptime checks before 9:00 AM Central (14:00 UTC). Morning GAS triggers (resetDailyTasks 5AM, healthCheck 6AM, snapshot 6:30AM) slow GAS responses and flood Pushover with false DOWN/RECOVERED pairs
- **Timeout bump**: 20s → 45s. GAS cold starts regularly exceed 20s, triggering false DOWNs

## What was happening
GAS API was flapping every 15-20 min during early morning hours when heavy scheduled triggers compete with the uptime check. Each flap generated two Pushover alerts (DOWN + RECOVERED).

## Deploy note
This is a Cloudflare Worker — after merge, deploy with `wrangler deploy uptime-worker.js` (not clasp push).

## Test plan
- [ ] Verify no Pushover alerts before 9 AM tomorrow
- [ ] Verify alerts still fire after 9 AM if GAS is actually down
- [ ] Verify 45s timeout eliminates cold-start false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)