### PR TITLE
feat: Phase 4 review triage gate (#145)

### DIFF
--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -59,6 +59,52 @@ MODEL = "gpt-4o"
 MAX_TOKENS = 4000
 TEMPERATURE = 0
 
+# ---------------------------------------------------------------------------
+# Review mode — set by triage_review.py via REVIEW_MODE env var
+# ---------------------------------------------------------------------------
+REVIEW_MODE = os.environ.get("REVIEW_MODE", "medium")
+
+MODE_CONFIG = {
+    "light": {
+        "model":            "gpt-4o-mini",
+        "max_tokens":       1500,
+        "max_diff_chars":   5000,
+        "per_file_cap":     3000,
+        "max_context_chars": 15000,
+        "include_related":  False,
+        "system_prompt_override": (
+            "You are a code reviewer for a Google Apps Script project. "
+            "Review this small diff for correctness, ES5 compliance (no arrow functions, "
+            "let/const, template literals, or other ES6+ syntax in .html files), and "
+            "correct TAB_MAP usage (no hardcoded sheet names). "
+            "Be concise. Only flag actual problems."
+        ),
+    },
+    "medium": {
+        "model":            MODEL,           # gpt-4o (or post-#129 default)
+        "max_tokens":       4096,
+        "max_diff_chars":   MAX_DIFF_CHARS,
+        "per_file_cap":     PER_FILE_CAP,
+        "max_context_chars": MAX_CONTEXT_CHARS,
+        "include_related":  True,
+        "system_prompt_override": None,      # use existing system prompt
+    },
+    "full": {
+        "model":            MODEL,
+        "max_tokens":       4096,
+        "max_diff_chars":   MAX_DIFF_CHARS,
+        "per_file_cap":     PER_FILE_CAP,
+        "max_context_chars": MAX_CONTEXT_CHARS,
+        "include_related":  True,
+        "system_prompt_override": None,      # same as medium; reserved for Phase 5
+    },
+}
+
+
+def get_mode_config():
+    """Return the config dict for the current REVIEW_MODE."""
+    return MODE_CONFIG.get(REVIEW_MODE, MODE_CONFIG["medium"])
+
 # ── system prompt ────────────────────────────────────────────────────
 SYSTEM_PROMPT = (
     "You are a senior code reviewer for TBM (TillerBudgetMaster), a Google Apps Script "
@@ -289,28 +335,38 @@ def read_changed_file_content(fname):
     except Exception:
         return None
 
-def build_context(diff_text, changed_files, related_files=None):
+def build_context(diff_text, changed_files, related_files=None, cfg=None):
     """Build review context from diff, changed files, and related files.
 
     Returns (context_string, truncation_notes_list).
     truncation_notes only covers changed content (affects verdict).
     Related-file truncation is informational and does NOT force INCONCLUSIVE.
+
+    cfg: mode config dict from get_mode_config(). Defaults to medium constants.
     """
+    if cfg is None:
+        cfg = MODE_CONFIG["medium"]
+
+    diff_chars_cap = cfg["max_diff_chars"]
+    context_chars_cap = cfg["max_context_chars"]
+    per_file_cap = cfg["per_file_cap"]
+    include_related = cfg["include_related"]
+
     parts = []
     truncation_notes = []
 
     # ---- diff ----
     parts.append("=== PR DIFF ===\n")
-    diff_text, diff_truncated = truncate_preserving_edges(diff_text, MAX_DIFF_CHARS, "diff")
+    diff_text, diff_truncated = truncate_preserving_edges(diff_text, diff_chars_cap, "diff")
     if diff_truncated:
-        truncation_notes.append("diff truncated at %d chars" % MAX_DIFF_CHARS)
+        truncation_notes.append("diff truncated at %d chars" % diff_chars_cap)
     parts.append(diff_text)
 
     # ---- changed files ----
     current_len = sum(len(p) for p in parts)
-    remaining = max(0, MAX_CONTEXT_CHARS - current_len)
+    remaining = max(0, context_chars_cap - current_len)
     file_count = len(changed_files) if changed_files else 1
-    per_file = max(8000, min(PER_FILE_CAP, remaining // file_count if file_count else PER_FILE_CAP))
+    per_file = max(8000, min(per_file_cap, remaining // file_count if file_count else per_file_cap))
 
     for fname in changed_files:
         content = read_changed_file_content(fname)
@@ -328,17 +384,18 @@ def build_context(diff_text, changed_files, related_files=None):
     changed_context = "".join(parts)
     changed_context, context_truncated = truncate_preserving_edges(
         changed_context,
-        MAX_CONTEXT_CHARS,
+        context_chars_cap,
         "total context",
     )
     if context_truncated:
-        truncation_notes.append("total context capped at %d chars" % MAX_CONTEXT_CHARS)
+        truncation_notes.append("total context capped at %d chars" % context_chars_cap)
 
     # ---- related files (callers / consumers / siblings) ----
     # Truncation here is informational only — does NOT affect verdict.
+    # In light mode, related files are skipped entirely (include_related=False).
     related_parts = []
     related_text = ""
-    if related_files:
+    if include_related and related_files:
         related_parts.append(
             "\n=== RELATED FILES (not changed — callers/consumers/siblings for cross-reference) ===\n"
         )
@@ -373,15 +430,28 @@ def build_context(diff_text, changed_files, related_files=None):
 
 # ── OpenAI call ──────────────────────────────────────────────────────
 
-def send_to_openai(context_text, api_key):
-    """Send context to OpenAI gpt-4o with JSON mode. Returns parsed response dict."""
+def send_to_openai(context_text, api_key, cfg=None):
+    """Send context to OpenAI with JSON mode. Returns parsed response dict.
+
+    cfg: mode config dict from get_mode_config(). Controls model, max_tokens,
+    and system prompt. Defaults to medium (gpt-4o, 4096 tokens, full prompt).
+    """
+    if cfg is None:
+        cfg = MODE_CONFIG["medium"]
+
+    model_to_use = cfg["model"]
+    max_tokens_to_use = cfg["max_tokens"]
+    system_prompt_to_use = cfg.get("system_prompt_override") or SYSTEM_PROMPT
+
+    print("Using model: %s (mode=%s, max_tokens=%d)" % (model_to_use, REVIEW_MODE, max_tokens_to_use))
+
     payload = {
-        "model": MODEL,
+        "model": model_to_use,
         "messages": [
-            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "system", "content": system_prompt_to_use},
             {"role": "user", "content": context_text},
         ],
-        "max_tokens": MAX_TOKENS,
+        "max_tokens": max_tokens_to_use,
         "temperature": TEMPERATURE,
         "response_format": {"type": "json_object"},
     }
@@ -684,16 +754,22 @@ def main():
     except FileNotFoundError:
         pass  # no file list — just use the diff
 
+    # ---- get mode config ----
+    cfg = get_mode_config()
+    print("Review mode: %s (model=%s)" % (REVIEW_MODE, cfg["model"]))
+
     # ---- discover related files ----
     related_files = get_related_files(changed_files)
-    if related_files:
+    if related_files and cfg["include_related"]:
         print("Related files for cross-reference: %s" % ", ".join(related_files))
+    elif related_files and not cfg["include_related"]:
+        print("Related files skipped in %s mode." % REVIEW_MODE)
 
     # ---- build context ----
-    context, truncation_notes = build_context(diff_text, changed_files, related_files)
+    context, truncation_notes = build_context(diff_text, changed_files, related_files, cfg=cfg)
 
     # ---- send to OpenAI ----
-    data = send_to_openai(context, api_key)
+    data = send_to_openai(context, api_key, cfg=cfg)
 
     # save raw response for debugging
     with open("codex_response.json", "w") as fh:

--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -366,7 +366,7 @@ def build_context(diff_text, changed_files, related_files=None, cfg=None):
     current_len = sum(len(p) for p in parts)
     remaining = max(0, context_chars_cap - current_len)
     file_count = len(changed_files) if changed_files else 1
-    per_file = max(8000, min(per_file_cap, remaining // file_count if file_count else per_file_cap))
+    per_file = max(1000, min(per_file_cap, remaining // file_count if file_count else per_file_cap))
 
     for fname in changed_files:
         content = read_changed_file_content(fname)

--- a/.github/scripts/triage_review.py
+++ b/.github/scripts/triage_review.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+# triage_review.py
+# Purpose: Classify a PR into skip/light/medium/full before the Codex review call.
+# Called by: .github/workflows/codex-pr-review.yml (after "Build PR diff and file list")
+# Env vars expected:
+#   DIFF_FILE          path to pr_diff.txt (default: pr_diff.txt)
+#   CHANGED_FILES_FILE path to changed_files.txt (default: changed_files.txt)
+#   SKIP_LIST_FILE     path to .codex-review-skip (default: .codex-review-skip)
+#   ALWAYS_FULL_FILE   path to .codex-review-always-full (default: .codex-review-always-full)
+#   GITHUB_OUTPUT      path for GitHub Actions output (set by runner)
+# Output:
+#   Writes mode=skip|light|medium|full and reason=<one-liner> to GITHUB_OUTPUT
+#   Writes triage_output.json with full classification details
+#   Exit 0 on success (including skip). Exit 1 only on script error.
+
+import os
+import sys
+import json
+import fnmatch
+
+# ---------------------------------------------------------------------------
+# HOT file constants — ALSO document in CLAUDE.md "Hot file lock" section (Phase 4.1)
+# ---------------------------------------------------------------------------
+HOT_FILES = [
+    "kidshub.js",
+    "kidshub.gs",
+    "dataengine.js",
+    "dataengine.gs",
+    "code.js",
+    "code.gs",
+    "audit-source.sh",
+    "claude.md",
+    "tbmsmoke.js",     # covers tbmSmokeTest.js, Tbmsmoketest.js etc.
+    "tbmsmoketest.js",
+    "tbmsmoketest.gs",
+]
+
+HOT_PATTERNS = [
+    ".github/workflows/",
+    ".github/scripts/",
+]
+
+# Docs/spec patterns that qualify a file for skip mode
+DOCS_PATTERNS = [
+    "specs/*.md",
+    "specs/**/*.md",
+    "docs/*.md",
+    "docs/**/*.md",
+    "*.md",
+    "*.txt",
+]
+
+# Code file extensions — if any changed file has one of these, skip mode is blocked
+CODE_EXTENSIONS = set([
+    ".py", ".js", ".ts", ".yml", ".yaml", ".gs", ".html", ".sh", ".json"
+])
+
+
+def load_pattern_file(path):
+    """Read a pattern file (one glob per line, # comments). Returns list of patterns."""
+    if not os.path.isfile(path):
+        return []
+    patterns = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                patterns.append(line)
+    return patterns
+
+
+def is_hot_file(filepath, extra_full_patterns):
+    """Return True if filepath matches HOT_FILES, HOT_PATTERNS, or extra_full_patterns."""
+    basename = os.path.basename(filepath).lower()
+    # Basename match against HOT_FILES
+    for hot in HOT_FILES:
+        if basename == hot.lower():
+            return True
+    # Prefix match against HOT_PATTERNS
+    norm = filepath.replace("\\", "/")
+    for pattern in HOT_PATTERNS:
+        if norm.startswith(pattern) or ("/" + pattern.lstrip("/")) in norm:
+            return True
+    # Extra always-full patterns
+    for pattern in extra_full_patterns:
+        if fnmatch.fnmatch(norm, pattern) or fnmatch.fnmatch(basename, pattern):
+            return True
+    return False
+
+
+def is_docs_file(filepath):
+    """Return True if filepath matches docs/spec/text patterns."""
+    norm = filepath.replace("\\", "/")
+    basename = os.path.basename(norm)
+    for pattern in DOCS_PATTERNS:
+        if fnmatch.fnmatch(norm, pattern) or fnmatch.fnmatch(basename, pattern):
+            return True
+    return False
+
+
+def is_code_file(filepath):
+    """Return True if the file has a code extension."""
+    ext = os.path.splitext(filepath)[1].lower()
+    return ext in CODE_EXTENSIONS
+
+
+def is_generated_file(filepath, skip_patterns):
+    """Return True if the file is generated (by name, header comment, or skip-list).
+
+    Extension-agnostic: vocab.generated.js qualifies even though .js is a code extension.
+    HOT-path handling is the caller's responsibility — this function does not check paths.
+    """
+    basename = os.path.basename(filepath)
+    # (a) Filename pattern: *.generated.* — 'generated' in any dot-delimited segment
+    parts = basename.split(".")
+    if len(parts) >= 3 and "generated" in [p.lower() for p in parts]:
+        return True
+    # (b) Explicit skip-list match (extension-agnostic glob patterns)
+    norm = filepath.replace("\\", "/")
+    for pattern in skip_patterns:
+        if fnmatch.fnmatch(norm, pattern) or fnmatch.fnmatch(basename, pattern):
+            return True
+    # (c) Content check: first 20 lines — any DO NOT EDIT BY HAND variant
+    DO_NOT_EDIT_MARKERS = [
+        "// DO NOT EDIT BY HAND",
+        "# DO NOT EDIT BY HAND",
+        "/* DO NOT EDIT BY HAND */",
+        "DO NOT EDIT BY HAND",  # catch bare variant in XML/HTML comments
+    ]
+    if os.path.isfile(filepath):
+        try:
+            with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
+                for i, line in enumerate(f):
+                    if i >= 20:
+                        break
+                    for marker in DO_NOT_EDIT_MARKERS:
+                        if marker in line:
+                            return True
+        except OSError:
+            pass
+    return False
+
+
+def count_diff_lines(diff_path):
+    """Count added and removed lines from a unified diff file."""
+    added = 0
+    removed = 0
+    if not os.path.isfile(diff_path):
+        return 0, 0
+    with open(diff_path, "r", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            if line.startswith("+") and not line.startswith("+++"):
+                added += 1
+            elif line.startswith("-") and not line.startswith("---"):
+                removed += 1
+    return added, removed
+
+
+def write_github_output(key, value):
+    """Write a key=value pair to GITHUB_OUTPUT."""
+    output_path = os.environ.get("GITHUB_OUTPUT", "")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as f:
+            f.write("%s=%s\n" % (key, value))
+    else:
+        # Local testing fallback
+        print("OUTPUT: %s=%s" % (key, value))
+
+
+def main():
+    diff_file = os.environ.get("DIFF_FILE", "pr_diff.txt")
+    changed_files_file = os.environ.get("CHANGED_FILES_FILE", "changed_files.txt")
+    skip_list_file = os.environ.get("SKIP_LIST_FILE", ".codex-review-skip")
+    always_full_file = os.environ.get("ALWAYS_FULL_FILE", ".codex-review-always-full")
+
+    # Load optional pattern files
+    skip_patterns = load_pattern_file(skip_list_file)
+    always_full_patterns = load_pattern_file(always_full_file)
+
+    # Read changed files
+    if not os.path.isfile(changed_files_file):
+        print("ERROR: changed_files.txt not found", file=sys.stderr)
+        sys.exit(1)
+    with open(changed_files_file, "r", encoding="utf-8") as f:
+        files = [line.strip() for line in f if line.strip()]
+
+    # Read diff metadata
+    diff_bytes = os.path.getsize(diff_file) if os.path.isfile(diff_file) else 0
+    added_lines, removed_lines = count_diff_lines(diff_file)
+    net_lines = added_lines + removed_lines
+
+    # Classify each file
+    hot_files_touched = []
+    generated_files = []
+    docs_files = []
+    code_files_present = []
+
+    for fp in files:
+        if is_hot_file(fp, always_full_patterns):
+            hot_files_touched.append(fp)
+        if is_generated_file(fp, skip_patterns):
+            generated_files.append(fp)
+        if is_docs_file(fp):
+            docs_files.append(fp)
+        if is_code_file(fp):
+            code_files_present.append(fp)
+
+    # ---------------------------------------------------------------------------
+    # Mode classification — precedence: skip > full > light > medium
+    # ---------------------------------------------------------------------------
+    mode = "medium"
+    reason = "default: no specific condition matched"
+
+    # Identify generated files that are NOT in a HOT path — those qualify for skip.
+    # Generated files inside HOT paths (e.g. .github/scripts/generated_config.py)
+    # are trust-sensitive infrastructure and always trigger FULL review.
+    generated_non_hot = [
+        fp for fp in generated_files
+        if not is_hot_file(fp, always_full_patterns)
+    ]
+    generated_in_hot = [
+        fp for fp in generated_files
+        if is_hot_file(fp, always_full_patterns)
+    ]
+
+    # Docs-only skip: every file is a docs/spec file AND no code extensions present
+    all_non_code = len(code_files_present) == 0
+    non_docs_files = [fp for fp in files if not is_docs_file(fp)]
+
+    zero_diff = diff_bytes == 0
+
+    # skip: zero-byte diff (binary-only)
+    if zero_diff and len(files) > 0:
+        mode = "skip"
+        reason = "binary-only PR: zero-byte diff with %d changed file(s)" % len(files)
+
+    # skip (docs-only path): all files are docs/specs AND no code extensions present
+    elif len(non_docs_files) == 0 and all_non_code and len(files) > 0:
+        mode = "skip"
+        reason = "all changed files are docs/specs (no code files touched)"
+
+    # skip (generated path): all files are generated AND none are in HOT paths
+    # NOTE: extension-agnostic — vocab.generated.js qualifies. HOT-path carve-out
+    # means a generated file in .github/ still triggers full, not skip.
+    elif (len(files) > 0
+          and len(generated_non_hot) == len(files)
+          and len(generated_in_hot) == 0):
+        mode = "skip"
+        reason = "all changed files are generated (outside HOT paths): %s" % (
+            ", ".join(generated_non_hot[:3])
+            + (" (+%d more)" % (len(generated_non_hot) - 3) if len(generated_non_hot) > 3 else "")
+        )
+
+    # full: any HOT file touched (overrides light)
+    elif hot_files_touched:
+        mode = "full"
+        reason = "HOT file touched: %s" % ", ".join(hot_files_touched[:3])
+        if len(hot_files_touched) > 3:
+            reason += " (+%d more)" % (len(hot_files_touched) - 3)
+
+    # light: small diff, no hot files, at least one code file
+    elif net_lines <= 30 and len(hot_files_touched) == 0 and len(code_files_present) >= 1:
+        mode = "light"
+        reason = "small diff (%d net lines), no HOT files, code files present" % net_lines
+
+    # medium: everything else
+    else:
+        mode = "medium"
+        reason = "default: %d net lines, %d code files, 0 HOT files" % (
+            net_lines, len(code_files_present)
+        )
+
+    # ---------------------------------------------------------------------------
+    # Write outputs
+    # ---------------------------------------------------------------------------
+    triage_output = {
+        "mode": mode,
+        "reason": reason,
+        "hot_files_touched": hot_files_touched,
+        "diff_lines_added": added_lines,
+        "diff_lines_removed": removed_lines,
+        "diff_net_lines": net_lines,
+        "diff_bytes": diff_bytes,
+        "files": files,
+        "skip_list_patterns": skip_patterns,
+        "always_full_patterns": always_full_patterns,
+        "generated_files": generated_files,
+    }
+
+    with open("triage_output.json", "w", encoding="utf-8") as f:
+        json.dump(triage_output, f, indent=2)
+
+    write_github_output("mode", mode)
+    write_github_output("reason", reason)
+
+    print("Triage result: mode=%s | %s" % (mode, reason))
+    print("  files=%d, hot=%d, net_lines=%d, diff_bytes=%d" % (
+        len(files), len(hot_files_touched), net_lines, diff_bytes
+    ))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/triage_review.py
+++ b/.github/scripts/triage_review.py
@@ -234,6 +234,15 @@ def main():
         mode = "skip"
         reason = "binary-only PR: zero-byte diff with %d changed file(s)" % len(files)
 
+    # full: any HOT file touched — checked BEFORE docs-only and generated-only skip
+    # paths so that CLAUDE.md, audit-source.sh, and workflow files always get full
+    # review even if the rest of the PR looks like docs or generated content.
+    elif hot_files_touched:
+        mode = "full"
+        reason = "HOT file touched: %s" % ", ".join(hot_files_touched[:3])
+        if len(hot_files_touched) > 3:
+            reason += " (+%d more)" % (len(hot_files_touched) - 3)
+
     # skip (docs-only path): all files are docs/specs AND no code extensions present
     elif len(non_docs_files) == 0 and all_non_code and len(files) > 0:
         mode = "skip"
@@ -250,13 +259,6 @@ def main():
             ", ".join(generated_non_hot[:3])
             + (" (+%d more)" % (len(generated_non_hot) - 3) if len(generated_non_hot) > 3 else "")
         )
-
-    # full: any HOT file touched (overrides light)
-    elif hot_files_touched:
-        mode = "full"
-        reason = "HOT file touched: %s" % ", ".join(hot_files_touched[:3])
-        if len(hot_files_touched) > 3:
-            reason += " (+%d more)" % (len(hot_files_touched) - 3)
 
     # light: small diff, no hot files, at least one code file
     elif net_lines <= 30 and len(hot_files_touched) == 0 and len(code_files_present) >= 1:

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -127,14 +127,129 @@ jobs:
             echo "empty_diff=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Send to OpenAI gpt-4o
+      - name: Triage review scope
         if: steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true'
+        id: triage
+        env:
+          DIFF_FILE: pr_diff.txt
+          CHANGED_FILES_FILE: changed_files.txt
+        run: python3 .github/scripts/triage_review.py
+
+      - name: Upload triage artifact
+        if: always() && steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: triage-output
+          path: triage_output.json
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Post skip comment
+        if: steps.triage.outputs.mode == 'skip' && github.event_name == 'pull_request_target' && steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const reason = '${{ steps.triage.outputs.reason }}';
+            const body = [
+              '<!-- codex-pr-review -->',
+              '## Codex PR Review \u2014 Skipped',
+              '',
+              '**Verdict:** SKIPPED',
+              '',
+              'Codex review was skipped because: ' + reason + '.',
+              '',
+              'No OpenAI API call was made. This PR does not contain code changes',
+              'that require automated code review.',
+              '',
+              '**Files Reviewed:** (none \u2014 triage-skipped)',
+              '',
+              '_If this skip is incorrect, add a code file to trigger a real review,',
+              'or remove the file from `.codex-review-skip`._',
+            ].join('\n');
+
+            const issueNumber = Number('${{ steps.pr.outputs.number }}');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('<!-- codex-pr-review -->')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }
+
+      - name: Apply triage label
+        if: github.event_name == 'pull_request_target' && steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true' && steps.triage.outputs.mode != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const mode = '${{ steps.triage.outputs.mode }}';
+            const labelMap = {
+              'skip':   'pipeline:triage-skipped',
+              'light':  'pipeline:triage-light',
+              'medium': 'pipeline:triage-medium',
+              'full':   'pipeline:triage-full',
+            };
+            const newLabel = labelMap[mode];
+            if (!newLabel) return;
+
+            const issueNumber = Number('${{ steps.pr.outputs.number }}');
+
+            // Remove any existing pipeline:triage-* label
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+            for (const label of currentLabels) {
+              if (label.name.startsWith('pipeline:triage-')) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    name: label.name,
+                  });
+                } catch (e) {}
+              }
+            }
+
+            // Add the new triage label
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [newLabel],
+              });
+            } catch (e) {
+              core.warning('Could not apply triage label: ' + e.message);
+            }
+
+      - name: Send to OpenAI gpt-4o
+        if: steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true' && steps.triage.outputs.mode != 'skip'
         id: review
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DIFF_FILE: pr_diff.txt
           CHANGED_FILES_FILE: changed_files.txt
           EMPTY_DIFF: ${{ steps.diff.outputs.empty_diff }}
+          REVIEW_MODE: ${{ steps.triage.outputs.mode }}
         run: python3 .github/scripts/codex_review.py
 
       - name: Upload review report artifact
@@ -149,7 +264,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Post review comment on PR
-        if: always() && steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true'
+        if: always() && steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true' && steps.triage.outputs.mode != 'skip'
         uses: actions/github-script@v7
         with:
           script: |
@@ -184,7 +299,7 @@ jobs:
             }
 
       - name: Apply finding labels
