### PR TITLE
feat: ComicStudio v4 Day 2 — Drive draft/resume + Mission/Free mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ playwright-report/
 
 # Claude Code local settings (per-machine, not shared)
 .claude/settings.local.json
+__pycache__/

--- a/Code.js
+++ b/Code.js
@@ -1,6 +1,6 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// Code.gs v79 — Apps Script Router (TBM Consolidated)
+// Code.gs v80 — Apps Script Router (TBM Consolidated)
 // WRITES TO: (routes only — delegates to DataEngine, KidsHub, etc.)
 // READS FROM: (routes only — delegates to DataEngine, KidsHub, etc.)
 // ════════════════════════════════════════════════════════════════════
@@ -19,7 +19,7 @@ function isLessonRunsEnabled_() {
   } catch (e) { return false; }
 }
 
-function getCodeVersion() { return 79; }
+function getCodeVersion() { return 80; }
 
 // v37 FIX 5: ES5-safe left-pad helper — replaces String.padStart()
 function leftPad2_(n) {
@@ -457,7 +457,12 @@ function serveData(e) {
         'qaClearTestDataSafe': qaClearTestDataSafe,
         'qaResetDataSafe': qaResetDataSafe,
         'qaExportStateSafe': qaExportStateSafe,
-        'getAssetRegistrySafe': getAssetRegistrySafe
+        'getAssetRegistrySafe': getAssetRegistrySafe,
+        // ComicStudio v4 Day 2 — Drive draft + mode aggregator
+        'saveComicDraftSafe': saveComicDraftSafe,
+        'loadComicDraftSafe': loadComicDraftSafe,
+        'deleteComicDraftSafe': deleteComicDraftSafe,
+        'getComicStudioContextSafe': getComicStudioContextSafe
       };
 
       if (!fn || !API_WHITELIST[fn]) {
@@ -2025,4 +2030,4 @@ function getOpsHealthSafe() {
   });
 }
 
-// END OF FILE — Code.gs v79
+// END OF FILE — Code.gs v80

