### PR TITLE
feat: storyfactory → sparklelearning audio_story bridge — Phase 1 (#140)

### DIFF
--- a/ActivityStoryPacks.js
+++ b/ActivityStoryPacks.js
@@ -1,0 +1,87 @@
+// Version history tracked in Notion deploy page. Do not add version comments here.
+// ════════════════════════════════════════════════════════════════════
+// ActivityStoryPacks.gs v1 — Pre-authored story packs for SparkleLearning audio_story
+// WRITES TO: (none — read-only module)
+// READS FROM: (none — static constant)
+// ════════════════════════════════════════════════════════════════════
+// PURPOSE: Supply the story/question/answer/options fields for JJ's
+//   curriculum audio_story activities. Consumed by Kidshub.js
+//   getTodayContent_() which mutates matching activities in place before
+//   returning to SparkleLearning.html.
+//
+// CONSUMER: SparkleLearning.html renderAudioStory() (line 2473)
+// DATA FLOW: CurriculumSeed storyId → ACTIVITY_STORY_PACKS[storyId] →
+//   activity.{story, question, answer, options} → renderAudioStory
+//
+// NOT TO BE CONFUSED WITH: StoryFactory.js STORY_INDEX which owns
+//   full-scene vocabulary_bedtime stories served by StoryReader.html.
+//   Audio-story packs are a different shape for a different renderer.
+// ════════════════════════════════════════════════════════════════════
+
+function getActivityStoryPacksVersion() { return 1; }
+
+var ACTIVITY_STORY_PACKS = {
+  'jj-kitchen': {
+    title: "JJ's Kitchen",
+    story: "JJ walks into the kitchen for a snack. Daddy asks if she wants ice cream. JJ smiles and nods and holds up three fingers. Daddy scoops one, two, three big scoops into her bowl. JJ takes a big blue spoon and says thank you, Daddy!",
+    question: "How many scoops of ice cream did Daddy give JJ?",
+    answer: "Three",
+    options: ["Three", "One", "Five"]
+  },
+  'jj-buggsy-treasure': {
+    title: "JJ and Buggsy's Treasure Hunt",
+    story: "JJ and Buggsy find a map in the yard. The map shows a treasure hunt! They follow the yellow arrows and look for stars. Under the rectangle rock they find one, two, three, four, five shiny treasures. Buggsy gives JJ a big hug!",
+    question: "How many treasures did JJ and Buggsy find?",
+    answer: "Five",
+    options: ["Five", "Two", "Three"]
+  },
+  'jj-buggsy-rainy': {
+    title: "JJ and Buggsy's Rainy Day",
+    story: "It is raining and JJ and Buggsy can not go outside. Buggsy has a big idea to build a blanket fort. They pick a green blanket and drape it over two chairs. JJ puts heart pillows inside and Buggsy brings snacks. The green fort is the best rainy day ever!",
+    question: "What color was JJ and Buggsy's blanket fort?",
+    answer: "Green",
+    options: ["Green", "Red", "Blue"]
+  }
+};
+
+/**
+ * Look up an activity story pack by storyId.
+ * Returns the pack object (title + story + question + answer + options)
+ * or null if the storyId is unknown.
+ */
+function getActivityStoryPack_(storyId) {
+  if (!storyId || typeof storyId !== 'string') return null;
+  var pack = ACTIVITY_STORY_PACKS[storyId];
+  if (!pack) return null;
+  // Return a shallow copy so callers can't mutate the master constant.
+  return {
+    title: pack.title,
+    story: pack.story,
+    question: pack.question,
+    answer: pack.answer,
+    options: pack.options.slice()
+  };
+}
+
+/**
+ * Safe wrapper — returns a JSON-round-tripped copy.
+ * Whitelisted in Code.js serveData API_WHITELIST. Registered in
+ * Tbmsmoketest.js CANONICAL_SAFE_FUNCTIONS. Callable from HTML via
+ * google.script.run but the typical consumer is server-side
+ * getTodayContent_() which calls the underscore variant directly.
+ *
+ * Returns:
+ *   { ok: true,  pack: {title, story, question, answer, options} } — on hit
+ *   { ok: false, error: 'unknown_story_id', storyId: '...' }       — on miss
+ */
+function getActivityStoryPackSafe(storyId) {
+  return withMonitor_('getActivityStoryPackSafe', function() {
+    var pack = getActivityStoryPack_(storyId);
+    if (!pack) {
+      return { ok: false, error: 'unknown_story_id', storyId: storyId || null };
+    }
+    return JSON.parse(JSON.stringify({ ok: true, pack: pack }));
+  });
+}
+
+// END OF FILE — ActivityStoryPacks.gs v1

--- a/Code.js
+++ b/Code.js
@@ -1,6 +1,6 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// Code.gs v76 — Apps Script Router (TBM Consolidated)
+// Code.gs v77 — Apps Script Router (TBM Consolidated)
 // WRITES TO: (routes only — delegates to DataEngine, KidsHub, etc.)
 // READS FROM: (routes only — delegates to DataEngine, KidsHub, etc.)
 // ════════════════════════════════════════════════════════════════════
@@ -19,7 +19,7 @@ function isLessonRunsEnabled_() {
   } catch (e) { return false; }
 }
 
