### PR TITLE
feat(pipeline): close PR orchestration loop — Phase 2/3

### DIFF
--- a/.github/scripts/review-fixer.js
+++ b/.github/scripts/review-fixer.js
@@ -150,13 +150,36 @@ function applyEs6IncludesFix(root, finding) {
   return true;
 }
 
+// ── Phase 2: arrow function fix ─────────────────────────────────────
+// Converts block-body arrow functions inside <script> tags to ES5.
+// Handles: (params) => { and identifier => {
+// Does NOT handle expression arrows (param => expr) — those need return injection.
+function applyEs6ArrowFunctionFix(root, finding) {
+  if (!finding || !finding.file) return false;
+  var filePath = path.join(root, finding.file);
+  if (!fs.existsSync(filePath)) return false;
+  var content = fs.readFileSync(filePath, 'utf8');
+  var original = content;
+  content = content.replace(/<script\b[^>]*>([\s\S]*?)<\/script>/gi, function(fullMatch, body) {
+    // (params_no_nested_parens) => {
+    var fixed = body.replace(/\(([^()]*)\)\s*=>\s*\{/g, 'function($1) {');
+    // single_identifier => {
+    fixed = fixed.replace(/\b([a-zA-Z_$][\w$]*)\s*=>\s*\{/g, 'function($1) {');
+    return fullMatch.replace(body, fixed);
+  });
+  if (content === original) return false;
+  fs.writeFileSync(filePath, content, 'utf8');
+  return true;
+}
+
 const RULES = {
   tbm_ops_errorlog_tab: { needsDeploy: true, apply: applyErrorLogFix },
   tbm_ops_tiller_hours: { needsDeploy: true, apply: applyTillerHoursFix },
   tbm_soul_ticker_special: { needsDeploy: true, apply: applySoulTickerFix },
   es6_let_const: { needsDeploy: true, apply: applyEs6LetConstFix },
   missing_failure_handler: { needsDeploy: true, apply: applyMissingFailureHandlerFix },
-  es6_includes: { needsDeploy: true, apply: applyEs6IncludesFix }
+  es6_includes: { needsDeploy: true, apply: applyEs6IncludesFix },
+  es6_arrow_function: { needsDeploy: true, apply: applyEs6ArrowFunctionFix }
 };
 
 // ── Structured report consumption ───────────────────────────────────
@@ -203,6 +226,9 @@ function classifyFinding(finding) {
     }
     if (combined.indexOf('.includes(') !== -1) {
       return 'es6_includes';
+    }
+    if (combined.indexOf('arrow') !== -1 || combined.indexOf('=>') !== -1) {
+      return 'es6_arrow_function';
     }
   }
   if (combined.indexOf('failurehandler') !== -1 || combined.indexOf('failure handler') !== -1 ||
@@ -498,6 +524,8 @@ async function prepare() {
     hasStructuredReport: !!structuredReport,
     reportFindings: reportFindings
   };
+
+  setOutput('pr_number', String(prNumber));
 
   if (nextCycle >= 4) {
     writeJson(RESULT_PATH, Object.assign({}, base, { status: 'stopped' }));

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -166,7 +166,7 @@ jobs:
         shell: bash
         run: |
           echo "Dispatching codex-pr-review for PR #${PR_NUMBER} after fix push..."
-          curl -sS -X POST \
+          curl -sS --fail-with-body -X POST \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/review-fixer.yml
+++ b/.github/workflows/review-fixer.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: pipeline-review-fixer-${{ github.event.pull_request.number || inputs.pr }}
@@ -156,6 +157,22 @@ jobs:
             git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           fi
           git push origin "HEAD:${HEAD_REF}"
+
+      - name: Retrigger Codex review after fix push
+        if: success() && steps.prepare.outputs.status == 'applied' && steps.prepare.outputs.pr_number != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.PIPELINE_BOT_TOKEN || github.token }}
+          PR_NUMBER: ${{ steps.prepare.outputs.pr_number }}
+        shell: bash
+        run: |
+          echo "Dispatching codex-pr-review for PR #${PR_NUMBER} after fix push..."
+          curl -sS -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/codex-pr-review.yml/dispatches" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"pr\":\"${PR_NUMBER}\"}}"
+          echo "Codex re-review dispatch sent for PR #${PR_NUMBER}."
 
       - name: Finalize review fixes
         if: success() && steps.prepare.outputs.status == 'applied'


### PR DESCRIPTION
## Summary

- **Phase 2 — New mechanical rule:** `es6_arrow_function` added to the RULES map. Converts block-body arrow functions (`(params) => {` and `identifier => {`) inside `<script>` tags to ES5 `function() {}` form. This is the second most common ES5 violation Codex flags, after `let/const`. `classifyFinding()` now maps Codex findings that mention `arrow` or `=>` to this rule automatically.

- **Phase 3 — Loop closure:** After review-fixer pushes a fix commit, a new step dispatches `workflow_dispatch` on `codex-pr-review.yml` for the same PR. This closes the loop unconditionally — regardless of whether `PIPELINE_BOT_TOKEN` retriggers CI via the `synchronize` event. `actions: write` permission added to the job. `pr_number` output added to `prepare()` so the step has the PR number.

## What this closes

Issue #107 — PR Orchestration Loop epic. The loop now runs end-to-end without LT acting as courier:
1. Codex reviews PR → posts structured findings + `pipeline:fix-needed` label
2. Fixer applies mechanical fixes, pushes commit
3. **New:** Fixer dispatches Codex review for the updated commit
4. Codex re-reviews → loop continues until PASS or cycle cap (3)
5. Watcher posts STOPPED + Pushover when cap is reached

## Test plan

- [ ] Merge and verify `codex-pr-review.yml` accepts `workflow_dispatch` with `inputs.pr` on the next PR
- [ ] Confirm review-fixer step "Retrigger Codex review" appears in Actions log after a fix-push cycle
- [ ] Confirm `pr_number` output is non-empty in the Actions step summary
- [ ] Verify `es6_arrow_function` rule fires when Codex flags `=>` in an HTML file (check next review cycle with an arrow-function finding)
- [ ] Verify audit-source.sh PASS (workflow YAML lints clean)

Closes #107

https://claude.ai/code/session_01TX3qfHM5Y2xu932EoipEcB