### PR TITLE
fix: education audit Phase A — 5 integrity fixes

### DIFF
--- a/BaselineDiagnostic.html
+++ b/BaselineDiagnostic.html
@@ -1297,7 +1297,7 @@ var Diag = (function() {
         .withSuccessHandler(function() {})
         .withFailureHandler(function(err) { console.error('QuestionLog failed:', err); })
         .logQuestionResultSafe({
-          child: IS_SPARKLE ? 'jj' : 'buggsy',
+          child: CHILD,
           subject: q.section || 'General',
           teksCode: q.teks || '',
           questionType: q.type || 'mc',

--- a/BaselineDiagnostic.html
+++ b/BaselineDiagnostic.html
@@ -1291,6 +1291,23 @@ var Diag = (function() {
     var isCorrect = (selectedIdx === q.correct);
     answers[currentIndex].isCorrect = isCorrect;
 
+    // Log per-question result to QuestionLog for mastery tracking (#161)
+    if (!TBM_TEST_MODE && typeof google !== 'undefined' && google.script && google.script.run) {
+      google.script.run
+        .withSuccessHandler(function() {})
+        .withFailureHandler(function(err) { console.error('QuestionLog failed:', err); })
+        .logQuestionResultSafe({
+          child: IS_SPARKLE ? 'jj' : 'buggsy',
+          subject: q.section || 'General',
+          teksCode: q.teks || '',
+          questionType: q.type || 'mc',
+          difficulty: 'diagnostic',
+          correct: isCorrect,
+          timeSpentSeconds: 0,
+          sessionModule: 'baseline-diagnostic'
+        });
+    }
+
     // Highlight options
     var btns = document.querySelectorAll('.mc-option');
     for (var i = 0; i < btns.length; i++) {

--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -1557,7 +1557,8 @@ function submitAnswer(qId) {
   answers[key].correct = correct;
 
   // Log per-question result to QuestionLog for mastery tracking (#161)
-  if (!TBM_TEST_MODE && !_usingFallback && typeof google !== 'undefined' && google.script && google.script.run) {
+  // Only log MC (auto-graded) questions — open-ended have correct=true hardcoded which inflates accuracy
+  if (isMC && !TBM_TEST_MODE && !_usingFallback && typeof google !== 'undefined' && google.script && google.script.run) {
     google.script.run
       .withSuccessHandler(function() {})
       .withFailureHandler(function(err) { console.error('QuestionLog failed:', err); })
@@ -1565,7 +1566,7 @@ function submitAnswer(qId) {
         child: SANDBOX_CHILD,
         subject: q.strand || 'General',
         teksCode: q.teks || '',
-        questionType: isMC ? 'MC' : 'open_ended',
+        questionType: 'MC',
         difficulty: q.difficulty || 'standard',
         correct: correct,
         timeSpentSeconds: 0,

--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -1556,6 +1556,23 @@ function submitAnswer(qId) {
   answers[key].submitted = true;
   answers[key].correct = correct;
 
+  // Log per-question result to QuestionLog for mastery tracking (#161)
+  if (!TBM_TEST_MODE && !_usingFallback && typeof google !== 'undefined' && google.script && google.script.run) {
+    google.script.run
+      .withSuccessHandler(function() {})
+      .withFailureHandler(function(err) { console.error('QuestionLog failed:', err); })
+      .logQuestionResultSafe({
+        child: SANDBOX_CHILD,
+        subject: q.strand || 'General',
+        teksCode: q.teks || '',
+        questionType: isMC ? 'MC' : 'open_ended',
+        difficulty: q.difficulty || 'standard',
+        correct: correct,
+        timeSpentSeconds: 0,
+        sessionModule: 'homework'
+      });
+  }
+
   if (isMC) {
     if (correct) { playBugsyCorrect(); } else { playBugsyWrong(); }
     // #171 — track missed questions for Error Journal
@@ -1881,14 +1898,11 @@ function renderResults() {
             rings: ringsEarned
           });
 
-        // Only award MC rings immediately if no open-ended questions pending review.
-        // If open-ended exists, all rings (MC + review) come on parent approval to prevent double award.
-        if (allOpenEnded.length === 0 && ringsEarned > 0) {
-          google.script.run
-            .withSuccessHandler(function() { console.log('Rings awarded: ' + ringsEarned); })
-            .withFailureHandler(function(err) { console.error('Ring award failed:', err.message); })
-            .awardRingsSafe(SANDBOX_CHILD, ringsEarned, 'homework-module');
-        } else if (allOpenEnded.length > 0) {
+        // Ring awards handled server-side by submitHomework_() auto-award path.
+        // When auto-graded (no open-ended): server awards rings immediately.
+        // When pending_review (has open-ended): server defers to approveHomework_().
+        // Client-side awardRingsSafe() removed to prevent double-award (#160).
+        if (allOpenEnded.length > 0) {
           console.log('Rings deferred — ' + allOpenEnded.length + ' open-ended question(s) pending parent review');
         }
 

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -3212,6 +3212,39 @@ function _aggregateKHEducation_(child, bounds, eduData) {
   return out;
 }
 
+// v65: QuestionLog-based accuracy — real correct/total from per-question data (#164)
+function _computeQuestionLogAccuracy_(child, bounds) {
+  var result = { correct: 0, total: 0, accuracy: null, bySubject: {} };
+  try {
+    var ss = getKHSS_();
+    var tabName = (typeof TAB_MAP !== 'undefined' && TAB_MAP['QuestionLog']) || 'QuestionLog';
+    var sheet = ss.getSheetByName(tabName);
+    if (!sheet || sheet.getLastRow() < 2) return result;
+    var data = sheet.getDataRange().getValues();
+    // Headers: Question_UID, Child, Date, Day_Of_Week, Subject, TEKS_Code,
+    //          Question_Type, Distractor_Level, Difficulty, Correct, Time_Spent_Seconds, Session_Module, Timestamp
+    for (var i = 1; i < data.length; i++) {
+      var rowChild = String(data[i][1] || '').toLowerCase();
+      if (rowChild !== child) continue;
+      var rowDate = String(data[i][2] || '');
+      if (rowDate < bounds.startISO || rowDate > bounds.endISO) continue;
+      result.total++;
+      var correct = data[i][9] === true || String(data[i][9]).toLowerCase() === 'true';
+      if (correct) result.correct++;
+      var subj = String(data[i][4] || 'Other');
+      if (!result.bySubject[subj]) result.bySubject[subj] = { correct: 0, total: 0 };
+      result.bySubject[subj].total++;
+      if (correct) result.bySubject[subj].correct++;
+    }
+    if (result.total > 0) {
+      result.accuracy = Math.round((result.correct / result.total) * 100);
+    }
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('_computeQuestionLogAccuracy_', e);
+  }
+  return result;
+}
+
 function _buildChildReport_(child, bounds, histData, eduData, flags) {
   var isJJ = (child === 'jj');
   var histAgg = _sumRingsThisWeek_(child, bounds, histData);
@@ -3259,6 +3292,17 @@ function _buildChildReport_(child, bounds, histData, eduData, flags) {
     base.pendingReview = eduAgg.pendingReview;
     base.weekLog = eduAgg.weekLog;
     base.subjects = eduAgg.subjects;
+  }
+
+  // v65: Real accuracy from QuestionLog (#164) — replaces avgScore when data exists
+  var qlAccuracy = _computeQuestionLogAccuracy_(child, bounds);
+  if (qlAccuracy.total > 0) {
+    base.avgScore = qlAccuracy.accuracy;
+    base.questionLogStats = {
+      correct: qlAccuracy.correct,
+      total: qlAccuracy.total,
+      bySubject: qlAccuracy.bySubject
+    };
   }
 
   // Phase 2 (#133 lands KH_LessonRuns): merge in JJ data from lesson runs.
@@ -4485,16 +4529,20 @@ function getDesignChoicesSafe(child) {
 }
 
 // ── HOMEWORK GATE — Design unlocked after any education submission today ──
+// v65: Also checks KH_PowerScan — savePowerScanResultsSafe writes there,
+// not KH_Education, so PowerScan-only days were silently failing (#163).
 function getDesignUnlocked_(child) {
   var childLower = String(child || '').toLowerCase();
   if (childLower !== 'buggsy' && childLower !== 'jj') return false;
-  var sheet = ensureKHEducationTab_();
-  if (sheet.getLastRow() < 2) return false;
-  var data = sheet.getDataRange().getValues();
   var today = getTodayISO_();
-  for (var i = 1; i < data.length; i++) {
-    var rowChild = String(data[i][1] || '').toLowerCase();
-    var rowDate = data[i][0];
+
+  // Check KH_Education (submitHomeworkSafe writes here)
+  var sheet = ensureKHEducationTab_();
+  if (sheet.getLastRow() >= 2) {
+    var data = sheet.getDataRange().getValues();
+    for (var i = 1; i < data.length; i++) {
+      var rowChild = String(data[i][1] || '').toLowerCase();
+      var rowDate = data[i][0];
     var rowDateStr = '';
     if (rowDate instanceof Date) {
       var y = rowDate.getFullYear();
@@ -4507,6 +4555,24 @@ function getDesignUnlocked_(child) {
       return true;
     }
   }
+  }
+
+  // Check KH_PowerScan (savePowerScanResultsSafe writes here)
+  // Columns: 0=Date (ISO string), 1=Child
+  var ss = getKHSS_();
+  var psTabName = (typeof TAB_MAP !== 'undefined' && TAB_MAP['KH_PowerScan']) || 'KH_PowerScan';
+  var psSheet = ss.getSheetByName(psTabName);
+  if (psSheet && psSheet.getLastRow() >= 2) {
+    var psData = psSheet.getDataRange().getValues();
+    for (var j = 1; j < psData.length; j++) {
+      var psDateVal = String(psData[j][0] || '');
+      var psChild = String(psData[j][1] || '').toLowerCase();
+      if (psChild === childLower && psDateVal === today) {
+        return true;
+      }
+    }
+  }
+
   return false;
 }
 

--- a/WolfkidCER.html
+++ b/WolfkidCER.html
@@ -1215,7 +1215,7 @@ function updateCounts() {
 function handleSubmit() {
   playBugsyAudio('buggsy_cer_submit.mp3');
   submitted = true;
-  clearDraft_();
+  /* clearDraft_ moved to submitHomeworkSafe success handler — prevents data loss if submit fails */
   // Stop writing timer
   if (timerRunning) {
     timerRunning = false;
@@ -1237,6 +1237,7 @@ function handleSubmit() {
       if (typeof google !== 'undefined' && google.script && google.script.run) {
         google.script.run
           .withSuccessHandler(function(result) {
+            clearDraft_(); /* Only clear draft after server confirms success */
             console.log('Submitted: ' + (result && result.status ? result.status : 'unknown'));
           })
           .withFailureHandler(function(err) { console.error('Submit failed:', err); })

--- a/WolfkidCER.html
+++ b/WolfkidCER.html
@@ -898,6 +898,47 @@ var sessionInterval = null;
 var TARGET_MINUTES = 35;
 
 // ─── Init ───
+// ─── Draft Auto-Save (#162) ───
+var _DRAFT_LS_KEY = 'tbm_wolfkid_draft_' + new Date().toISOString().slice(0, 10);
+var _DRAFT_FIELDS = ['claimTextarea', 'evidenceTextarea', 'reasoningTextarea'];
+
+function saveDraft_() {
+  if (submitted) return;
+  try {
+    var parts = {};
+    var hasContent = false;
+    for (var i = 0; i < _DRAFT_FIELDS.length; i++) {
+      var el = document.getElementById(_DRAFT_FIELDS[i]);
+      var val = el ? el.value : '';
+      parts[_DRAFT_FIELDS[i]] = val;
+      if (val.replace(/^\s+|\s+$/g, '').length > 0) hasContent = true;
+    }
+    if (!hasContent) return;
+    localStorage.setItem(_DRAFT_LS_KEY, JSON.stringify({ parts: parts, savedAt: new Date().toISOString() }));
+  } catch (e) {}
+}
+
+function loadDraft_() {
+  try {
+    var raw = localStorage.getItem(_DRAFT_LS_KEY);
+    if (!raw) return;
+    var draft = JSON.parse(raw);
+    if (!draft || !draft.parts) return;
+    setTimeout(function() {
+      for (var i = 0; i < _DRAFT_FIELDS.length; i++) {
+        var el = document.getElementById(_DRAFT_FIELDS[i]);
+        if (el && draft.parts[_DRAFT_FIELDS[i]]) el.value = draft.parts[_DRAFT_FIELDS[i]];
+      }
+      updateCounts();
+      console.log('Draft restored from ' + draft.savedAt);
+    }, 300);
+  } catch (e) {}
+}
+
+function clearDraft_() {
+  try { localStorage.removeItem(_DRAFT_LS_KEY); } catch (e) {}
+}
+
 function init() {
   buildStarField();
   buildEpisodeTracker();
@@ -905,6 +946,10 @@ function init() {
   buildStarters();
   document.getElementById("cerPrompt").innerHTML = EPISODE.cerPrompt;
   startSessionTimer();
+  // Auto-save every 30 seconds + on unload
+  setInterval(saveDraft_, 30000);
+  window.addEventListener('beforeunload', saveDraft_);
+  loadDraft_();
 }
 
 // ─── Star Field ───
@@ -1170,6 +1215,7 @@ function updateCounts() {
 function handleSubmit() {
   playBugsyAudio('buggsy_cer_submit.mp3');
   submitted = true;
+  clearDraft_();
   // Stop writing timer
   if (timerRunning) {
     timerRunning = false;

--- a/fact-sprint.html
+++ b/fact-sprint.html
@@ -1376,6 +1376,23 @@ function handleAnswer(idx) {
     btns[idx].className = 'answer-btn wrong';
   }
 
+  // Log per-question result to QuestionLog for mastery tracking (#161)
+  if (!TBM_TEST_MODE && !_usingFallback && typeof google !== 'undefined' && google.script && google.script.run) {
+    google.script.run
+      .withSuccessHandler(function() {})
+      .withFailureHandler(function(err) { console.error('QuestionLog failed:', err); })
+      .logQuestionResultSafe({
+        child: CHILD,
+        subject: 'Math Facts',
+        teksCode: q.teks || '',
+        questionType: 'MC',
+        difficulty: q.difficulty || 'standard',
+        correct: isCorrect,
+        timeSpentSeconds: 0,
+        sessionModule: 'fact-sprint'
+      });
+  }
+
   // Flash the question card
   var qCard = document.getElementById('question-card');
   if (isCorrect) {
@@ -1545,10 +1562,7 @@ function finishSprint() {
         rings: rings
       });
 
-    google.script.run
-      .withSuccessHandler(function() {})
-      .withFailureHandler(function(err) { console.error('Ring award failed:', err); })
-      .awardRingsSafe(CHILD, rings, 'fact-sprint');
+    // Client-side awardRingsSafe() removed — server-side submitHomework_() handles ring awards (#160).
   }
 
   // Persist PBs to server

--- a/investigation-module.html
+++ b/investigation-module.html
@@ -1567,13 +1567,13 @@ function showCompletionScreen() {
 
 // ─── INVESTIGATION JOURNAL SUBMIT (Monday) ───
 function submitInvestigationJournal() {
-  clearDraft_();
   var text = document.getElementById('investigation-journal').value;
   if (!text || text.trim().length < 5) {
     document.getElementById('investigation-journal').style.borderColor = '#ffc107';
     document.getElementById('investigation-journal').placeholder = 'Write at least one sentence...';
     return;
   }
+  clearDraft_(); // Clear draft only after validation passes (#162 Codex fix)
   ExecSkills._journalData = {
     type: 'investigation-reflection',
     hypothesis: sectionData.hypothesis,

--- a/investigation-module.html
+++ b/investigation-module.html
@@ -1573,7 +1573,7 @@ function submitInvestigationJournal() {
     document.getElementById('investigation-journal').placeholder = 'Write at least one sentence...';
     return;
   }
-  clearDraft_(); // Clear draft only after validation passes (#162 Codex fix)
+  /* Draft cleared in submitForReview success handler, not here — prevents data loss if submit fails */
   ExecSkills._journalData = {
     type: 'investigation-reflection',
     hypothesis: sectionData.hypothesis,
@@ -1673,6 +1673,7 @@ function submitForReview() {
       if (typeof google !== 'undefined' && google.script && google.script.run) {
         google.script.run
           .withSuccessHandler(function() {
+            clearDraft_(); /* Only clear draft after server confirms success */
             btn.textContent = 'SUBMITTED';
             btn.style.background = '#22C55E';
             status.style.color = '#F59E0B';
@@ -1736,7 +1737,7 @@ function loadCurriculumContent() {
 // ─── INIT ───
 // ─── Draft Auto-Save (#162) ───
 var _DRAFT_LS_KEY = 'tbm_investigation_draft_' + new Date().toISOString().slice(0, 10);
-var _DRAFT_FIELDS = ['hypothesis-text', 'prediction-text', 'conclusion-text'];
+var _DRAFT_FIELDS = ['hypothesis-text', 'prediction-text', 'conclusion-text', 'investigation-journal'];
 
 function saveDraft_() {
   try {
@@ -1748,6 +1749,15 @@ function saveDraft_() {
       parts[_DRAFT_FIELDS[i]] = val;
       if (val.replace(/^\s+|\s+$/g, '').length > 0) hasContent = true;
     }
+    /* Also save procedure steps (dynamic inputs) */
+    var steps = [];
+    var stepEls = document.querySelectorAll('.step-input');
+    for (var s = 0; s < stepEls.length; s++) {
+      var sv = stepEls[s].value || '';
+      steps.push(sv);
+      if (sv.replace(/^\s+|\s+$/g, '').length > 0) hasContent = true;
+    }
+    parts['_procedure_steps'] = steps;
     if (!hasContent) return;
     localStorage.setItem(_DRAFT_LS_KEY, JSON.stringify({ parts: parts, savedAt: new Date().toISOString() }));
   } catch (e) {}
@@ -1763,6 +1773,14 @@ function loadDraft_() {
       for (var i = 0; i < _DRAFT_FIELDS.length; i++) {
         var el = document.getElementById(_DRAFT_FIELDS[i]);
         if (el && draft.parts[_DRAFT_FIELDS[i]]) el.value = draft.parts[_DRAFT_FIELDS[i]];
+      }
+      /* Restore procedure steps */
+      if (draft.parts['_procedure_steps']) {
+        var savedSteps = draft.parts['_procedure_steps'];
+        var stepEls = document.querySelectorAll('.step-input');
+        for (var s = 0; s < Math.min(savedSteps.length, stepEls.length); s++) {
+          if (savedSteps[s]) stepEls[s].value = savedSteps[s];
+        }
       }
       console.log('Draft restored from ' + draft.savedAt);
     }, 300);

--- a/investigation-module.html
+++ b/investigation-module.html
@@ -1567,6 +1567,7 @@ function showCompletionScreen() {
 
 // ─── INVESTIGATION JOURNAL SUBMIT (Monday) ───
 function submitInvestigationJournal() {
+  clearDraft_();
   var text = document.getElementById('investigation-journal').value;
   if (!text || text.trim().length < 5) {
     document.getElementById('investigation-journal').style.borderColor = '#ffc107';
@@ -1733,8 +1734,51 @@ function loadCurriculumContent() {
 }
 
 // ─── INIT ───
+// ─── Draft Auto-Save (#162) ───
+var _DRAFT_LS_KEY = 'tbm_investigation_draft_' + new Date().toISOString().slice(0, 10);
+var _DRAFT_FIELDS = ['hypothesis-text', 'prediction-text', 'conclusion-text'];
+
+function saveDraft_() {
+  try {
+    var parts = {};
+    var hasContent = false;
+    for (var i = 0; i < _DRAFT_FIELDS.length; i++) {
+      var el = document.getElementById(_DRAFT_FIELDS[i]);
+      var val = el ? el.value : '';
+      parts[_DRAFT_FIELDS[i]] = val;
+      if (val.replace(/^\s+|\s+$/g, '').length > 0) hasContent = true;
+    }
+    if (!hasContent) return;
+    localStorage.setItem(_DRAFT_LS_KEY, JSON.stringify({ parts: parts, savedAt: new Date().toISOString() }));
+  } catch (e) {}
+}
+
+function loadDraft_() {
+  try {
+    var raw = localStorage.getItem(_DRAFT_LS_KEY);
+    if (!raw) return;
+    var draft = JSON.parse(raw);
+    if (!draft || !draft.parts) return;
+    setTimeout(function() {
+      for (var i = 0; i < _DRAFT_FIELDS.length; i++) {
+        var el = document.getElementById(_DRAFT_FIELDS[i]);
+        if (el && draft.parts[_DRAFT_FIELDS[i]]) el.value = draft.parts[_DRAFT_FIELDS[i]];
+      }
+      console.log('Draft restored from ' + draft.savedAt);
+    }, 300);
+  } catch (e) {}
+}
+
+function clearDraft_() {
+  try { localStorage.removeItem(_DRAFT_LS_KEY); } catch (e) {}
+}
+
 function init() {
   buildStarField();
+  // Auto-save every 30 seconds + on unload
+  setInterval(saveDraft_, 30000);
+  window.addEventListener('beforeunload', saveDraft_);
+  loadDraft_();
 
   // Render prompt
   document.getElementById('prompt-text').textContent = 'Intel Report: ' + INVESTIGATION.prompt;

--- a/reading-module.html
+++ b/reading-module.html
@@ -1520,6 +1520,23 @@ function lockInMC(qId) {
   ans.submitted = true;
   ans.correct = (ans.selected === q.answer);
 
+  // Log per-question result to QuestionLog for mastery tracking (#161)
+  if (!TBM_TEST_MODE && !_usingFallback && typeof google !== 'undefined' && google.script && google.script.run) {
+    google.script.run
+      .withSuccessHandler(function() {})
+      .withFailureHandler(function(err) { console.error('QuestionLog failed:', err); })
+      .logQuestionResultSafe({
+        child: SANDBOX_CHILD,
+        subject: q.label || 'RLA',
+        teksCode: q.teks || '',
+        questionType: q.type || 'MC',
+        difficulty: q.difficulty || 'standard',
+        correct: ans.correct,
+        timeSpentSeconds: 0,
+        sessionModule: 'reading'
+      });
+  }
+
   if (!ans.correct) {
     missedQuestions.push({
       question: q.question,
@@ -1781,10 +1798,7 @@ function renderResults() {
           rings: earnedRings
         });
 
-      google.script.run
-        .withSuccessHandler(function() { console.log('Rings awarded: ' + earnedRings); })
-        .withFailureHandler(function(err) { console.error('Ring award failed:', err.message); })
-        .awardRingsSafe(SANDBOX_CHILD, earnedRings, 'reading-module');
+      // Client-side awardRingsSafe() removed — server-side submitHomework_() handles ring awards (#160).
 
       google.script.run
         .withSuccessHandler(function() { console.log('Reading completion logged'); })

--- a/writing-module.html
+++ b/writing-module.html
@@ -1085,6 +1085,7 @@ function init() {
   buildStarField();
   currentFormat = getWeekFormat();
   highlightFormatTab(currentFormat);
+  initDraftAutoSave_();
   // #171 — ExecSkills Plan Your Attack (shows before plan view)
   var fmt = FORMATS[currentFormat];
   ExecSkills.showPlanYourAttack({
@@ -1101,6 +1102,66 @@ function init() {
     }
   });
 }
+
+// ─── Draft Auto-Save (#162) ───
+var _DRAFT_LS_KEY = 'tbm_writing_draft_' + new Date().toISOString().slice(0, 10);
+var _draftInterval = null;
+
+function saveDraft_() {
+  if (submitted) return;
+  try {
+    var data = getAllText();
+    if (!data || !data.parts) return;
+    var hasContent = false;
+    var keys = Object.keys(data.parts);
+    for (var i = 0; i < keys.length; i++) {
+      if (data.parts[keys[i]] && data.parts[keys[i]].replace(/^\s+|\s+$/g, '').length > 0) {
+        hasContent = true;
+        break;
+      }
+    }
+    if (!hasContent) return;
+    localStorage.setItem(_DRAFT_LS_KEY, JSON.stringify({
+      format: currentFormat,
+      parts: data.parts,
+      savedAt: new Date().toISOString()
+    }));
+  } catch (e) { /* localStorage may be unavailable */ }
+}
+
+function loadDraft_() {
+  try {
+    var raw = localStorage.getItem(_DRAFT_LS_KEY);
+    if (!raw) return;
+    var draft = JSON.parse(raw);
+    if (!draft || !draft.parts) return;
+    if (draft.format !== currentFormat) return;
+    // Restore after a short delay to let DOM render
+    setTimeout(function() {
+      var keys = Object.keys(draft.parts);
+      for (var i = 0; i < keys.length; i++) {
+        var el = document.getElementById('textarea-' + keys[i]);
+        if (el && draft.parts[keys[i]]) {
+          el.value = draft.parts[keys[i]];
+        }
+      }
+      updateCounts();
+      console.log('Draft restored from ' + draft.savedAt);
+    }, 300);
+  } catch (e) { /* ignore parse errors */ }
+}
+
+function clearDraft_() {
+  try { localStorage.removeItem(_DRAFT_LS_KEY); } catch (e) {}
+}
+
+function initDraftAutoSave_() {
+  // Auto-save every 30 seconds
+  _draftInterval = setInterval(saveDraft_, 30000);
+  // Save on page unload
+  window.addEventListener('beforeunload', saveDraft_);
+  // Restore any saved draft after rendering
+  loadDraft_();
 
 // ─── Star Field ───
 function buildStarField() {
@@ -1458,6 +1519,7 @@ function getSessionTimeString() {
 function handleSubmit() {
   if (submitted) return;
   submitted = true;
+  clearDraft_();
 
   stopWritingTimer();
   if (sessionInterval) {

--- a/writing-module.html
+++ b/writing-module.html
@@ -1519,7 +1519,7 @@ function getSessionTimeString() {
 function handleSubmit() {
   if (submitted) return;
   submitted = true;
-  clearDraft_();
+  /* clearDraft_ moved to submitHomeworkSafe success handler — prevents data loss if submit fails */
 
   stopWritingTimer();
   if (sessionInterval) {
@@ -1567,6 +1567,7 @@ function handleSubmit() {
       if (typeof google !== 'undefined' && google.script && google.script.run) {
         google.script.run
           .withSuccessHandler(function(result) {
+            clearDraft_(); /* Only clear draft after server confirms success */
             console.log('Submitted: ' + (result && result.status ? result.status : 'unknown'));
           })
           .withFailureHandler(function(err) { console.error('Submit failed:', err); })


### PR DESCRIPTION
## Summary
- **A1 (#160):** Remove duplicate ring awards on auto-graded modules — `submitHomework_()` server-side auto-award is now single source of truth. Client-side `awardRingsSafe()` calls removed from HomeworkModule, reading-module, fact-sprint.
- **A2 (#161):** Wire `logQuestionResultSafe()` into HomeworkModule, reading-module, fact-sprint, BaselineDiagnostic — enables per-question mastery tracking pipeline.
- **A3 (#162):** Add localStorage-based draft auto-save to writing-module, investigation-module, WolfkidCER — 30s periodic save + beforeunload beacon.
- **A4 (#163):** Fix WOLFDOME unlock gate to also check `KH_PowerScan` — `getDesignUnlocked_()` previously only checked `KH_Education`, missing PowerScan-only days.
- **A5 (#164):** Add `_computeQuestionLogAccuracy_()` — replaces raw Score-column average with real correct/total from QuestionLog data.

Closes #160, #161, #162, #163, #164

## Test plan
- [ ] Complete a HomeworkModule (all MC) — verify rings awarded exactly once in KH_History (no duplicate)
- [ ] Complete a fact-sprint — verify QuestionLog tab has new rows with TEKS_Code, Correct, Subject populated
- [ ] Type in writing-module, refresh page — verify draft restores from localStorage
- [ ] Complete a PowerScan only (no homework) — verify WOLFDOME design dashboard unlocks
- [ ] Check ProgressReport — verify avgScore shows % from QuestionLog when data exists
- [ ] Run `bash audit-source.sh` — PASS with 0 failures, 0 warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)