-function getCodeVersion() { return 76; }
+function getCodeVersion() { return 77; }
 
 // v37 FIX 5: ES5-safe left-pad helper — replaces String.padStart()
 function leftPad2_(n) {
@@ -409,7 +409,7 @@ function serveData(e) {
         'updateFamilyNoteSafe': updateFamilyNoteSafe, 'addKidsEventSafe': addKidsEventSafe,
         'runMERGatesSafe': runMERGatesSafe, 'stampCloseMonthSafe': stampCloseMonthSafe,
         'getVaultDataSafe': getVaultDataSafe, 'runStoryFactorySafe': runStoryFactorySafe,
-        'listStoredStoriesSafe': listStoredStoriesSafe, 'getStoredStorySafe': getStoredStorySafe,
+        'listStoredStoriesSafe': listStoredStoriesSafe, 'getStoredStorySafe': getStoredStorySafe, 'getActivityStoryPackSafe': getActivityStoryPackSafe,
         'getTodayContentSafe': getTodayContentSafe, 'seedWeek1CurriculumSafe': seedWeek1CurriculumSafe, 'seedStaarRlaSprintSafe': seedStaarRlaSprintSafe,
         'reconcileVeinPulse': reconcileVeinPulse, 'getScriptUrlSafe': getScriptUrlSafe,
         'submitFeedbackSafe': submitFeedbackSafe, 'getAudioBatchSafe': getAudioBatchSafe,
@@ -1999,4 +1999,4 @@ function getOpsHealthSafe() {
   });
 }
 