--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -1504,6 +1504,7 @@ function autosaveDraft() {
 
 function startAutosaveTimer() {
   if (_autosaveTimer) return;
+  autosaveDraft(); /* Immediate first save — child may close tab within first 60s */
   _autosaveTimer = setInterval(autosaveDraft, 60000);
   window.addEventListener('beforeunload', autosaveDraft);
 }
@@ -1574,7 +1575,7 @@ function startFresh() {
     google.script.run
       .withSuccessHandler(() => {})
       .withFailureHandler(() => {})
-      .deleteComicDraftSafe(CHILD, getTodayDateKey());
+      .deleteComicDraftSafe(CHILD, null); /* Server derives date via getTodayISO_() — avoids client/server timezone mismatch */
   }
   buildPanelGrid();
   renderCaptions();

--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="comic-studio">
-<meta name="tbm-version" content="v6">
+<meta name="tbm-version" content="v7">
 <title>Wolfkid Comic Studio</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -804,9 +804,9 @@ main {
 <script>
 // ── ComicStudio v4 — Day 2: F3 Drive Draft/Resume + F4 Mission/Free Mode
 // ES6 EXEMPT: Surface Pro 5 / Chrome — see specs/comicstudio-v4.md §3
-// tbm-version: v5
+// tbm-version: v7
 
-const COMIC_STUDIO_VERSION = 6;
+const COMIC_STUDIO_VERSION = 7;
 
 // ── Test Mode Detection ──
 const TBM_TEST_MODE = window.location.search.indexOf('test=1') !== -1;
@@ -1336,6 +1336,7 @@ function updateCaption(idx, val) {
   const wc = document.getElementById(`wc-${idx}`);
   if (wc) wc.textContent = countWords(val) + ' words';
   checkVocabUsage();
+  if (val && !hasDrawnAnything) { hasDrawnAnything = true; startAutosaveTimer(); }
 }
 
 function countWords(str) {
@@ -1496,8 +1497,8 @@ function autosaveDraft() {
   setAutosaveIndicator('saving');
   const payload = serializeDraft();
   google.script.run
-    .withSuccessHandler(() => setAutosaveIndicator('saved'))
-    .withFailureHandler(() => setAutosaveIndicator('failed'))
+    .withSuccessHandler(function(result) { if (result && result.success === false) { setAutosaveIndicator('failed'); } else { setAutosaveIndicator('saved'); } })
+    .withFailureHandler(function() { setAutosaveIndicator('failed'); })
     .saveComicDraftSafe(CHILD, JSON.stringify(payload));
 }
 
@@ -1586,7 +1587,8 @@ function renderMissionBrief(ctx) {
   html += '<h3>MISSION MODE</h3>';
   html += `<p>${escapeHtml(title)}</p>`;
   if (ctx.studentCER) {
-    const excerpt = String(ctx.studentCER).substring(0, 120);
+    const cerText = ctx.studentCER.responseText || ctx.studentCER.claim || '';
+    const excerpt = cerText.substring(0, 120);
     html += `<div class="cer-excerpt">"${escapeHtml(excerpt)}${excerpt.length >= 120 ? '…' : ''}"</div>`;
   }
   html += '</div>';
@@ -1663,4 +1665,4 @@ init();
 </script>
 </body>
 </html>
-<!-- ComicStudio.html v6 -->
+<!-- ComicStudio.html v7 -->

--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="comic-studio">
-<meta name="tbm-version" content="v5">
+<meta name="tbm-version" content="v6">
 <title>Wolfkid Comic Studio</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -584,6 +584,121 @@ main {
   color: #22C55E;
   border-color: #22C55E;
 }
+#autosave-indicator.failed {
+  color: #EF4444;
+  border-color: #EF4444;
+}
+
+/* Resume overlay — F3 Day 2 */
+#resume-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(11,15,26,0.97);
+  z-index: 110;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+#resume-overlay.hidden { display: none; }
+#resume-overlay .resume-card {
+  background: #171D30;
+  border: 1px solid #1E2A4A;
+  border-radius: 16px;
+  padding: 28px 24px;
+  max-width: 480px;
+  width: 100%;
+  text-align: center;
+  animation: fadeSlide 0.4s ease;
+}
+#resume-overlay h2 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 16px;
+  font-weight: 900;
+  color: #F59E0B;
+  margin-bottom: 10px;
+}
+#resume-overlay p {
+  font-size: 13px;
+  color: #94A3B8;
+  margin-bottom: 20px;
+  line-height: 1.6;
+}
+.resume-btn-row {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+.resume-btn-row button {
+  flex: 1;
+  max-width: 180px;
+  padding: 12px 16px;
+  border: none;
+  border-radius: 10px;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  letter-spacing: 1px;
+  transition: all 0.2s;
+}
+.btn-resume { background: #F59E0B; color: #0B0F1A; }
+.btn-resume:hover { background: #FBBF24; }
+.btn-fresh { background: #1E2A4A; color: #94A3B8; border: 1px solid #334155 !important; }
+.btn-fresh:hover { color: #E2E8F0; }
+
+/* Mode brief — F4 Day 2 */
+#mode-brief-wrap {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+#mode-brief-wrap.hidden { display: none; }
+.mode-brief-card {
+  border-radius: 12px;
+  padding: 14px 16px;
+  margin-top: 12px;
+  animation: fadeSlide 0.4s ease;
+}
+.mode-brief-card.mission {
+  background: rgba(245,158,11,0.08);
+  border: 1px solid rgba(245,158,11,0.25);
+}
+.mode-brief-card.free {
+  background: rgba(59,130,246,0.08);
+  border: 1px solid rgba(59,130,246,0.25);
+}
+.mode-brief-card h3 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  margin-bottom: 6px;
+}
+.mode-brief-card.mission h3 { color: #F59E0B; }
+.mode-brief-card.free h3 { color: #60A5FA; }
+.mode-brief-card p {
+  font-size: 13px;
+  color: #E2E8F0;
+  line-height: 1.5;
+}
+.mode-brief-card .cer-excerpt {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #94A3B8;
+  font-style: italic;
+  border-left: 2px solid #F59E0B;
+  padding-left: 8px;
+  line-height: 1.5;
+}
+
+/* Rings cap note */
+#rings-cap-note {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: #64748B;
+  text-align: center;
+  margin-top: 8px;
+}
 </style>
 </head>
 <body>
@@ -614,7 +729,22 @@ main {
   <button class="nav-tab" onclick="switchTab('preview')">Preview</button>
 </div>
 
+<div id="mode-brief-wrap" class="hidden"></div>
+
 <main id="main-content">
+  <!-- Resume Draft overlay — F3 Day 2 -->
+  <div id="resume-overlay" class="hidden">
+    <div class="resume-card">
+      <div style="font-size:40px;margin-bottom:10px;">&#128194;</div>
+      <h2>DRAFT FOUND</h2>
+      <p id="resume-desc">You left off on a comic. Want to pick up where you stopped?</p>
+      <div class="resume-btn-row">
+        <button class="btn-resume" onclick="resumeDraft()">RESUME</button>
+        <button class="btn-fresh" onclick="startFresh()">START FRESH</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Plan Your Attack overlay -->
   <div id="plan-overlay">
     <div class="plan-card">
@@ -664,6 +794,7 @@ main {
     <div class="section-label">YOUR COMIC</div>
     <div id="preview-area"></div>
     <button class="btn-primary" id="finish-btn" onclick="finishComic()">FINISH &amp; EARN RINGS</button>
+    <div id="rings-cap-note"></div>
   </div>
 
   <!-- Completion -->
@@ -671,11 +802,11 @@ main {
 </main>
 
 <script>
-// ── ComicStudio v4 — Day 1: F1 Pointer Events + F2 6-Brush System + F3 Autosave scaffold
+// ── ComicStudio v4 — Day 2: F3 Drive Draft/Resume + F4 Mission/Free Mode
 // ES6 EXEMPT: Surface Pro 5 / Chrome — see specs/comicstudio-v4.md §3
-// tbm-version: v4
+// tbm-version: v5
 
-const COMIC_STUDIO_VERSION = 5;
+const COMIC_STUDIO_VERSION = 6;
 
 // ── Test Mode Detection ──
 const TBM_TEST_MODE = window.location.search.indexOf('test=1') !== -1;
@@ -719,6 +850,22 @@ let activeTab = 'draw';
 // F3: stroke history for autosave payload
 const strokeHistory = [];  // [{panelIdx, type, color, size, points:[]}]
 let currentStroke = null;
+
+// F3 Day 2: Drive draft state
+let hasDrawnAnything = false;
+let currentMode = 'free';    // 'mission' | 'free'
+let ringsCap = 30;           // set by getComicStudioContextSafe
+let currentEpisodeId = null;
+let pendingDraft = null;     // draft loaded from Drive, awaiting context
+let studioCtx = null;        // full context from server
+
+// F3 Day 2: two-phase init gate (context + draft must both resolve before resume/fresh)
+let _initPending = 2;
+function _initReady() {
+  _initPending--;
+  if (_initPending > 0) return;
+  _onBothLoaded();
+}
 
 // ── F2: Brush definitions ──
 const BRUSHES = [
@@ -776,6 +923,40 @@ const LAYOUTS = [
   { count: 3, label: '3 Panels', icon: '|||' },
   { count: 4, label: '4 Panels', icon: '||||' }
 ];
+
+// ── F3 Day 2: serverCall Promise wrapper ──
+function serverCall(fn, ...args) {
+  return new Promise((resolve, reject) => {
+    if (typeof google === 'undefined' || !google.script || !google.script.run) {
+      reject(new Error('google.script.run unavailable'));
+      return;
+    }
+    google.script.run
+      .withSuccessHandler(resolve)
+      .withFailureHandler(reject)[fn](...args);
+  });
+}
+
+function getTodayDateKey() {
+  const d = new Date();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+function serializeDraft() {
+  return {
+    version: COMIC_STUDIO_VERSION,
+    timestamp: new Date().toISOString(),
+    panelCount,
+    captions: captions.slice(0, panelCount),
+    strokeHistory,
+    panels: panelCanvases.map((canvas, idx) => ({
+      idx,
+      dataUrl: canvas ? canvas.toDataURL('image/jpeg', 0.7) : null
+    }))
+  };
+}
 
 // ── Stars ──
 function createStars() {
@@ -976,6 +1157,12 @@ function attachPointerEvents(canvas, panelIdx) {
       size: brushSize,
       points: [{ x: pos.x, y: pos.y, pressure: e.pressure }]
     };
+
+    // F3 Day 2: start autosave timer on first stroke
+    if (!hasDrawnAnything) {
+      hasDrawnAnything = true;
+      startAutosaveTimer();
+    }
   });
 
   canvas.addEventListener('pointermove', (e) => {
@@ -1220,7 +1407,9 @@ function finishComic() {
   let rings = 15;
   if (captionedPanels === panelCount) rings += 10;
   if (totalWords >= 20) rings += 5;
-  if (checkVocabInCaptions()) rings += 10;
+  // Spec bug fix: vocab bonus (+10) is Mission-only — not awarded in Free mode.
+  if (currentMode === 'mission' && checkVocabInCaptions()) rings += 10;
+  rings = Math.min(rings, ringsCap);
   ringsEarned = rings;
 
   document.getElementById('tab-preview').classList.add('hidden');
@@ -1284,92 +1473,64 @@ function loadCurriculumVocab() {
     .getTodayContentSafe(CHILD);
 }
 
-// ── F3: Autosave scaffold ──
-// Day 1: persist to localStorage so a tab close doesn't lose work.
-// Day 3 will replace this with a Drive write; until then the indicator
-// stays honest about where the draft lives.
-const COMICSTUDIO_DRAFT_KEY = 'comicstudio:draft:v1';
-let isRestoring = false;
-let pendingRestoreCount = 0;
-
-function buildAutosavePayload() {
-  return {
-    version: COMIC_STUDIO_VERSION,
-    timestamp: new Date().toISOString(),
-    panelCount,
-    captions: captions.slice(0, panelCount),
-    strokeCount: strokeHistory.length,
-    strokeHistory: strokeHistory,
-    // panels: JPEG dataURLs to keep payload under the localStorage 5MB cap.
-    // Day 3 Drive save can switch back to PNG if it wants lossless storage.
-    panels: panelCanvases.map((canvas, idx) => ({
-      idx,
-      dataUrl: canvas ? canvas.toDataURL('image/jpeg', 0.7) : null
-    }))
-  };
-}
+// ── F3 Day 2: Drive-based autosave ──
+let _autosaveTimer = null;
 
 function setAutosaveIndicator(state) {
   const indicator = document.getElementById('autosave-indicator');
   if (!indicator) return;
   const labels = {
-    draft:    { text: 'DRAFT',         title: 'Draft — not yet saved to Drive (Day 3)' },
-    local:    { text: 'DRAFT (LOCAL)', title: 'Saved locally — Drive sync wires on Day 3' },
-    restored: { text: 'RESTORED',      title: 'Restored from local draft — keep working to update' },
-    full:     { text: 'LOCAL FULL',    title: 'Local storage full — export to free space' }
+    saving:   { text: 'SAVING…',  cls: 'saving' },
+    saved:    { text: 'SAVED',    cls: 'saved'   },
+    failed:   { text: 'SAVE ERR', cls: 'failed'  },
+    restored: { text: 'RESTORED', cls: 'saved'   }
   };
-  const conf = labels[state] || labels.draft;
+  const conf = labels[state] || { text: 'AUTOSAVE', cls: '' };
   indicator.textContent = conf.text;
-  indicator.title = conf.title;
+  indicator.className = conf.cls;
 }
 
-function autosave() {
-  // Don't overwrite the draft while restoration is still painting canvases
-  if (isRestoring) {
-    console.log('[ComicStudio] Autosave skipped: restoration in progress');
-    return;
-  }
-
-  const payload = buildAutosavePayload();
-  console.log('[ComicStudio] Autosave at', new Date().toISOString(), payload);
-
-  // Try to persist locally. Falls through to in-memory DRAFT if unavailable.
-  try {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      window.localStorage.setItem(COMICSTUDIO_DRAFT_KEY, JSON.stringify(payload));
-      setAutosaveIndicator('local');
-      return;
-    }
-  } catch (e) {
-    if (e && e.name === 'QuotaExceededError') {
-      setAutosaveIndicator('full');
-      console.warn('[ComicStudio] localStorage quota exceeded; draft not persisted', e);
-      return;
-    }
-    console.warn('[ComicStudio] localStorage failed; draft kept in memory only', e);
-  }
-  setAutosaveIndicator('draft');
+function autosaveDraft() {
+  if (TBM_TEST_MODE || !hasDrawnAnything) return;
+  if (typeof google === 'undefined' || !google.script || !google.script.run) return;
+  setAutosaveIndicator('saving');
+  const payload = serializeDraft();
+  google.script.run
+    .withSuccessHandler(() => setAutosaveIndicator('saved'))
+    .withFailureHandler(() => setAutosaveIndicator('failed'))
+    .saveComicDraftSafe(CHILD, JSON.stringify(payload));
 }
 
-function loadDraft() {
-  try {
-    if (typeof window === 'undefined' || !window.localStorage) return null;
-    const raw = window.localStorage.getItem(COMICSTUDIO_DRAFT_KEY);
-    if (!raw) return null;
-    const draft = JSON.parse(raw);
-    if (!draft || draft.version !== COMIC_STUDIO_VERSION) return null;
-    return draft;
-  } catch (e) {
-    console.warn('[ComicStudio] Failed to load draft', e);
-    return null;
-  }
+function startAutosaveTimer() {
+  if (_autosaveTimer) return;
+  _autosaveTimer = setInterval(autosaveDraft, 60000);
+  window.addEventListener('beforeunload', autosaveDraft);
 }
 
-function restoreDraft(draft) {
-  if (!draft) return false;
+function rehydratePanels(draft) {
+  return new Promise(resolve => {
+    const validPanels = Array.isArray(draft.panels)
+      ? draft.panels.filter(p => p && typeof p.idx === 'number' && p.dataUrl)
+      : [];
+    if (validPanels.length === 0) { resolve(); return; }
+    let remaining = validPanels.length;
+    validPanels.forEach(p => {
+      const canvas = panelCanvases[p.idx];
+      const ctx = panelContexts[p.idx];
+      if (!canvas || !ctx) { remaining--; if (remaining === 0) resolve(); return; }
+      const img = new Image();
+      img.onload = () => {
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        remaining--;
+        if (remaining === 0) resolve();
+      };
+      img.onerror = () => { remaining--; if (remaining === 0) resolve(); };
+      img.src = p.dataUrl;
+    });
+  });
+}
 
-  // Restore in-memory state BEFORE rebuilding the grid so the right
-  // number of canvases get created.
+function applyDraftState(draft) {
   if (typeof draft.panelCount === 'number' && draft.panelCount >= 1 && draft.panelCount <= 4) {
     panelCount = draft.panelCount;
   }
@@ -1380,58 +1541,104 @@ function restoreDraft(draft) {
   }
   if (Array.isArray(draft.strokeHistory)) {
     strokeHistory.length = 0;
-    for (let i = 0; i < draft.strokeHistory.length; i++) {
-      strokeHistory.push(draft.strokeHistory[i]);
-    }
+    draft.strokeHistory.forEach(s => strokeHistory.push(s));
   }
-
+  buildLayoutPicker();
   buildPanelGrid();
-
-  // Paint the saved bitmaps back onto each panel canvas.
-  // Image.onload is async, so guard autosave until all panels are loaded.
-  const validPanels = Array.isArray(draft.panels)
-    ? draft.panels.filter(p => p && typeof p.idx === 'number' && p.dataUrl)
-    : [];
-
-  if (validPanels.length > 0) {
-    isRestoring = true;
-    pendingRestoreCount = validPanels.length;
-    validPanels.forEach(p => {
-      const canvas = panelCanvases[p.idx];
-      const ctx = panelContexts[p.idx];
-      if (!canvas || !ctx) {
-        pendingRestoreCount--;
-        if (pendingRestoreCount <= 0) isRestoring = false;
-        return;
-      }
-      const img = new Image();
-      img.onload = () => {
-        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-        pendingRestoreCount--;
-        if (pendingRestoreCount <= 0) isRestoring = false;
-      };
-      img.onerror = () => {
-        console.warn('[ComicStudio] Failed to restore panel ' + p.idx);
-        pendingRestoreCount--;
-        if (pendingRestoreCount <= 0) isRestoring = false;
-      };
-      img.src = p.dataUrl;
-    });
-  }
-
   renderCaptions();
-  setAutosaveIndicator('restored');
-  return true;
 }
 
-// F3: 60-second autosave interval
-const AUTOSAVE_INTERVAL_MS = 60000;
-let autosaveTimer = setInterval(autosave, AUTOSAVE_INTERVAL_MS);
+function showResumePrompt(draft) {
+  const desc = document.getElementById('resume-desc');
+  if (desc && draft.timestamp) {
+    const d = new Date(draft.timestamp);
+    desc.textContent = `You left off on ${d.toLocaleDateString()}. Resume or start fresh?`;
+  }
+  document.getElementById('resume-overlay').classList.remove('hidden');
+}
 
-// F3: beforeunload autosave
-window.addEventListener('beforeunload', () => {
-  autosave();
-});
+function resumeDraft() {
+  document.getElementById('resume-overlay').classList.add('hidden');
+  applyDraftState(pendingDraft);
+  rehydratePanels(pendingDraft).then(() => {
+    setAutosaveIndicator('restored');
+    hasDrawnAnything = true;
+    startAutosaveTimer();
+  });
+}
+
+function startFresh() {
+  document.getElementById('resume-overlay').classList.add('hidden');
+  if (!TBM_TEST_MODE && typeof google !== 'undefined' && google.script && google.script.run) {
+    google.script.run
+      .withSuccessHandler(() => {})
+      .withFailureHandler(() => {})
+      .deleteComicDraftSafe(CHILD, getTodayDateKey());
+  }
+  buildPanelGrid();
+  renderCaptions();
+}
+
+// ── F4 Day 2: Mode brief rendering ──
+function renderMissionBrief(ctx) {
+  const title = ctx.episode ? (ctx.episode.title || 'Wolfkid Mission') : 'Wolfkid Mission';
+  let html = '<div class="mode-brief-card mission">';
+  html += '<h3>MISSION MODE</h3>';
+  html += `<p>${escapeHtml(title)}</p>`;
+  if (ctx.studentCER) {
+    const excerpt = String(ctx.studentCER).substring(0, 120);
+    html += `<div class="cer-excerpt">"${escapeHtml(excerpt)}${excerpt.length >= 120 ? '…' : ''}"</div>`;
+  }
+  html += '</div>';
+  document.getElementById('mode-brief-wrap').innerHTML = html;
+  document.getElementById('mode-brief-wrap').classList.remove('hidden');
+}
+
+function renderFreeBrief(ctx) {
+  const prompts = ctx && ctx.freePrompts ? ctx.freePrompts : [];
+  const picked = prompts.length
+    ? prompts[Math.floor(Math.random() * prompts.length)]
+    : { text: 'Draw your own Wolfkid story!' };
+  let html = '<div class="mode-brief-card free">';
+  html += '<h3>FREE CREATE</h3>';
+  html += `<p>${escapeHtml(picked.text)}</p>`;
+  html += '</div>';
+  document.getElementById('mode-brief-wrap').innerHTML = html;
+  document.getElementById('mode-brief-wrap').classList.remove('hidden');
+}
+
+function onContextLoaded(ctx) {
+  studioCtx = ctx;
+  if (ctx && ctx.mode === 'mission') {
+    currentMode = 'mission';
+    ringsCap = typeof ctx.ringsCap === 'number' ? ctx.ringsCap : 55;
+    if (ctx.vocab && ctx.vocab.length > 0) {
+      todayVocab = {
+        word: (ctx.vocab[0].word || '').toUpperCase(),
+        def: ctx.vocab[0].definition || ctx.vocab[0].def || '',
+        prompt: `Use "${ctx.vocab[0].word || ''}" in one of your comic captions!`
+      };
+      renderVocab();
+    }
+    renderMissionBrief(ctx);
+  } else {
+    currentMode = 'free';
+    ringsCap = ctx && typeof ctx.ringsCap === 'number' ? ctx.ringsCap : 30;
+    renderFreeBrief(ctx);
+  }
+  const note = document.getElementById('rings-cap-note');
+  if (note) note.textContent = `Up to ${ringsCap} rings this session`;
+  _initReady();
+}
+
+function _onBothLoaded() {
+  if (pendingDraft && !TBM_TEST_MODE) {
+    showResumePrompt(pendingDraft);
+  } else {
+    buildPanelGrid();
+    renderCaptions();
+  }
+}
 
 // ── Init ──
 function init() {
@@ -1439,19 +1646,21 @@ function init() {
   buildLayoutPicker();
   buildBrushSelector();
   buildToolbar();
-  // Try to restore a local draft first; restoreDraft() rebuilds the grid
-  // with the saved panelCount. Otherwise build a fresh grid.
-  const draft = loadDraft();
-  if (!restoreDraft(draft)) {
-    buildPanelGrid();
-    renderCaptions();
-  }
   renderVocab();
-  loadCurriculumVocab();
+  if (TBM_TEST_MODE) { buildPanelGrid(); renderCaptions(); return; }
+  serverCall('getComicStudioContextSafe', CHILD)
+    .then(ctx => { onContextLoaded(ctx); })
+    .catch(() => { onContextLoaded(null); });
+  serverCall('loadComicDraftSafe', CHILD)
+    .then(draft => {
+      if (draft && draft.version === COMIC_STUDIO_VERSION) { pendingDraft = draft; }
+      _initReady();
+    })
+    .catch(() => { _initReady(); });
 }
 
 init();
 </script>
 </body>
 </html>
-<!-- ComicStudio.html v5 -->
+<!-- ComicStudio.html v6 -->

--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -1141,6 +1141,7 @@ function attachPointerEvents(canvas, panelIdx) {
       const bx = Math.min(Math.floor(pos.x), canvas.width - 1);
       const by = Math.min(Math.floor(pos.y), canvas.height - 1);
       floodFill(panelIdx, bx, by, activeColor);
+      if (!hasDrawnAnything) { hasDrawnAnything = true; startAutosaveTimer(); }
       return;
     }
 

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v61 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v62 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 🧹📅 KH_LessonRuns, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 61; }
+function getKidsHubVersion() { return 62; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -45,6 +45,21 @@ var KH_GRADE_REWARDS = {
   'D': { rings: 0, cash: 0 },
   'F': { rings: 0, cash: 0 }
 };
+
+// v62: ComicStudio Free Mode prompts — shown when kid has no CER submitted for today's episode.
+var COMIC_STUDIO_FREE_PROMPTS = [
+  { id: 'mtl-vehicle',  text: "Draw Mach Turbo Light's newest vehicle. What does it do that no other ride can?" },
+  { id: 'pack-meeting', text: "Draw the Pack at their team meeting. Who's arguing? Who's laughing?" },
+  { id: 'new-villain',  text: "Draw a villain we haven't met yet. Give them a name and a weakness." },
+  { id: 'hq-day',       text: 'Draw a normal day at Pack HQ. Show what everyone is doing.' },
+  { id: 'training',     text: "Draw Wolfkid training for a dangerous mission. Show three skills he's practicing." },
+  { id: 'origin',       text: 'Draw how Wolfkid first met Mach Turbo Light. Where were they? What happened?' },
+  { id: 'disaster',     text: 'Draw the aftermath of a disaster — a flood, a storm, a fire. How does the Pack help?' },
+  { id: 'secret-base',  text: "Draw the Pack's secret underground base. Label three rooms." },
+  { id: 'crowd',        text: 'Draw the Pack getting thanked by a crowd. Who is cheering loudest? Why?' },
+  { id: 'future',       text: 'Draw Wolfkid 10 years from now. What does he look like? What job does he have?' }
+];
+
 var KH_SUBJECTS = ['Math', 'Reading', 'Science', 'Social Studies', 'Art', 'Music', 'PE', 'Other'];
 var KH_QUARTERS = ['Q1', 'Q2', 'Q3', 'Q4', 'S1', 'S2', 'Final'];
 
@@ -4621,5 +4636,199 @@ function getDailyMissionsInitSafe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v61
+// ── v62: Comic Studio — Drive draft storage + mode aggregator ────────────────
+
+function ensureComicArchiveRootFolder_() {
+  var props = PropertiesService.getScriptProperties();
+  var cached = props.getProperty('COMIC_ARCHIVE_FOLDER_ID');
+  if (cached) {
+    try { return DriveApp.getFolderById(cached); } catch (_) {}
+  }
+  var root = DriveApp.getRootFolder();
+  var existing = root.getFoldersByName('Wolfkid Comics');
+  var folder = existing.hasNext() ? existing.next() : root.createFolder('Wolfkid Comics');
+  props.setProperty('COMIC_ARCHIVE_FOLDER_ID', folder.getId());
+  return folder;
+}
+
+function ensureComicDraftsFolder_() {
+  var props = PropertiesService.getScriptProperties();
+  var cached = props.getProperty('COMIC_DRAFTS_FOLDER_ID');
+  if (cached) {
+    try { return DriveApp.getFolderById(cached); } catch (_) {}
+  }
+  var root = ensureComicArchiveRootFolder_();
+  var sub = root.getFoldersByName('drafts');
+  var drafts = sub.hasNext() ? sub.next() : root.createFolder('drafts');
+  props.setProperty('COMIC_DRAFTS_FOLDER_ID', drafts.getId());
+  return drafts;
+}
+
+function saveComicDraft_(child, draftJson) {
+  try {
+    var childLower = String(child || 'buggsy').toLowerCase();
+    var dateKey = getTodayISO_();
+    var fileName = childLower + '_' + dateKey + '.json';
+    var folder = ensureComicDraftsFolder_();
+    var existing = folder.getFilesByName(fileName);
+    while (existing.hasNext()) { existing.next().setTrashed(true); }
+    var blob = Utilities.newBlob(draftJson, 'application/json', fileName);
+    var file = folder.createFile(blob);
+    return { success: true, fileId: file.getId(), bytes: draftJson.length };
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('saveComicDraft_', e);
+    return { success: false, error: String(e) };
+  }
+}
+
+function saveComicDraftSafe(child, draftJson) {
+  return withMonitor_('saveComicDraftSafe', function() {
+    return JSON.parse(JSON.stringify(saveComicDraft_(child, draftJson)));
+  });
+}
+
+function deleteComicDraft_(child, dateKey) {
+  try {
+    var childLower = String(child || 'buggsy').toLowerCase();
+    var key = dateKey || getTodayISO_();
+    var fileName = childLower + '_' + key + '.json';
+    var folder = ensureComicDraftsFolder_();
+    var files = folder.getFilesByName(fileName);
+    var count = 0;
+    while (files.hasNext()) {
+      files.next().setTrashed(true);
+      count++;
+    }
+    return { success: true, deleted: count };
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('deleteComicDraft_', e);
+    return { success: false, error: String(e) };
+  }
+}
+
+function deleteComicDraftSafe(child, dateKey) {
+  return withMonitor_('deleteComicDraftSafe', function() {
+    return JSON.parse(JSON.stringify(deleteComicDraft_(child, dateKey)));
+  });
+}
+
+function loadComicDraft_(child) {
+  try {
+    var childLower = String(child || 'buggsy').toLowerCase();
+    var dateKey = getTodayISO_();
+    var folder = ensureComicDraftsFolder_();
+    var fileName = childLower + '_' + dateKey + '.json';
+    var files = folder.getFilesByName(fileName);
+    if (!files.hasNext()) return null;
+    var file = files.next();
+    var text = file.getBlob().getDataAsString();
+    return JSON.parse(text);
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('loadComicDraft_', e);
+    return null;
+  }
+}
+
+function loadComicDraftSafe(child) {
+  return withMonitor_('loadComicDraftSafe', function() {
+    var result = loadComicDraft_(child);
+    return JSON.parse(JSON.stringify(result));
+  });
+}
+
+function slugifyEpisodeTitle_(title) {
+  return String(title || 'untitled')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/, '')
+    .substring(0, 30);
+}
+
+function getComicStudioContext_(child) {
+  var childLower = String(child || 'buggsy').toLowerCase();
+  var today = getTodayISO_();
+  var result = {
+    mode: 'free',
+    episodeId: null,
+    episode: null,
+    studentCER: null,
+    vocab: [],
+    freePrompts: [],
+    ringsCap: 30
+  };
+
+  var dayContent = null;
+  try {
+    var content = getTodayContent_(childLower);
+    dayContent = (content && content.content) || null;
+    if (dayContent && dayContent.vocabulary) {
+      result.vocab = dayContent.vocabulary.slice(0, 5);
+    }
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('getComicStudioContext_:content', e);
+  }
+
+  var studentCER = null;
+  try {
+    var sheet = ensureKHEducationTab_();
+    if (sheet.getLastRow() >= 2) {
+      var data = sheet.getDataRange().getValues();
+      for (var i = data.length - 1; i >= 1; i--) {
+        var row = data[i];
+        var ts = row[0];
+        var rowChild = String(row[1] || '').toLowerCase();
+        var module = String(row[2] || '').toLowerCase();
+        var subject = String(row[3] || '').toLowerCase();
+        var responseText = String(row[6] || '');
+        var status = String(row[7] || '');
+        var rings = Number(row[9]) || 0;
+        if (rowChild !== childLower) continue;
+        if (!(ts instanceof Date)) continue;
+        var rowDateKey = Utilities.formatDate(ts, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+        if (rowDateKey !== today) continue;
+        var isWolfkid = module.indexOf('wolfkid') !== -1 || subject.indexOf('wolfkid') !== -1;
+        if (!isWolfkid) continue;
+        if (!responseText) continue;
+        studentCER = {
+          submittedAt: ts.toISOString(),
+          claim: responseText.split(/[.!?]/)[0].trim() + '.',
+          responseText: responseText,
+          rings: rings,
+          status: status
+        };
+        break;
+      }
+    }
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('getComicStudioContext_:cer', e);
+  }
+
+  if (dayContent && dayContent.wolfkidEpisode && studentCER) {
+    result.mode = 'mission';
+    result.episodeId = slugifyEpisodeTitle_(dayContent.wolfkidEpisode.title);
+    result.episode = {
+      id: result.episodeId,
+      title: dayContent.wolfkidEpisode.title || '',
+      scenario: dayContent.wolfkidEpisode.scenario || '',
+      writingPrompt: dayContent.wolfkidEpisode.writingPrompt || '',
+      data: dayContent.wolfkidEpisode.data || {}
+    };
+    result.studentCER = studentCER;
+    result.ringsCap = 55;
+  } else {
+    result.mode = 'free';
+    result.freePrompts = COMIC_STUDIO_FREE_PROMPTS.slice();
+    result.ringsCap = 30;
+  }
+
+  return result;
+}
+
+function getComicStudioContextSafe(child) {
+  return withMonitor_('getComicStudioContextSafe', function() {
+    return JSON.parse(JSON.stringify(getComicStudioContext_(child)));
+  });
+}
+
+// END OF FILE — KidsHub.gs v62
 // ════════════════════════════════════════════════════════════════════

--- a/Tbmsmoketest.js
+++ b/Tbmsmoketest.js
@@ -1,5 +1,5 @@
 // ════════════════════════════════════════════════════════════════════
-// tbmSmokeTest.gs v11 — Pre-Deploy Structural Validation
+// tbmSmokeTest.gs v12 — Pre-Deploy Structural Validation
 // WRITES TO: (none — read-only checks)
 // READS FROM: All sheets (for schema/wiring validation)
 // ════════════════════════════════════════════════════════════════════
@@ -37,7 +37,7 @@
 // A PASS here means "safe to deploy" not "system works perfectly."
 // ════════════════════════════════════════════════════════════════════
 
-function getSmokeTestVersion() { return 11; }
+function getSmokeTestVersion() { return 12; }
 
 var CANONICAL_SAFE_FUNCTIONS = [
   'addKidsEventSafe', 'getKHAppUrlsSafe', 'getKHLastModifiedSafe', 'getKidsHubDataSafe',
@@ -716,4 +716,4 @@ function checkHTMLContracts_() {
 }
 
 
-// END OF FILE — tbmSmokeTest.gs v11
+// END OF FILE — tbmSmokeTest.gs v12


### PR DESCRIPTION
Closes #147

## Summary
- **F3 Drive autosave:** Replaces localStorage scaffold with `saveComicDraftSafe`/`loadComicDraftSafe`/`deleteComicDraftSafe`. On load, `loadComicDraftSafe` is called in parallel with `getComicStudioContextSafe`; if a draft is found, the resume-overlay prompts Resume vs Start Fresh. Autosave timer fires every 60s after first stroke.
- **F4 Mission/Free mode:** `getComicStudioContextSafe` aggregates mode, episode title, student CER excerpt, vocab, free prompts, and ringsCap. Mode brief card renders between nav-bar and main content.
- **Ring cap fix:** Vocab bonus (+10) is Mission-only per spec; `Math.min(rings, ringsCap)` applied as final gate (Free cap=30, Mission cap=55).
- **Two-phase init gate:** Context and draft server calls run in parallel; `_onBothLoaded()` fires only after both resolve, preventing race conditions.

## Versions
| File | Before | After |
|------|--------|-------|
| Code.gs | v79 | v80 |
| KidsHub.gs | v61 | v62 |
| tbmSmokeTest.gs | v11 | v12 |
| ComicStudio.html | v5 | v6 |

## Deploy
- Deployment @514
- Smoke WARN (pre-existing KH_LessonRuns tab missing, unrelated to this PR)
- Regression: PASS
- All 82 Safe functions verified present (4 new: saveComicDraftSafe, loadComicDraftSafe, deleteComicDraftSafe, getComicStudioContextSafe)

## Test plan
- [ ] Load `/comic-studio` on Surface Pro 5 — mode brief card renders (Mission or Free)
- [ ] Draw one stroke — autosave indicator shows SAVING then SAVED after 60s
- [ ] Reload page — resume-overlay appears with date; click RESUME restores panels + captions
- [ ] Reload page — click START FRESH clears draft, fresh canvas loads
- [ ] Complete comic in Free mode — vocab bonus NOT awarded; rings ≤ 30
- [ ] Complete comic in Mission mode (day with wolfkidEpisode + submitted CER) — vocab bonus awarded if used; rings ≤ 55
- [ ] `?test=1` flag — TEST MODE banner shows, skips server calls, fresh grid loads immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)