### PR TITLE
feat: SparkleLearning visual overhaul — all 10 rendering fixes

### DIFF
--- a/AssetRegistry.js
+++ b/AssetRegistry.js
@@ -1,4 +1,4 @@
-// AssetRegistry.gs — v3
+// AssetRegistry.gs — v4
 // ════════════════════════════════════════════════════════════════════
 // Shared asset catalog for SparkleLearning, CurriculumSeed, and validators.
 // V8 server-side — modern JS OK here.
@@ -6,7 +6,7 @@
 // READS FROM: (in-memory constant — no sheet reads)
 // ════════════════════════════════════════════════════════════════════
 
-function getAssetRegistryVersion() { return 3; }
+function getAssetRegistryVersion() { return 4; }
 
 var ASSET_REGISTRY = {
   // ── Letter intro hero images — concepts tied to letters in CurriculumSeed ──
@@ -36,18 +36,31 @@ var ASSET_REGISTRY = {
   'heart':      { id: 'heart',      type: 'svg',   value: 'heart',        name: 'heart',      plural: 'hearts',      color: 'pink',   category: 'shape' },
   'moon':       { id: 'moon',       type: 'svg',   value: 'moon',         name: 'moon',       plural: 'moons',       color: 'purple', category: 'shape' },
   'flowers':    { id: 'flowers',    type: 'emoji', value: '\uD83C\uDF38', name: 'flower',     plural: 'flowers',     color: 'pink',   category: 'nature' },
+  'flower':     { id: 'flower',     type: 'emoji', value: '\uD83C\uDF38', name: 'flower',     plural: 'flowers',     color: 'pink',   category: 'nature' },
   'rainbows':   { id: 'rainbows',   type: 'emoji', value: '\uD83C\uDF08', name: 'rainbow',    plural: 'rainbows',    color: 'purple', category: 'nature' },
+  'rainbow':    { id: 'rainbow',    type: 'emoji', value: '\uD83C\uDF08', name: 'rainbow',    plural: 'rainbows',    color: 'purple', category: 'nature' },
   'gems':       { id: 'gems',       type: 'emoji', value: '\uD83D\uDC8E', name: 'gem',        plural: 'gems',        color: 'blue',   category: 'object' },
+  'gem':        { id: 'gem',        type: 'emoji', value: '\uD83D\uDC8E', name: 'gem',        plural: 'gems',        color: 'blue',   category: 'object' },
 
   // ── Phase 2 letter intro images — JJ weeks 5-8 ──
   'tiger':      { id: 'tiger',      type: 'emoji', value: '\uD83D\uDC2F', name: 'tiger',      plural: 'tigers',      color: 'orange', category: 'animal' },
   'orange':     { id: 'orange',     type: 'emoji', value: '\uD83C\uDF4A', name: 'orange',     plural: 'oranges',     color: 'orange', category: 'food' },
-  'cat':        { id: 'cat',        type: 'emoji', value: '\uD83D\uDC31', name: 'cat',        plural: 'cats',        color: 'gray',   category: 'animal' },
 
   // ── Shape assets for color_sort items[].name — validates against registry ──
   'circle':     { id: 'circle',     type: 'svg',   value: 'circle',       name: 'circle',     plural: 'circles',     color: 'blue',   category: 'shape' },
   'square':     { id: 'square',     type: 'svg',   value: 'square',       name: 'square',     plural: 'squares',     color: 'green',  category: 'shape' },
-  'triangle':   { id: 'triangle',   type: 'svg',   value: 'triangle',     name: 'triangle',   plural: 'triangles',   color: 'yellow', category: 'shape' }
+  'triangle':   { id: 'triangle',   type: 'svg',   value: 'triangle',     name: 'triangle',   plural: 'triangles',   color: 'yellow', category: 'shape' },
+
+  // ── Extended animal/nature set — explicit emoji for all CurriculumSeed + prompt list objects ──
+  'fish':       { id: 'fish',       type: 'emoji', value: '\uD83D\uDC1F', name: 'fish',       plural: 'fish',        color: 'blue',   category: 'animal' },
+  'bird':       { id: 'bird',       type: 'emoji', value: '\uD83D\uDC26', name: 'bird',       plural: 'birds',       color: 'blue',   category: 'animal' },
+  'birds':      { id: 'birds',      type: 'emoji', value: '\uD83D\uDC26', name: 'bird',       plural: 'birds',       color: 'blue',   category: 'animal' },
+  'dog':        { id: 'dog',        type: 'emoji', value: '\uD83D\uDC36', name: 'dog',        plural: 'dogs',        color: 'brown',  category: 'animal' },
+  'dogs':       { id: 'dogs',       type: 'emoji', value: '\uD83D\uDC36', name: 'dog',        plural: 'dogs',        color: 'brown',  category: 'animal' },
+  'cat':        { id: 'cat',        type: 'emoji', value: '\uD83D\uDC31', name: 'cat',        plural: 'cats',        color: 'orange', category: 'animal' },
+  'cats':       { id: 'cats',       type: 'emoji', value: '\uD83D\uDC31', name: 'cat',        plural: 'cats',        color: 'orange', category: 'animal' },
+  'tree':       { id: 'tree',       type: 'emoji', value: '\uD83C\uDF33', name: 'tree',       plural: 'trees',       color: 'green',  category: 'nature' },
+  'trees':      { id: 'trees',      type: 'emoji', value: '\uD83C\uDF33', name: 'tree',       plural: 'trees',       color: 'green',  category: 'nature' }
 };
 
 // ── Plural index — O(1) lookup by plural, singular, or display name ──
@@ -71,4 +84,4 @@ function getAssetRegistry_() {
   return ASSET_REGISTRY;
 }
 
-// END OF FILE — AssetRegistry.gs v3
+// END OF FILE — AssetRegistry.gs v4

--- a/Code.js
+++ b/Code.js
@@ -1025,11 +1025,12 @@ function getStoredStorySafe(storyKey) {
 // v77: Asset Registry — returns full ASSET_REGISTRY with 12h CacheService TTL
 function getAssetRegistrySafe() {
   return withMonitor_('getAssetRegistrySafe', function() {
+    var cacheKey = 'asset_registry_v' + getAssetRegistryVersion();
     var cache = CacheService.getScriptCache();
-    var cached = cache.get('asset_registry_v1');
+    var cached = cache.get(cacheKey);
     if (cached) { return JSON.parse(cached); }
     var reg = getAssetRegistry_();
-    try { cache.put('asset_registry_v1', JSON.stringify(reg), 43200); } catch (e) {}
+    try { cache.put(cacheKey, JSON.stringify(reg), 43200); } catch (e) {}
     return JSON.parse(JSON.stringify(reg));
   });
 }

--- a/SparkleLearning.html
+++ b/SparkleLearning.html
@@ -651,6 +651,7 @@ var countState = {};
 var traceState = {};
 var sortState = {};
 var nameState = {};
+var _wrongAnswerTimer = null;
 
 /* ─── Asset Registry (fetched once at load, cached module-level) ─── */
 var _assetRegistry = null;
@@ -1829,6 +1830,9 @@ function handleCorrectAnswer(activity, el) {
   if (activityLocked) { return; }
   activityLocked = true;
 
+  /* Cancel any pending wrong-answer audio so it can't play over the celebration */
+  if (_wrongAnswerTimer) { clearTimeout(_wrongAnswerTimer); _wrongAnswerTimer = null; }
+
   if (el) {
     el.className += ' correct';
     var rect = el.getBoundingClientRect();
@@ -1852,7 +1856,8 @@ function handleWrongAnswer(el) {
   var tryClips = ['jj_feedback_tryagain1.mp3','jj_feedback_tryagain2.mp3','jj_feedback_tryagain3.mp3','jj_feedback_tryagain4.mp3'];
   /* +100ms delay before Try Again audio — gives JJ a moment to process (P2 Fix 6) */
   var _clip = tryClips[Math.floor(Math.random() * tryClips.length)];
-  setTimeout(function() {
+  _wrongAnswerTimer = setTimeout(function() {
+    _wrongAnswerTimer = null;
     playAudioCached(_clip, 'Try again!');
   }, 100);
   setTimeout(function() {

--- a/SparkleLearning.html
+++ b/SparkleLearning.html
@@ -4,13 +4,24 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <meta name="tbm-module" content="sparkle-learn">
-  <meta name="tbm-version" content="v15">
+  <meta name="tbm-version" content="v16">
   <title>SparkleLearn v3 — JJ's Learning Games</title>
   <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
   <style>
     /* ═══════════════════════════════════════════════════
        SparkleLearn v2 — CSS
        ═══════════════════════════════════════════════════ */
+
+    /* ─── Font CDN Fallback (P3 Fix 10) ─── */
+    /* local() sources load instantly if font is cached on device;
+       browser falls through to the <link> Google Fonts stylesheet otherwise */
+    @font-face {
+      font-family: 'Fredoka One';
+      font-style: normal;
+      font-weight: 400;
+      src: local('Fredoka One'), local('FredokaOne-Regular');
+    }
+
     * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
 
     body {
@@ -23,7 +34,7 @@
     }
 
     h1, h2, h3, .heading-text {
-      font-family: 'Fredoka One', 'Arial Rounded MT Bold', sans-serif;
+      font-family: 'Fredoka One', 'Comic Sans MS', 'Arial Rounded MT Bold', sans-serif;
     }
 
     /* ─── Star Counter ─── */
@@ -121,8 +132,8 @@
       -webkit-animation: popCorrect 0.4s ease; animation: popCorrect 0.4s ease;
     }
     .option-btn.wrong {
-      background: rgba(245,158,11,0.3); border-color: #f59e0b;
-      -webkit-animation: wobble 0.5s ease; animation: wobble 0.5s ease;
+      background: rgba(168,85,247,0.2); border-color: rgba(168,85,247,0.6);
+      -webkit-animation: gentlePulse 0.6s ease; animation: gentlePulse 0.6s ease;
     }
     .option-btn.selected {
       border-color: #fde68a; background: rgba(253,230,138,0.2);
@@ -198,13 +209,12 @@
       gap: 12px; margin-top: 16px;
     }
     .color-bin {
-      width: 80px; height: 80px; border-radius: 16px;
-      border: 3px solid rgba(255,255,255,0.3);
+      width: 100px; height: 120px; border-radius: 18px;
+      border: 6px solid rgba(255,255,255,0.7);
       cursor: pointer; -webkit-transition: all 0.2s; transition: all 0.2s;
       display: -webkit-flex; display: flex;
       -webkit-align-items: center; align-items: center;
       -webkit-justify-content: center; justify-content: center;
-      font-size: 32px; color: #fff; font-weight: 700;
     }
     .color-bin.selected-bin {
       border-color: #fde68a; box-shadow: 0 0 20px rgba(253,230,138,0.4);
@@ -275,11 +285,11 @@
     }
     .pattern-mystery {
       width: 64px; height: 64px; border-radius: 14px;
-      border: 3px dashed #fde68a; background: rgba(253,230,138,0.1);
+      border: 3px solid #fde68a; background: rgba(253,230,138,0.25);
       display: -webkit-flex; display: flex;
       -webkit-align-items: center; align-items: center;
       -webkit-justify-content: center; justify-content: center;
-      font-family: 'Fredoka One', sans-serif; font-size: 36px;
+      font-family: 'Fredoka One', 'Comic Sans MS', sans-serif; font-size: 36px;
       color: #fde68a;
     }
 
@@ -314,8 +324,8 @@
       animation: feedbackPop 1s ease forwards;
     }
     .feedback-text.wrong-fb {
-      color: #f59e0b; font-size: 40px;
-      text-shadow: 0 0 30px rgba(245,158,11,0.6);
+      color: #f472b6; font-size: 40px;
+      text-shadow: 0 0 30px rgba(244,114,182,0.6);
     }
 
     /* ─── Celebration ─── */
@@ -545,6 +555,32 @@
     @keyframes skLoadShimmer { 0%,100% { opacity: 0.7; color: #ffaaee; } 50% { opacity: 1; color: #ffe0ff; } }
     @keyframes skLoadDot { 0%,100% { transform: translateY(0) scale(1); } 50% { transform: translateY(-16px) scale(1.3); } }
     @keyframes skLoadFloat { 0% { opacity: 0; transform: translateY(0) scale(0.5); } 20% { opacity: 1; } 80% { opacity: 1; } 100% { opacity: 0; transform: translateY(-320px) rotate(40deg) scale(1.2); } }
+
+    /* ─── Wrong Answer: gentle purple pulse (P2 Fix 6) ─── */
+    @-webkit-keyframes gentlePulse {
+      0%, 100% { -webkit-transform: scale(1); }
+      50% { -webkit-transform: scale(1.04); }
+    }
+    @keyframes gentlePulse {
+      0%, 100% { transform: scale(1); }
+      50% { transform: scale(1.04); }
+    }
+
+    /* ─── Name Builder: pulsing gold slot cue (P2 Fix 8) ─── */
+    @-webkit-keyframes pulseSlot {
+      0%, 100% { border-color: #fde68a; box-shadow: 0 0 0 rgba(253,230,138,0); }
+      50% { border-color: #fde68a; box-shadow: 0 0 14px rgba(253,230,138,0.7); }
+    }
+    @keyframes pulseSlot {
+      0%, 100% { border-color: #fde68a; box-shadow: 0 0 0 rgba(253,230,138,0); }
+      50% { border-color: #fde68a; box-shadow: 0 0 14px rgba(253,230,138,0.7); }
+    }
+    .name-slot.next-slot {
+      border-style: solid;
+      border-color: #fde68a;
+      -webkit-animation: pulseSlot 1.2s ease-in-out infinite;
+      animation: pulseSlot 1.2s ease-in-out infinite;
+    }
   </style>
 </head>
 <body style="background:#1a0533;">
@@ -930,6 +966,15 @@ function renderShape(shape, color, size) {
       return '<svg width="' + s + '" height="' + s + '" viewBox="0 0 100 100">' +
         '<circle cx="50" cy="50" r="45" fill="' + c + '"/></svg>';
   }
+}
+
+/* ─── SVG Dot renderer — 40px orb with highlight (P2 Fix 4) ─── */
+function renderSvgDot(colorHex) {
+  var c = colorHex || '#a855f7';
+  return '<svg width="40" height="40" viewBox="0 0 40 40" style="display:inline-block;vertical-align:middle;margin:3px">' +
+    '<circle cx="20" cy="20" r="18" fill="' + c + '"/>' +
+    '<circle cx="13" cy="13" r="6" fill="rgba(255,255,255,0.45)"/>' +
+    '</svg>';
 }
 
 /* ═══════════════════════════════════════════════════════════
@@ -1619,8 +1664,19 @@ function resolveAsset(assetId, size, fallbackColor) {
     return renderShape(entry.value, entry.color || fallbackColor, size || 64);
   }
   if (entry.type === 'image') {
-    // Phase 2: lazy-load real src from getAssetImageSafe cache
-    return '<img class="asset-img" alt="' + escapeHtml(entry.name || '') + '" src="" data-asset-id="' + escapeHtml(assetId) + '" style="width:' + (size || 120) + 'px;height:auto;" />';
+    // Phase 2 lazy-load never shipped — fall back to emoji if entry has one,
+    // otherwise render a colored SVG circle with the first letter of the asset name.
+    if (entry.emoji) {
+      return '<span class="asset-emoji" style="font-size:' + (size || 120) + 'px;line-height:1;display:inline-block;">' + entry.emoji + '</span>';
+    }
+    var _fc = (entry.name || assetId || '?').charAt(0).toUpperCase();
+    var _bgCol = entry.color ? (COLOR_MAP[entry.color] || entry.color) : '#a855f7';
+    var _sz = size || 120;
+    return '<svg width="' + _sz + '" height="' + _sz + '" viewBox="0 0 120 120">' +
+      '<circle cx="60" cy="60" r="56" fill="' + _bgCol + '"/>' +
+      '<circle cx="42" cy="42" r="16" fill="rgba(255,255,255,0.35)"/>' +
+      '<text x="60" y="82" text-anchor="middle" font-family="Fredoka One,Comic Sans MS,sans-serif" font-size="58" fill="white">' + escapeHtml(_fc) + '</text>' +
+      '</svg>';
   }
   return renderShape('circle', fallbackColor || 'pink', size || 64);
 }
@@ -1794,12 +1850,16 @@ function handleWrongAnswer(el) {
   if (activityLocked) { return; }
   if (el) { el.className += ' wrong'; }
   var tryClips = ['jj_feedback_tryagain1.mp3','jj_feedback_tryagain2.mp3','jj_feedback_tryagain3.mp3','jj_feedback_tryagain4.mp3'];
-  playAudioCached(tryClips[Math.floor(Math.random() * tryClips.length)], 'Try again!');
+  /* +100ms delay before Try Again audio — gives JJ a moment to process (P2 Fix 6) */
+  var _clip = tryClips[Math.floor(Math.random() * tryClips.length)];
+  setTimeout(function() {
+    playAudioCached(_clip, 'Try again!');
+  }, 100);
   setTimeout(function() {
     if (el) {
       el.className = el.className.replace(' wrong', '');
     }
-  }, 600);
+  }, 700);
 }
 
 /* ═══════════════════════════════════════════════════════════
@@ -1813,9 +1873,15 @@ function renderLetterIntro(activity) {
   var html = '<div class="activity-card">';
   html += '<p class="instruction">Meet the letter:</p>';
 
-  // Render activity.image hero asset above the letter card when available
+  // Render activity.image hero asset above the letter card when available (P2 Fix 5)
   if (activity.image) {
-    html += '<div style="text-align:center;margin-bottom:8px;">' + resolveAsset(activity.image, 96, 'gold') + '</div>';
+    html += '<div style="text-align:center;margin-bottom:12px;">' + resolveAsset(activity.image, 120, 'gold') + '</div>';
+  } else {
+    /* No image — render the focus letter as a large decorative element with gradient circle */
+    html += '<div style="text-align:center;margin-bottom:12px;">';
+    html += '<div style="display:inline-flex;-webkit-align-items:center;align-items:center;-webkit-justify-content:center;justify-content:center;width:140px;height:140px;border-radius:50%;background:linear-gradient(135deg,#7c3aed,#ec4899);">';
+    html += '<span style="font-family:\'Fredoka One\',\'Comic Sans MS\',sans-serif;font-size:80px;color:#fde68a;text-shadow:0 0 20px rgba(253,230,138,0.5);">' + escapeHtml(letter.toUpperCase()) + '</span>';
+    html += '</div></div>';
   }
 
   html += '<div class="big-letter">' + letter.toUpperCase() + '</div>';
@@ -2005,10 +2071,11 @@ function renderQuantityMatch(activity) {
   html += '<p style="font-size:18px;color:#e0d4f5;margin-bottom:8px;">Dots</p>';
   var shuffledG = shuffleArray(groups);
   for (var i = 0; i < shuffledG.length; i++) {
-    html += '<button class="option-btn" id="qmDots' + i + '" style="display:block;margin:8px auto;min-width:100px;font-size:18px;" ';
+    html += '<button class="option-btn" id="qmDots' + i + '" style="display:block;margin:8px auto;min-width:100px;" ';
     html += 'onclick="tapQmDots(' + i + ',' + shuffledG[i].dots + ')">';
+    /* SVG gradient circles — 40px orbs with highlight (P2 Fix 4) */
     for (var d = 0; d < shuffledG[i].dots; d++) {
-      html += '&#9679; ';
+      html += renderSvgDot('#a855f7');
     }
     html += '</button>';
   }
@@ -2562,13 +2629,17 @@ function renderAudioStory(activity) {
   mc.innerHTML = html;
 
   speak(story, function() {
+    /* 2000ms pause after story — JJ processes what she heard (P2 Fix 7) */
     setTimeout(function() {
       var qEl = document.getElementById('storyQuestion');
       if (qEl) { qEl.style.display = 'block'; }
       speak(question, function() {
-        speakOptions(options, 0);
+        /* 1000ms pause after question before reading options (P2 Fix 7) */
+        setTimeout(function() {
+          speakOptions(options, 0);
+        }, 1000);
       });
-    }, 500);
+    }, 2000);
   });
 }
 
@@ -2600,7 +2671,7 @@ function renderColorSort(activity) {
     { shape: 'triangle', color: 'red' },
     { shape: 'diamond', color: 'blue' }
   ];
-  var bins = activity.bins || ['red', 'blue'];
+  var bins = activity.bins || activity.colors || ['red', 'blue'];
 
   sortState = { selectedItem: null, remaining: items.length, items: items };
 
@@ -2618,13 +2689,14 @@ function renderColorSort(activity) {
   }
   html += '</div>';
 
-  /* Bins */
+  /* Bins — large filled color rectangles, no text label (P1 Fix 2) */
   html += '<div class="bin-row" id="sortBins">';
   for (var b = 0; b < bins.length; b++) {
+    var _binHex = COLOR_MAP[bins[b]] || bins[b];
     html += '<div class="color-bin" id="sortBin' + b + '" ';
-    html += 'style="background:' + (COLOR_MAP[bins[b]] || bins[b]) + ';" ';
+    html += 'style="background:' + _binHex + ';border-color:' + _binHex + ';" ';
     html += 'onclick="tapSortBin(' + b + ',\'' + bins[b] + '\')">';
-    html += escapeHtml(bins[b]);
+    /* No text — pure color rectangle so a 4-year-old reads the color visually */
     html += '</div>';
   }
   html += '</div></div>';
@@ -2781,6 +2853,10 @@ function renderNameBuilder(activity) {
   html += '</div></div>';
   mc.innerHTML = html;
 
+  /* Pulse the first empty slot so JJ knows where to start (P2 Fix 8) */
+  var _firstSlot = document.getElementById('nameSlot0');
+  if (_firstSlot) { _firstSlot.className += ' next-slot'; }
+
   var spellKey = target === 'JJ' ? 'jj_spell_jj.mp3' : (target === 'KINDLE' ? 'jj_spell_kindle.mp3' : null);
   speak("Build the name " + target + "! Tap the letters in order. First, find " + target.charAt(0) + "!", spellKey);
 }
@@ -2798,6 +2874,7 @@ function tapNameLetter(bankIdx, letter) {
     var slot = document.getElementById('nameSlot' + nextIdx);
     if (slot) {
       slot.textContent = letter;
+      slot.className = slot.className.replace(' next-slot', '').replace(' next-slot', '');
       slot.className += ' filled';
     }
 
@@ -2814,6 +2891,9 @@ function tapNameLetter(bankIdx, letter) {
         handleCorrectAnswer(todayContent.activities[currentActivityIndex], null);
       }, 500);
     } else {
+      /* Pulse the next empty slot (P2 Fix 8) */
+      var nextSlotEl = document.getElementById('nameSlot' + nameState.progress.length);
+      if (nextSlotEl) { nextSlotEl.className += ' next-slot'; }
       var nextExpected = nameState.target.charAt(nameState.progress.length);
       setTimeout(function() {
         speak("Now find " + nextExpected + "!");


### PR DESCRIPTION
## Summary

Fixes all 10 rendering problems from Issue #166. SparkleLearning.html scored 35/100 on visual QA — these fixes address the 3 activity-breaking P1s, 5 experience-degrading P2s, and 2 polish P3s.

**Files changed:** `SparkleLearning.html` (v15→v16), `AssetRegistry.js` (v2→v3)

---

### P1 — Activity-breaking

- **`resolveAsset()` image-type** — was producing `<img src="">` (blank). Now falls back to emoji (if registry entry has one) or a colored SVG letter-circle. Phase 2 lazy-load never shipped; this makes the fallback safe.
- **`renderColorSort()` bins** — bins were showing text labels ("red", "blue") a 4-year-old cannot read. Now large 100×120px filled color rectangles with thick border, no text. Also fixes `activity.colors` fallback so 3- and 4-bin sorts render all bins correctly.
- **`ASSET_REGISTRY` v3** — added emoji entries for `fish`, `bird/birds`, `dog/dogs`, `cat/cats`, `tree/trees`. Added singular aliases for `flower`, `rainbow`, `gem` so count_with_me object lookups never fall back to generic pink circles.

### P2 — Experience-degrading

- **`renderQuantityMatch()` dots** — replaced `&#9679;` Unicode bullets with 40px SVG orbs (purple fill + white highlight) via new `renderSvgDot()` helper.
- **`renderLetterIntro()` hero** — asset rendered at 120px (was 96px). When `activity.image` is not set, renders the focus letter inside a gradient background circle instead of nothing.
- **Wrong answer feedback** — `.option-btn.wrong` changed from orange/amber + wobble to soft purple `rgba(168,85,247,0.2)` + new `@keyframes gentlePulse`. Feedback text changed from orange to warm pink `#f472b6`. Added 100ms delay before Try Again audio so JJ can process what happened.
- **`renderAudioStory()` timing** — post-story delay 500ms→2000ms. Added 1000ms gap after question audio before reading answer options. The Listen Again button was already present.
- **`renderNameBuilder()` slot cue** — added `@keyframes pulseSlot` + `.name-slot.next-slot` CSS. First empty slot pulses gold on render; pulse shifts to next slot on each correct tap so JJ knows where to place the next letter.

### P3 — Polish

- **`.pattern-mystery`** — solid gold background `rgba(253,230,138,0.25)` + solid border replaces transparent dashed — now visually matches `.pattern-item` dimensions.
- **Font CDN fallback** — added `@font-face` with `local('Fredoka One')` so cached installs skip the CDN round-trip. Added `'Comic Sans MS'` as playful system fallback before `sans-serif` in heading font stacks.

---

## Test plan

- [ ] Gate 1: `audit-source.sh` → **PASS** (0 failures, 0 warnings — confirmed pre-push)
- [ ] Gate 4 — Deploy Manifest (verify features exist post-push to GAS):
  - `grep -n "gentlePulse" SparkleLearning.html` → keyframes + `.option-btn.wrong` usage
  - `grep -n "pulseSlot" SparkleLearning.html` → keyframes + `.name-slot.next-slot`
  - `grep -n "renderSvgDot" SparkleLearning.html` → helper + call in renderQuantityMatch
  - `grep -n "activity.colors" SparkleLearning.html` → bin fallback fix
  - `grep -n "fish\|bird\|dog\|cat\|tree" AssetRegistry.js` → new registry entries
- [ ] Gate 5 — Feature Verification (device QA after GAS deploy):
  - color_sort bins show solid color rectangles, no text
  - letter_intro with image= renders emoji at 120px; without image= renders letter in gradient circle
  - quantity_match dots are purple SVG orbs, not Unicode bullets
  - wrong answer flash is soft purple, not orange
  - name_builder first slot pulses gold; pulse shifts on each correct tap
  - audio_story waits 2s after story before showing question; 1s before reading options
  - pattern "?" placeholder has solid gold background, not dashed outline
  - Fredoka One renders correctly if CDN is unavailable

Closes #166

https://claude.ai/code/session_01X7Au6dAAD87Qoz8rhC7hgP