### PR TITLE
fix: claspignore QAHarness and TBMConfig

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -23,4 +23,6 @@ specs/**
 staar-rla-sprint-final.json
 claude-md-baseline.json
 spelling-catalog.json
+QAHarness.*
+TBMConfig.*
 !appsscript.json


### PR DESCRIPTION
## Summary
Add `QAHarness.*` and `TBMConfig.*` to `.claspignore` with wildcard extensions. These files exist on GAS (deployed by PR #102) but cause `clasp push` conflicts when not ignored locally.

## Test plan
- [ ] `clasp push` succeeds without "Conflicting files found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)