### PR TITLE
feat: parent reporting de-stub — Phase 1 (#137)

### DIFF
--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v57 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v58 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 57; }
+function getKidsHubVersion() { return 58; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -2915,125 +2915,290 @@ function verifyAudioFiles(expectedFilenames) {
 }
 
 /**
- * v29: Progress report data stub — called by ProgressReport.html.
- * Returns skeleton data structure. Wire to real sheet data when
- * KH_Homework and KH_SparkleProgress sheets have data flowing.
+ * v30: Parent-facing weekly progress report data.
+ *
+ * Tier classification (see specs/parent-reporting-scope.md):
+ *   Tier A (real, this week):   populated from KH_History + KH_Education
+ *   Tier B (blocked for JJ):    returns null + tierB_blocked=true until
+ *                               #133 Phase 2 lands KH_LessonRuns
+ *   Tier C (future):            lifetime totals, time tracking, alerts
+ *
+ * Naming split enforced: Buggsy uses ringsThisWeek/ringsTotal,
+ * JJ uses starsThisWeek/starsTotal. Conditional field assignment in
+ * _buildChildReport_ means the UI reading the wrong side gets undefined,
+ * which is louder than a silent zero.
+ *
+ * Closes #137 (Phase 1).
  */
+function getWeeklyProgressVersion() { return 2; }
+
 function getWeeklyProgressSafe() {
   return withMonitor_('getWeeklyProgressSafe', function() {
-    var today = new Date();
-    var dayOfWeek = today.getDay();
-    var mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-    var monday = new Date(today);
-    monday.setDate(today.getDate() + mondayOffset);
-    monday.setHours(0, 0, 0, 0);
-    var mondayISO = monday.getFullYear() + '-' + (monday.getMonth() + 1 < 10 ? '0' : '') + (monday.getMonth() + 1) + '-' + (monday.getDate() < 10 ? '0' : '') + monday.getDate();
-
-    var children = ['buggsy', 'jj'];
-    var result = {};
-
-    // Read KH_History for chores this week
+    var bounds = _computeWeekBounds_();
     var histData = readSheet_('KH_History');
-    var histH = histData && histData.length > 0 ? histData[0].map(String) : [];
-
-    // Read KH_Education for daily homework data
-    // Schema: Timestamp,Child,Module,Subject,Score,AutoGraded,ResponseText,Status,ParentNotes,RingsAwarded,ReviewTimestamp,GeminiFeedback
     var eduData = readSheet_('KH_Education');
-    var eduH = eduData && eduData.length > 0 ? eduData[0].map(String) : [];
 
-    for (var ci = 0; ci < children.length; ci++) {
-      var child = children[ci];
-      var choresCompleted = 0, ringsEarned = 0, streakDays = 0;
-      var modulesCompleted = 0, pendingReview = 0, mcRingsTotal = 0, mcCount = 0;
-      var subjectCounts = {};
-      var uniqueDays = {};
+    var buggsy = _buildChildReport_('buggsy', bounds, histData, eduData, {
+      hasKHEducation: true,
+      tierBBlocked: false
+    });
 
-      // Aggregate KH_History this week
-      if (histData && histH.length > 0) {
-        var hChild = histH.indexOf('Child');
-        var hDate = histH.indexOf('Date');
-        var hPoints = histH.indexOf('Points');
-        var hType = histH.indexOf('Event_Type');
-        for (var hi = 1; hi < histData.length; hi++) {
-          var row = histData[hi];
-          if (String(row[hChild] || '').toLowerCase() !== child) continue;
-          var rowDate = String(row[hDate] || '');
-          if (rowDate < mondayISO) continue;
-          var evType = String(row[hType] || '');
-          if (evType === 'completion' || evType === 'approval') {
-            choresCompleted++;
-            ringsEarned += Number(row[hPoints]) || 0;
-            uniqueDays[rowDate] = true;
-          }
-        }
+    var jj = _buildChildReport_('jj', bounds, histData, eduData, {
+      hasKHEducation: false, // JJ does not write to KH_Education
+      tierBBlocked: true
+    });
+
+    return JSON.parse(JSON.stringify({
+      weekLabel: bounds.label,
+      weekStart: bounds.startISO,
+      weekEnd: bounds.endISO,
+      buggsy: buggsy,
+      jj: jj,
+      meta: {
+        generatedAt: new Date().toISOString(),
+        source: 'KH_History + KH_Education',
+        blockedTierB: ['jj'],
+        version: 2
       }
+    }));
+  });
+}
 
-      // Streak: count consecutive days with chores from today backwards
-      var dayKeys = Object.keys(uniqueDays).sort().reverse();
-      var checkDate = new Date(today);
-      for (var di = 0; di < 7; di++) {
-        var checkISO = checkDate.getFullYear() + '-' + (checkDate.getMonth() + 1 < 10 ? '0' : '') + (checkDate.getMonth() + 1) + '-' + (checkDate.getDate() < 10 ? '0' : '') + checkDate.getDate();
-        if (uniqueDays[checkISO]) { streakDays++; } else if (di > 0) { break; }
-        checkDate.setDate(checkDate.getDate() - 1);
-      }
+function _computeWeekBounds_() {
+  var today = new Date();
+  var dayOfWeek = today.getDay();
+  var mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  var monday = new Date(today);
+  monday.setDate(today.getDate() + mondayOffset);
+  monday.setHours(0, 0, 0, 0);
+  var friday = new Date(monday);
+  friday.setDate(monday.getDate() + 4);
+  var sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  return {
+    monday: monday,
+    friday: friday,
+    sunday: sunday,
+    startISO: _isoDate_(monday),
+    endISO: _isoDate_(sunday),
+    label: 'Week of ' + (monday.getMonth() + 1) + '/' + monday.getDate()
+  };
+}
 
-      // Aggregate KH_Education this week (daily homework submissions)
-      if (eduData && eduH.length > 0) {
-        var eChild = eduH.indexOf('Child');
-        var eTimestamp = eduH.indexOf('Timestamp');
-        var eSubject = eduH.indexOf('Subject');
-        var eScore = eduH.indexOf('Score');
-        var eAutoGraded = eduH.indexOf('AutoGraded');
-        var eStatus = eduH.indexOf('Status');
-        var eRings = eduH.indexOf('RingsAwarded');
-        for (var ei = 1; ei < eduData.length; ei++) {
-          var erow = eduData[ei];
-          if (String(erow[eChild] || '').toLowerCase() !== child) continue;
-          // Filter to this week using timestamp date portion
-          var ts = erow[eTimestamp];
-          var tsDate = ts instanceof Date
-            ? (ts.getFullYear() + '-' + (ts.getMonth() + 1 < 10 ? '0' : '') + (ts.getMonth() + 1) + '-' + (ts.getDate() < 10 ? '0' : '') + ts.getDate())
-            : String(ts || '').slice(0, 10);
-          if (tsDate < mondayISO) continue;
-          modulesCompleted++;
-          var rowStatus = String(erow[eStatus] || '');
-          if (rowStatus === 'pending_review') pendingReview++;
-          var isAuto = String(erow[eAutoGraded] || '').toLowerCase();
-          if (isAuto === 'true' || erow[eAutoGraded] === true) {
-            mcRingsTotal += Number(erow[eRings]) || 0;
-            mcCount++;
-          }
-          var subj = String(erow[eSubject] || 'Other');
-          subjectCounts[subj] = (subjectCounts[subj] || 0) + 1;
-        }
-      }
+function _isoDate_(d) {
+  var m = d.getMonth() + 1;
+  var day = d.getDate();
+  return d.getFullYear() + '-' + (m < 10 ? '0' : '') + m + '-' + (day < 10 ? '0' : '') + day;
+}
 
-      var topSubject = '';
-      var topCount = 0;
-      for (var sk in subjectCounts) {
-        if (subjectCounts[sk] > topCount) { topCount = subjectCounts[sk]; topSubject = sk; }
-      }
+function _weekdayLabel_(dayIdx) {
+  // 0=Mon, 1=Tue, 2=Wed, 3=Thu, 4=Fri
+  return ['Mon','Tue','Wed','Thu','Fri'][dayIdx] || '';
+}
 
-      // accuracy: for MC modules, rings/8 per module ≈ score %. Capped at 1.0.
-      var accuracy = (mcCount > 0 && mcRingsTotal > 0)
-        ? Math.min(1, Math.round((mcRingsTotal / (mcCount * 8)) * 100) / 100)
-        : 0;
+// Sum Points from KH_History where event_type is completion, approval, or education
+// for this child this week (bounds.startISO inclusive → bounds.endISO inclusive).
+// Also returns unique-day set for streak calculation.
+function _sumRingsThisWeek_(child, bounds, histData) {
+  var result = { pointsSum: 0, uniqueDays: {} };
+  if (!histData || histData.length < 2) return result;
+  var h = histData[0].map(String);
+  var hChild = h.indexOf('Child');
+  var hDate = h.indexOf('Date');
+  var hPoints = h.indexOf('Points');
+  var hType = h.indexOf('Event_Type');
+  if (hChild < 0 || hDate < 0 || hPoints < 0 || hType < 0) return result;
+  for (var i = 1; i < histData.length; i++) {
+    var row = histData[i];
+    if (String(row[hChild] || '').toLowerCase() !== child) continue;
+    var rowDate = String(row[hDate] || '').slice(0, 10);
+    if (rowDate < bounds.startISO || rowDate > bounds.endISO) continue;
+    var evType = String(row[hType] || '');
+    if (evType !== 'completion' && evType !== 'approval' && evType !== 'education') continue;
+    result.pointsSum += Number(row[hPoints]) || 0;
+    result.uniqueDays[rowDate] = true;
+  }
+  return result;
+}
 
-      result[child] = {
-        child: child,
-        weekLabel: 'Week of ' + (monday.getMonth() + 1) + '/' + monday.getDate(),
-        choresCompleted: choresCompleted,
-        ringsEarned: ringsEarned,
-        questionsAnswered: modulesCompleted,
-        accuracy: accuracy,
-        streakDays: streakDays,
-        topSubject: topSubject || 'None yet',
-        pendingReview: pendingReview
-      };
+// Walk backwards from today counting consecutive days with any
+// completion/approval/education row. Accepts the uniqueDays set from _sumRingsThisWeek_.
+// Gap on a day before today breaks the streak; missing today only breaks if yesterday
+// also missed (today's zero is allowed at the start of the day).
+function _computeStreakFromDays_(uniqueDays) {
+  var streak = 0;
+  var checkDate = new Date();
+  for (var di = 0; di < 30; di++) {
+    var iso = _isoDate_(checkDate);
+    if (uniqueDays[iso]) {
+      streak++;
+    } else if (di > 0) {
+      break;
+    }
+    checkDate.setDate(checkDate.getDate() - 1);
+  }
+  return streak;
+}
+
+// Aggregate KH_Education rows for one child this week into:
+//   count        — sessionsCompleted
+//   avgScore     — mean of Score column for auto-graded rows (0 if none)
+//   pendingReview — count of rows with Status='pending_review'
+//   weekLog      — 5 entries Mon-Fri of {day, status, score}
+//   subjects     — array of {name, score, total} grouped by Subject
+function _aggregateKHEducation_(child, bounds, eduData) {
+  var out = {
+    count: 0,
+    avgScore: null,
+    pendingReview: 0,
+    weekLog: [],
+    subjects: []
+  };
+  // Initialize 5-day weekLog regardless of rows
+  for (var di = 0; di < 5; di++) {
+    out.weekLog.push({ day: _weekdayLabel_(di), status: 'none', score: null });
+  }
+  if (!eduData || eduData.length < 2) return out;
+
+  var h = eduData[0].map(String);
+  var eChild = h.indexOf('Child');
+  var eTimestamp = h.indexOf('Timestamp');
+  var eSubject = h.indexOf('Subject');
+  var eScore = h.indexOf('Score');
+  var eAutoGraded = h.indexOf('AutoGraded');
+  var eStatus = h.indexOf('Status');
+  if (eChild < 0 || eTimestamp < 0) return out;
+
+  var scoreSum = 0;
+  var scoreCount = 0;
+  var subjectAgg = {}; // name → { score, total }
+  var dayAgg = {}; // iso → { status, scoreSum, scoreCount }
+
+  for (var i = 1; i < eduData.length; i++) {
+    var row = eduData[i];
+    if (String(row[eChild] || '').toLowerCase() !== child) continue;
+    var ts = row[eTimestamp];
+    var tsIso;
+    if (ts instanceof Date) {
+      tsIso = _isoDate_(ts);
+    } else {
+      tsIso = String(ts || '').slice(0, 10);
+    }
+    if (tsIso < bounds.startISO || tsIso > bounds.endISO) continue;
+
+    out.count++;
+    var statusVal = String(row[eStatus] || '');
+    if (statusVal === 'pending_review') out.pendingReview++;
+
+    var isAuto = String(row[eAutoGraded] || '').toLowerCase() === 'true' || row[eAutoGraded] === true;
+    var scoreVal = Number(row[eScore]) || 0;
+    if (isAuto && eScore >= 0) {
+      scoreSum += scoreVal;
+      scoreCount++;
     }
 
-    return JSON.parse(JSON.stringify(result));
-  });
+    var subjName = String(row[eSubject] || 'Other');
+    if (!subjectAgg[subjName]) subjectAgg[subjName] = { score: 0, total: 0 };
+    subjectAgg[subjName].total++;
+    if (isAuto) subjectAgg[subjName].score++;
+
+    // Track per-day status
+    if (!dayAgg[tsIso]) dayAgg[tsIso] = { status: 'none', scoreSum: 0, scoreCount: 0 };
+    var dayEntry = dayAgg[tsIso];
+    if (statusVal === 'pending_review') {
+      dayEntry.status = 'pending';
+    } else if (statusVal === 'auto_approved' || statusVal === 'approved') {
+      dayEntry.status = 'done';
+    }
+    if (isAuto) {
+      dayEntry.scoreSum += scoreVal;
+      dayEntry.scoreCount++;
+    }
+  }
+
+  if (scoreCount > 0) out.avgScore = Math.round(scoreSum / scoreCount);
+
+  // Fill weekLog Mon-Fri from dayAgg
+  var checkDate = new Date(bounds.monday);
+  for (var wi = 0; wi < 5; wi++) {
+    var wiso = _isoDate_(checkDate);
+    if (dayAgg[wiso]) {
+      out.weekLog[wi].status = dayAgg[wiso].status;
+      if (dayAgg[wiso].scoreCount > 0) {
+        out.weekLog[wi].score = Math.round(dayAgg[wiso].scoreSum / dayAgg[wiso].scoreCount);
+      }
+    }
+    checkDate.setDate(checkDate.getDate() + 1);
+  }
+
+  // Flatten subjects
+  var subjKeys = Object.keys(subjectAgg);
+  for (var sk = 0; sk < subjKeys.length; sk++) {
+    var key = subjKeys[sk];
+    out.subjects.push({
+      name: key,
+      score: subjectAgg[key].score,
+      total: subjectAgg[key].total
+    });
+  }
+
+  return out;
+}
+
+function _buildChildReport_(child, bounds, histData, eduData, flags) {
+  var isJJ = (child === 'jj');
+  var histAgg = _sumRingsThisWeek_(child, bounds, histData);
+  var streak = _computeStreakFromDays_(histAgg.uniqueDays);
+
+  // Build the base shape. Fields common to both children live here.
+  // Child-specific naming split (ringsThisWeek vs starsThisWeek) is applied below.
+  var base = {
+    name: isJJ ? 'JJ (Kindle)' : 'Buggsy',
+    child: child,
+    // Tier A — fields populated downstream
+    streak: streak,
+    sessionsCompleted: null,
+    sessionsTotal: 5,
+    completionRate: null,
+    avgScore: null,
+    pendingReview: 0,
+    weekLog: [],
+    subjects: [],
+    // Tier B (blocked marker for client UI)
+    milestones: [],
+    tierB_blocked: !!flags.tierBBlocked,
+    tierB_reason: flags.tierBBlocked ? 'jj-lesson-run-data-model' : null,
+    // Tier C (future)
+    timeSpent: null,
+    alerts: []
+  };
+
+  // Naming split: Buggsy → rings*, JJ → stars*. UI code reading the wrong
+  // side gets undefined, which is louder than a silent zero. Enforced by
+  // Gate 5 checklist item 16.
+  if (isJJ) {
+    base.starsThisWeek = histAgg.pointsSum;
+    base.starsTotal = null; // Tier C
+  } else {
+    base.ringsThisWeek = histAgg.pointsSum;
+    base.ringsTotal = null; // Tier C
+  }
+
+  if (flags.hasKHEducation) {
+    var eduAgg = _aggregateKHEducation_(child, bounds, eduData);
+    base.sessionsCompleted = eduAgg.count;
+    base.completionRate = Math.min(100, Math.round((eduAgg.count / base.sessionsTotal) * 100));
+    base.avgScore = eduAgg.avgScore;
+    base.pendingReview = eduAgg.pendingReview;
+    base.weekLog = eduAgg.weekLog;
+    base.subjects = eduAgg.subjects;
+  }
+
+  // Phase 2 (#133 lands KH_LessonRuns): merge in JJ data from lesson runs.
+  // Intentionally omitted from Phase 1 — branch will be added when
+  // _aggregateKHLessonRuns_ helper ships in the Phase 2 PR.
+
+  return base;
 }
 
 
@@ -4047,5 +4212,5 @@ function getDailyMissionsInitSafe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v57
+// END OF FILE — KidsHub.gs v58
 // ════════════════════════════════════════════════════════════════════

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v58 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v59 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 58; }
+function getKidsHubVersion() { return 59; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -3054,9 +3054,16 @@ function _aggregateKHEducation_(child, bounds, eduData) {
     weekLog: [],
     subjects: []
   };
-  // Initialize 5-day weekLog regardless of rows
+  // Initialize 5-day weekLog with position-aware default status:
+  //   past empty days → 'missed' (no activity recorded after the day passed)
+  //   today or future → 'none'  (not yet active; renderer shows dimmed/empty cell)
+  var todayIso = getTodayISO_();
+  var initDate = new Date(bounds.monday);
   for (var di = 0; di < 5; di++) {
-    out.weekLog.push({ day: _weekdayLabel_(di), status: 'none', score: null });
+    var dayIso = _isoDate_(initDate);
+    var defaultStatus = (dayIso < todayIso) ? 'missed' : 'none';
+    out.weekLog.push({ day: _weekdayLabel_(di), status: defaultStatus, score: null });
+    initDate.setDate(initDate.getDate() + 1);
   }
   if (!eduData || eduData.length < 2) return out;
 
@@ -4212,5 +4219,5 @@ function getDailyMissionsInitSafe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v58
+// END OF FILE — KidsHub.gs v59
 // ════════════════════════════════════════════════════════════════════

--- a/ProgressReport.html
+++ b/ProgressReport.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="progress-report">
-<meta name="tbm-version" content="v3">
+<meta name="tbm-version" content="v4">
 <title>Weekly Progress Report</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -589,6 +589,14 @@ function buildAlert(icon, text, type) {
 }
 
 function buildDayRow(dayName, status, score) {
+  // 'none' = today or future day with no data yet — render dimmed empty cell
+  if (status === 'none') {
+    return '<div class="day-row">' +
+      '<div class="day-name">' + dayName + '</div>' +
+      '<div class="day-status" style="color:#475569;">--</div>' +
+      '<div class="day-score" style="color:#475569;">--</div>' +
+      '</div>';
+  }
   var statusClass = 'pending';
   var statusText = 'Pending';
   if (status === 'done') { statusClass = 'done'; statusText = 'Completed'; }
@@ -756,7 +764,7 @@ function renderOverview(data) {
   html += '<h3>BUGGSY</h3>';
   html += '<div class="overview-row"><span class="overview-label">Rings This Week</span><span class="overview-value">' + b.ringsThisWeek + '</span></div>';
   html += '<div class="overview-row"><span class="overview-label">Total Rings</span><span class="overview-value">' + b.ringsTotal + '</span></div>';
-  html += '<div class="overview-row"><span class="overview-label">Sessions</span><span class="overview-value">' + b.sessionsCompleted + '/' + b.sessionsTotal + '</span></div>';
+  html += '<div class="overview-row"><span class="overview-label">Sessions</span><span class="overview-value">' + (b.sessionsCompleted !== null && b.sessionsCompleted !== undefined ? b.sessionsCompleted + '/' + b.sessionsTotal : '--') + '</span></div>';
   html += '<div class="overview-row"><span class="overview-label">Avg Score</span><span class="overview-value">' + (b.avgScore ? Math.round(b.avgScore) + '%' : '--') + '</span></div>';
   html += '<div class="overview-row"><span class="overview-label">Streak</span><span class="overview-value">' + b.streak + ' days</span></div>';
   html += '<div class="overview-row"><span class="overview-label">Time Spent</span><span class="overview-value">' + (b.timeSpent || 0) + ' min</span></div>';
@@ -766,7 +774,7 @@ function renderOverview(data) {
   html += '<h3>JJ (KINDLE)</h3>';
   html += '<div class="overview-row"><span class="overview-label">Stars This Week</span><span class="overview-value">' + j.starsThisWeek + '</span></div>';
   html += '<div class="overview-row"><span class="overview-label">Total Stars</span><span class="overview-value">' + j.starsTotal + '</span></div>';
-  html += '<div class="overview-row"><span class="overview-label">Sessions</span><span class="overview-value">' + j.sessionsCompleted + '/' + j.sessionsTotal + '</span></div>';
+  html += '<div class="overview-row"><span class="overview-label">Sessions</span><span class="overview-value">' + (j.sessionsCompleted !== null && j.sessionsCompleted !== undefined ? j.sessionsCompleted + '/' + j.sessionsTotal : 'Not yet tracked') + '</span></div>';
   html += '<div class="overview-row"><span class="overview-label">Streak</span><span class="overview-value">' + j.streak + ' days</span></div>';
   html += '</div>';
 

--- a/ProgressReport.html
+++ b/ProgressReport.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="progress-report">
-<meta name="tbm-version" content="v2">
+<meta name="tbm-version" content="v3">
 <title>Weekly Progress Report</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -314,6 +314,36 @@ main {
   color: #64748B;
   font-size: 14px;
 }
+.load-error-block {
+  text-align: center;
+  padding: 40px 20px;
+}
+.load-error-icon {
+  font-size: 32px;
+  margin-bottom: 10px;
+  color: #EF4444;
+}
+.load-error-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #E2E8F0;
+  margin-bottom: 6px;
+}
+.load-error-detail {
+  font-size: 12px;
+  color: #64748B;
+  margin-bottom: 16px;
+}
+.load-error-retry {
+  background: #3B82F6;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 24px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
 
 /* Overview summary */
 .overview-card {
@@ -577,13 +607,13 @@ function renderBuggsy(data) {
   var b = data.buggsy;
   var html = '';
 
-  // Normalize field names — handle both real backend shape and mock shape
-  var rings = b.ringsThisWeek !== undefined ? b.ringsThisWeek : (b.ringsEarned || 0);
-  var streak = b.streak !== undefined ? b.streak : (b.streakDays || 0);
-  var done = b.sessionsCompleted !== undefined ? b.sessionsCompleted : (b.questionsAnswered || 0);
+  // Direct field reads — Phase 1 real shape (specs/parent-reporting-scope.md)
+  var rings = b.ringsThisWeek || 0;
+  var streak = b.streak || 0;
+  var done = b.sessionsCompleted || 0;
   var total = b.sessionsTotal || 5;
-  var avgPct = b.avgScore !== undefined ? Math.round(b.avgScore) : (b.accuracy !== undefined ? Math.round(b.accuracy * 100) : null);
-  var completion = b.completionRate !== undefined ? b.completionRate : Math.min(100, Math.round((done / total) * 100));
+  var avgPct = b.avgScore !== null && b.avgScore !== undefined ? Math.round(b.avgScore) : null;
+  var completion = b.completionRate !== null && b.completionRate !== undefined ? b.completionRate : Math.min(100, Math.round((done / total) * 100));
   var pending = b.pendingReview || 0;
 
   html += '<div class="section-label">WEEKLY STATS</div>';
@@ -646,15 +676,27 @@ function renderJJ(data) {
   var j = data.jj;
   var html = '';
 
+  // Tier A fields available in Phase 1: starsThisWeek, streak
   html += '<div class="section-label">WEEKLY STATS</div>';
   html += '<div class="stat-grid">';
-  html += buildStatCard(j.starsThisWeek, 'Stars This Week');
-  html += buildStatCard(j.streak, 'Day Streak');
-  html += buildStatCard(j.sessionsCompleted + '/' + j.sessionsTotal, 'Sessions');
+  html += buildStatCard(j.starsThisWeek || 0, 'Stars This Week');
+  html += buildStatCard(j.streak || 0, 'Day Streak');
   html += '</div>';
 
+  // Tier B blocked: session/weekLog/subjects/avgScore/milestones unavailable until Phase 2 (#133)
+  if (j.tierB_blocked) {
+    html += '<div class="section-label">DETAILED PROGRESS</div>';
+    html += '<div class="empty-state" style="padding:20px;text-align:center;">';
+    html += '<div style="font-size:28px;margin-bottom:8px;">&#128303;</div>';
+    html += '<div style="font-weight:700;margin-bottom:6px;">Detailed Progress Coming Soon</div>';
+    html += '<div style="font-size:12px;color:#94A3B8;">Full session data, daily log, and subject breakdown will appear here once JJ\'s lesson data model is updated. Stars and streak are live.</div>';
+    html += '</div>';
+    document.getElementById('tab-jj').innerHTML = html;
+    return;
+  }
+
   html += '<div class="section-label">COMPLETION</div>';
-  html += buildScoreBar('Weekly Completion', j.completionRate, '#FBBF24');
+  html += buildScoreBar('Weekly Completion', j.completionRate || 0, '#FBBF24');
 
   if (j.milestones && j.milestones.length > 0) {
     html += '<div class="section-label">MILESTONES</div>';
@@ -888,40 +930,75 @@ function loadData() {
         onDataLoaded();
       })
       .withFailureHandler(function(err) {
-        useMockData();
+        showLoadError(err);
       })
       .getWeeklyProgressSafe();
   } else {
+    // No google.script.run — offline/dev environment. Use mock data.
     useMockData();
   }
 }
 
+// Show error state when getWeeklyProgressSafe fails in production.
+// Does NOT fall through to useMockData — silently showing zeros would mask real errors.
+function showLoadError(err) {
+  var now = new Date();
+  var hh = now.getHours();
+  var mm = now.getMinutes();
+  var timeStr = (hh < 10 ? '0' : '') + hh + ':' + (mm < 10 ? '0' : '') + mm;
+  var errMsg = (err && err.message) ? String(err.message) : 'Unknown error';
+  var loadEl = document.getElementById('loading');
+  if (loadEl) {
+    loadEl.innerHTML =
+      '<div class="load-error-block">' +
+      '<div class="load-error-icon">&#9888;</div>' +
+      '<div class="load-error-title">Error loading weekly data &mdash; last attempt at ' + timeStr + '</div>' +
+      '<div class="load-error-detail">' + errMsg + '</div>' +
+      '<button class="load-error-retry" onclick="loadData()">Retry</button>' +
+      '</div>';
+    loadEl.className = 'loading-wrap';
+  }
+}
+
+// useMockData is for local dev/offline only (when google.script.run is unavailable).
+// It mirrors the Phase 1 tier-classified shape so the renderer paths stay testable.
+// Production failure path is showLoadError() — not this function.
 function useMockData() {
   reportData = {
     buggsy: {
       name: 'Buggsy',
+      child: 'buggsy',
       ringsThisWeek: 0,
-      ringsTotal: 0,
+      ringsTotal: null,
       streak: 0,
       completionRate: 0,
       sessionsCompleted: 0,
       sessionsTotal: 5,
-      avgScore: 0,
-      timeSpent: 0,
+      avgScore: null,
+      pendingReview: 0,
+      timeSpent: null,
       subjects: [],
       weekLog: [],
+      milestones: [],
+      tierB_blocked: false,
+      tierB_reason: null,
       alerts: []
     },
     jj: {
       name: 'JJ (Kindle)',
+      child: 'jj',
       starsThisWeek: 0,
-      starsTotal: 0,
+      starsTotal: null,
       streak: 0,
-      completionRate: 0,
-      sessionsCompleted: 0,
+      sessionsCompleted: null,
       sessionsTotal: 5,
+      completionRate: null,
+      avgScore: null,
+      pendingReview: 0,
       milestones: [],
       weekLog: [],
+      tierB_blocked: true,
+      tierB_reason: 'jj-lesson-run-data-model',
       alerts: []
     }
   };


### PR DESCRIPTION
## Summary

- Rewrites `getWeeklyProgressSafe` from a stub to a tier-classified implementation pulling real data from KH_History + KH_Education for Buggsy (Tier A live), while returning `tierB_blocked: true` for JJ until #133 Phase 2 lands KH_LessonRuns
- Enforces naming split: Buggsy uses `ringsThisWeek`/`ringsTotal`, JJ uses `starsThisWeek`/`starsTotal` — wrong-side reads yield `undefined`, not a silent zero
- Removes normalization bridge (`b.ringsEarned`, `b.questionsAnswered`, `b.streakDays`) from ProgressReport.html — direct field reads only
- Adds "Detailed Progress Coming Soon" tier-B placeholder in JJ tab (renders when `tierB_blocked === true`)
- Replaces silent `useMockData()` production failure path with `showLoadError()` — shows "Error loading weekly data — last attempt at HH:MM" + Retry button per LT decision in spec Open questions #1
- `useMockData()` retained for offline/dev-only path (no `google.script.run`)

## Tier classification (Phase 1)

| Field group | Buggsy | JJ |
|---|---|---|
| rings/stars this week | Live (KH_History) | Live (KH_History as starsThisWeek) |
| streak | Live | Live |
| sessionsCompleted / weekLog / subjects / avgScore | Live (KH_Education) | Blocked (tierB_blocked=true) |
| milestones / timeSpent / ringsTotal / starsTotal | Tier C — future | Tier C — future |

## Dependency

Phase 2 (#133) ships `_aggregateKHLessonRuns_` and wires JJ's full Tier B data. The `_buildChildReport_` function has a clearly marked placeholder comment for that branch.

## Closes

Closes #137

## Test plan

- [ ] Smoke: `?action=runTests` — `overall: PASS`, `smoke.overall: PASS`, `wiring.missing: []` ✅ verified at deploy
- [ ] KidsHub.gs v58 confirmed live via smoke test environment check ✅
- [ ] ProgressReport loads without error; Buggsy shows real rings/sessions/weekLog; JJ shows "Detailed Progress Coming Soon"
- [ ] Failure handler: kill network after load starts — confirm error UI appears (not zeros)
- [ ] ES5 compliance: `audit-source.sh` PASS ✅
- [ ] Gate 4 manifest: all greps pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)