-// END OF FILE — Code.gs v76
+// END OF FILE — Code.gs v77

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v60 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v61 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 🧹📅 KH_LessonRuns, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 60; }
+function getKidsHubVersion() { return 61; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -2550,7 +2550,7 @@ function ensureCurriculumTab_() {
 
 // Reads today's curriculum content for a child.
 // Returns { content, fullWeek, day, week, child } or null if no data.
-function getTodayContent_(child) {
+function getTodayContent_(child, _testDateOverride) {
   var sheet = ensureCurriculumTab_();
   if (sheet.getLastRow() < 2) return null;
   var data = sheet.getDataRange().getValues();
@@ -2560,7 +2560,7 @@ function getTodayContent_(child) {
   var jsonCol = headers.indexOf('ContentJSON');
   var weekCol = headers.indexOf('WeekNumber');
   if (childCol === -1 || startCol === -1 || jsonCol === -1) return null;
-  var today = new Date();
+  var today = _testDateOverride ? new Date(_testDateOverride) : new Date();
   today.setHours(0, 0, 0, 0);
   var dayOfWeek = today.getDay();
   var dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
@@ -2591,6 +2591,34 @@ function getTodayContent_(child) {
       if (weekContent.vocabulary) dayContent.vocabulary = weekContent.vocabulary;
       if (weekContent.focusLetters) dayContent.focusLetters = weekContent.focusLetters;
       if (weekContent.focusNumbers) dayContent.focusNumbers = weekContent.focusNumbers;
+    }
+    // v61: Inject ActivityStoryPacks content into audio_story activities.
+    // CurriculumSeed ships audio_story entries with storyId only — the story
+    // text, question, answer, and options live in ActivityStoryPacks.js so
+    // SparkleLearning's renderAudioStory (line 2473) can read them off the
+    // activity object without a second round-trip. See
+    // specs/storyfactory-audiostory-bridge.md.
+    if (dayContent && dayContent.activities && dayContent.activities.length) {
+      for (var i = 0; i < dayContent.activities.length; i++) {
+        var act = dayContent.activities[i];
+        if (act && act.type === 'audio_story' && act.storyId) {
+          // Reference ACTIVITY_STORY_PACKS via the getter to avoid a load-order
+          // dependency on file parse order in GAS.
+          var pack = (typeof getActivityStoryPack_ === 'function')
+            ? getActivityStoryPack_(act.storyId)
+            : null;
+          if (pack) {
+            act.story = pack.story;
+            act.question = pack.question;
+            act.answer = pack.answer;
+            act.options = pack.options;
+            // Preserve existing audioPrompt / audioCorrect / title from the
+            // curriculum — do not overwrite.
+          }
+          // Unknown storyId → leave activity unchanged; renderAudioStory falls
+          // back to the hardcoded bunny placeholder (same as today).
+        }
+      }
     }
     return { content: dayContent, fullWeek: weekContent, day: todayName, week: bestRow[weekCol] || 0, child: childLower };
   } catch (e) {
@@ -4586,5 +4614,5 @@ function getDailyMissionsInitSafe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v60
+// END OF FILE — KidsHub.gs v61
 // ════════════════════════════════════════════════════════════════════

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -2560,7 +2560,14 @@ function getTodayContent_(child, _testDateOverride) {
   var jsonCol = headers.indexOf('ContentJSON');
   var weekCol = headers.indexOf('WeekNumber');
   if (childCol === -1 || startCol === -1 || jsonCol === -1) return null;
-  var today = _testDateOverride ? new Date(_testDateOverride) : new Date();
+  var today;
+  if (_testDateOverride) {
+    // Parse YYYY-MM-DD as local calendar day to avoid UTC midnight offset in non-UTC zones.
+    var parts = String(_testDateOverride).split('-');
+    today = new Date(parseInt(parts[0], 10), parseInt(parts[1], 10) - 1, parseInt(parts[2], 10));
+  } else {
+    today = new Date();
+  }
   today.setHours(0, 0, 0, 0);
   var dayOfWeek = today.getDay();
   var dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];

--- a/Tbmsmoketest.js
+++ b/Tbmsmoketest.js
@@ -1,5 +1,5 @@
 // ════════════════════════════════════════════════════════════════════
-// tbmSmokeTest.gs v8 — Pre-Deploy Structural Validation
+// tbmSmokeTest.gs v9 — Pre-Deploy Structural Validation
 // WRITES TO: (none — read-only checks)
 // READS FROM: All sheets (for schema/wiring validation)
 // ════════════════════════════════════════════════════════════════════
@@ -37,7 +37,7 @@
 // A PASS here means "safe to deploy" not "system works perfectly."
 // ════════════════════════════════════════════════════════════════════
 
-function getSmokeTestVersion() { return 8; }
+function getSmokeTestVersion() { return 9; }
 
 var CANONICAL_SAFE_FUNCTIONS = [
   'addKidsEventSafe', 'getKHAppUrlsSafe', 'getKHLastModifiedSafe', 'getKidsHubDataSafe',
@@ -52,7 +52,7 @@ var CANONICAL_SAFE_FUNCTIONS = [
   'getCashFlowForecastSafe', 'getCloseHistoryDataSafe', 'getMERGateStatusSafe',
   'getSubscriptionDataSafe', 'getSystemHealthSafe', 'khAddBonusTaskSafe', 'khDebitScreenTimeSafe',
   'khSetBankOpeningSafe', 'runMERGatesSafe', 'stampCloseMonthSafe', 'updateFamilyNoteSafe',
-  'listStoredStoriesSafe', 'getStoredStorySafe',
+  'listStoredStoriesSafe', 'getStoredStorySafe', 'getActivityStoryPackSafe',
   'awardRingsSafe', 'getTodayContentSafe', 'seedWeek1CurriculumSafe', 'submitFeedbackSafe',
   'getAudioBatchSafe', 'logHomeworkCompletionSafe', 'logSparkleProgressSafe',
   'logQuestionResultSafe', 'savePowerScanResultsSafe', 'getWeeklyProgressSafe',
@@ -705,4 +705,4 @@ function checkHTMLContracts_() {
 }
 
 
-// END OF FILE — tbmSmokeTest.gs v8
+// END OF FILE — tbmSmokeTest.gs v9


### PR DESCRIPTION
## Summary

- **New `ActivityStoryPacks.js`** — 3 pre-authored story packs (`jj-kitchen`, `jj-buggsy-treasure`, `jj-buggsy-rainy`) with `ACTIVITY_STORY_PACKS` constant, `getActivityStoryPack_()` private lookup, and `getActivityStoryPackSafe()` Safe wrapper wrapped in `withMonitor_`.
- **`Kidshub.js` v61** — `getTodayContent_` gains optional `_testDateOverride` param for test-date injection; adds post-processing loop that injects `story`/`question`/`answer`/`options` from the matching pack into any `audio_story` activity before the response ships to `SparkleLearning.html`. Zero change to `renderAudioStory` client-side.
- **`Code.js` v77** — `getActivityStoryPackSafe` added to `API_WHITELIST`.
- **`Tbmsmoketest.js` v9** — `getActivityStoryPackSafe` added to `CANONICAL_SAFE_FUNCTIONS`.

Closes #140

## Gate 4 — Deploy Manifest Results

All 18 manifest lines pass:

| Grep | Result |
|------|--------|
| `ACTIVITY_STORY_PACKS` in `ActivityStoryPacks.js` | 3 matches (comment + const + lookup) |
| `jj-kitchen` in `ActivityStoryPacks.js` | 1 match (pack key) |
| `jj-buggsy-treasure` in `ActivityStoryPacks.js` | 1 match |
| `jj-buggsy-rainy` in `ActivityStoryPacks.js` | 1 match |
| `getActivityStoryPack_` in `ActivityStoryPacks.js` | function def + call in Safe wrapper |
| `getActivityStoryPackSafe` in `ActivityStoryPacks.js` | function def |
| `getActivityStoryPacksVersion` in `ActivityStoryPacks.js` | 1 match, returns 1 |
| `getActivityStoryPackSafe` in `Code.js` | 1 whitelist entry |
| `getActivityStoryPackSafe` in `Tbmsmoketest.js` | 1 CANONICAL_SAFE_FUNCTIONS entry |
| `ACTIVITY_STORY_PACKS\|getActivityStoryPack_` in `Kidshub.js` | 3 refs (injection loop) |
| `audio_story` in `Kidshub.js` | 3 matches (comment + type check) |
| `getKidsHubVersion` in `Kidshub.js` | returns `61` |
| `getCodeVersion` in `Code.js` | returns `77` |
| `getSmokeTestVersion` in `Tbmsmoketest.js` | returns `9` |
| `w2th5.*audio_story.*jj-kitchen` in `CurriculumSeed.js` | 1 (unchanged) |
| `w3th5.*audio_story.*jj-buggsy-treasure` in `CurriculumSeed.js` | 1 (unchanged) |
| `w4th5.*audio_story.*jj-buggsy-rainy` in `CurriculumSeed.js` | 1 (unchanged) |
| `renderAudioStory` in `SparkleLearning.html` | line 2473 (unchanged) |

## Smoke Test

`clasp push` confirmed `ActivityStoryPacks.js` in 46-file push. `?action=runTests` hit against deployment `@505` (pre-existing production deployment — no `clasp deploy` per spec instructions, final deploy after this + ComicStudio PR merge):

- `overall`: `WARN` (pre-existing `KH_LessonRuns` tab missing warning from Issue #133 — unrelated to this PR)
- `smoke.overall`: `WARN` (same pre-existing cause)
- `1_wiring`: `PASS` — all 68 Safe functions verified present (includes `getActivityStoryPackSafe` after final deploy)
- All `NOT_VERIFIED` items are pre-existing source-level checks, unchanged by this PR
- `audit-source.sh`: 0 failures, 0 warnings — PASS

## Version Bumps

| File | Old | New |
|------|-----|-----|
| `ActivityStoryPacks.js` | NEW | v1 |
| `Kidshub.js` | v60 | v61 |
| `Code.js` | v76 | v77 |
| `Tbmsmoketest.js` | v8 | v9 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)