-        if: always() && steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true'
+        if: always() && steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true' && steps.triage.outputs.mode != 'skip'
         uses: actions/github-script@v7
         with:
           script: |
@@ -238,7 +353,7 @@ jobs:
             }
 
       - name: Integrity check — detect rubber-stamped audits
-        if: always() && steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true'
+        if: always() && steps.override.outputs.overridden != 'true' && steps.pr.outputs.same_repo == 'true' && steps.pr.outputs.draft != 'true' && steps.triage.outputs.mode != 'skip'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

Implements the Phase 4 review triage gate per `specs/phase4-review-triage-gate.md`.

- **New** `.github/scripts/triage_review.py` — rules-based classifier (skip/light/medium/full)
- **Edit** `.github/workflows/codex-pr-review.yml` — triage step, skip comment, triage label, mode-gated OpenAI call
- **Edit** `.github/scripts/codex_review.py` — `REVIEW_MODE`, `MODE_CONFIG`, `get_mode_config()`, branch points in `build_context()` and `send_to_openai()`

## Gate 4 Manifest Results

All 12 manifest greps pass:

| Check | Result |
|-------|--------|
| `def main` in triage_review.py | PASS — line 170 |
| `HOT_FILES` constant | PASS — line 24 |
| `HOT_PATTERNS` constant | PASS — line 38 |
| `REVIEW_MODE` in codex_review.py | PASS — line 65 |
| `MODE_CONFIG`/`get_mode_config` | PASS — lines 67, 104 |
| Triage step in workflow | PASS — lines 130, 136 |
| Skip condition on OpenAI step | PASS — line 245 |
| `REVIEW_MODE:` in workflow | PASS — line 252 |
| Post skip comment step | PASS — line 147 |
| Apply triage label step + labels | PASS — lines 196, 203–206 |
| `triage_output.json` written | PASS — line 290 |
| `gpt-4o-mini` in MODE_CONFIG | PASS — line 69 |

## Gate 5 Local Test Results

| Test | Expected | Result |
|------|----------|--------|
| docs-only PR (`specs/foo.md`) | skip | PASS |
| HOT pattern (`.github/workflows/*.yml`) | full | PASS |
| 10-line `AlertEngine.gs` | light | PASS |
| 5-line `Code.gs` (HOT overrides light) | full | PASS |
| Mixed spec + code → not skip | light | PASS |
| Zero-byte diff (binary-only) | skip | PASS |
| `vocab.generated.js` (extension-agnostic) | skip | PASS |
| Generated file in `.github/scripts/` (HOT carve-out) | full | PASS |
| `SparkleLearning.html` + 50 lines | medium | PASS |

## Smoke / Audit

- `audit-source.sh`: 0 failures, 0 warnings — PASS
- Python compile (`py_compile`): both scripts — PASS
- No `.gs` or `.html` files changed — no `clasp push` required

## Labels Created

- `pipeline:triage-skipped` (#E5E7EB)
- `pipeline:triage-light` (#DBEAFE)
- `pipeline:triage-medium` (#FEF3C7)
- `pipeline:triage-full` (#FEE2E2)

Closes #145

🤖 Generated with [Claude Code](https://claude.ai/claude-code)