### PR TITLE
feat: full stack ownership upgrade — 6 skills, 3 engines, Playwright, CF caching

### DIFF
--- a/.claude/commands/audio-pipeline.md
+++ b/.claude/commands/audio-pipeline.md
@@ -1,0 +1,88 @@
+---
+name: audio-pipeline
+description: >
+  Audio asset pipeline for the Thompson education platform. Use when
+  generating, storing, wiring, or debugging audio for JJ (Sparkle) or
+  Buggsy (Wolfkid) education surfaces. Covers ElevenLabs generation,
+  Google Drive storage, Web Speech API fallback, preload behavior, and
+  QA expectations. Trigger on: audio, ElevenLabs, voice, Nia, Marco,
+  speech, TTS, sound, celebration, pronunciation, phoneme, mp3, audio
+  clip, phrases.json.
+---
+
+1. **Cardinal Rule:** "Audio is product behavior for JJ, not decoration. She cannot read. If audio fails, the learning surface is broken. Every JJ-facing flow must have a working audio path with a visible loading state."
+
+2. **Voice Registry:**
+
+| Voice | Character | Child | ElevenLabs Voice ID | Model | Use For |
+|---|---|---|---|---|---|
+| Nia | Sparkle guide | JJ | A2YMjtICNQnO93UAZ8l6 | eleven_v3 | Instructions, feedback, celebrations, letter phrases |
+| Marco | Wolfkid commander | Buggsy | RYPzpPBmugfktRI79EC9 | eleven_v3 | Instructions, feedback |
+| IPA | Phoneme sounds | Both | (same voices) | eleven_flash_v2_5 | Individual letter sounds, phonics |
+
+3. **Audio Source of Truth:**
+   - `phrases.json` (repo root) — master list of all audio clips
+   - `node generate-audio.js` — batch generator (local Node.js)
+   - Google Drive: `Kids & Family/Audio Files/output/jj/` and `/buggsy/`
+   - Drive folder ID (Letters): `1rXWVBD9QMruWOj6AlNB4mY2E9wzWGctm`
+   - Files: A.mp3 through Z.mp3 + celebration clips
+
+4. **Audio Priority Order (JJ):**
+   1. ElevenLabs Nia (pre-generated MP3 from Drive) — ALL instructions, feedback, celebrations
+   2. Web Speech API — ONLY as fallback when ElevenLabs audio hasn't loaded yet
+   3. NEVER mix voices mid-activity. If Nia starts, Nia finishes.
+
+5. **Audio Priority Order (Buggsy):**
+   1. ElevenLabs Marco — instructions and feedback
+   2. Web Speech API — fallback
+   3. Audio is OPTIONAL for Buggsy. He must READ, not listen.
+
+6. **Loading and Playback Rules:**
+   - Show a loading indicator while audio fetches — never silent dead air
+   - Instruction audio plays AFTER visual elements render (not during)
+   - Celebration audio starts WITH confetti, not after
+   - Tap/click sounds: preload at init, play immediately (<50ms)
+   - Audio should not block interaction — play async
+   - Rotate celebration clips (don't play the same one every time)
+
+7. **Web Speech API Constraints:**
+   - Works in: Chrome, Android WebView, Fully Kiosk Browser
+   - Fails on: isolated phonics sounds, custom voices
+   - Never use for raw phoneme sounds — use ElevenLabs IPA model
+   - Configuration: rate 0.9, pitch 1.1 for JJ
+   - Pattern:
+   ```javascript
+   function speak(text, onEnd) {
+     var u = new SpeechSynthesisUtterance(text);
+     u.rate = 0.9; u.pitch = 1.1;
+     if (onEnd) u.onend = onEnd;
+     speechSynthesis.speak(u);
+   }
+   ```
+
+8. **ElevenLabs Clip Delivery:**
+   - GAS function `getAudioClip(filename)` reads from Drive, returns base64
+   - Client plays via: `new Audio('data:audio/mp3;base64,' + data).play()`
+   - Clips are pre-generated, not real-time — latency is Drive read, not generation
+
+9. **Adding New Audio — Workflow:**
+   1. Add entry to `phrases.json` with text, voice, and target path
+   2. Run `node generate-audio.js` locally
+   3. Verify clips in Drive output folder
+   4. Update Notion Audio Clip Queue DB if tracking
+   5. Wire in module: `google.script.run.withSuccessHandler(play).getAudioClip(name)`
+
+10. **QA Expectations:**
+    - Every JJ game type must have instruction audio
+    - No mid-activity voice switching (Nia → robot → Nia)
+    - Correct answer audio fires immediately
+    - Wrong answer audio is gentle, not punishing
+    - Celebration audio at session complete
+    - Loading indicator visible while audio loads
+
+11. **Guardrails:**
+    - Never ship a JJ surface without audio verification
+    - Never use Web Speech API as primary for JJ (it's fallback only)
+    - Never play the same celebration clip twice in a row
+    - Never block user interaction waiting for audio to finish
+    - Never hardcode Drive file IDs in modules — use the GAS audio function

--- a/.claude/commands/data-contracts.md
+++ b/.claude/commands/data-contracts.md
@@ -1,0 +1,144 @@
+---
+name: data-contracts
+description: >
+  Google Sheets data layer contracts for the Thompson platform. Use when
+  building, debugging, or auditing any code that reads from or writes to
+  Google Sheets tabs. Covers TAB_MAP entries, column schemas, ownership rules,
+  downstream consumers, and safe-wrapper patterns. Trigger on: sheet, tab,
+  column, TAB_MAP, data layer, schema, KH_, field name, sheet write, sheet
+  read, data contract, getRange, getValue.
+---
+
+# Data Contracts — Google Sheets Data Layer
+
+## Cardinal Rule
+
+TAB_MAP in DataEngine.gs is the only source of truth for sheet tab names. Never hardcode a sheet name with emoji prefixes. If a tab name is not in TAB_MAP, add it there first.
+
+---
+
+## Core Data Rules
+
+- All sheet access via `SpreadsheetApp.openById(SSID)` — never `getActiveSpreadsheet()`
+- Lock acquisition: `waitLock(30000)` — never `tryLock()`
+- All .gs files share one global scope — TAB_MAP, SSID, and constants from DataEngine.gs are available everywhere
+- Never redeclare shared constants
+
+---
+
+## Tab Registry
+
+| Tab Name (via TAB_MAP) | Owner Module | Writes | Reads | Purpose |
+|---|---|---|---|---|
+| KH_Chores | KidsHub.gs | resetDailyTasksAuto(), completeChore() | KidsHub.html, Parent Dashboard | Daily chore definitions and completion state |
+| KH_History | KidsHub.gs | logHistory_() | ProgressReport.html, Parent Dashboard | Ring/star awards, activity log |
+| KH_Education | KidsHub.gs | logHomeworkCompletion() | ProgressReport.html, EducationAlerts.js | Homework submissions, grades, TEKS tags |
+| KH_LessonRuns | KidsHub.gs | logLessonRun_() | ProgressReport.html | Sparkle/education session tracking |
+| KH_StoryProgress | StoryFactory.gs | (story state) | StoryLibrary.html | Story generation progress |
+| QuestionLog | KidsHub.gs | logQuestion_() | ProgressReport, ContentEngine, EducationAlerts | Per-question accuracy data for trends |
+| Dashboard_Export | DataEngine.gs | (computed) | ThePulse.html, TheVein.html | Financial dashboard data |
+| Debt_Export | DataEngine.gs | (computed) | ThePulse.html | Debt cascade data |
+| DebtModel | DataEngine.gs | (computed) | CascadeEngine.gs | Debt modeling |
+| ErrorLog | GASHardening.gs | logError_() | diagPreQA(), deploy verification | Runtime error tracking |
+| PerfLog | GASHardening.gs | logPerf_() | diagnostics | Performance monitoring |
+| Close History | MonitorEngine.gs | stampCloseMonth_() | MER gates | Month-end review tracking |
+
+---
+
+## Column Schemas (Education-Critical Tabs)
+
+**Important:** These are best-effort from code analysis. The actual columns must be verified by reading the sheet header row. Always grep the actual getRange/getValue calls to verify column positions before writing code against them.
+
+### KH_Education
+
+| Column | Name | Data Type | Written By | Example Value |
+|---|---|---|---|---|
+| A | Timestamp | DateTime | logHomeworkCompletion() | 2026-04-10T08:30:00 |
+| B | Child | String | logHomeworkCompletion() | buggsy |
+| C | Subject | String | logHomeworkCompletion() | math |
+| D | Topic | String | logHomeworkCompletion() | fractions |
+| E | Score | Number | logHomeworkCompletion() | 85 |
+| F | Total | Number | logHomeworkCompletion() | 100 |
+| G | Grade | String | logHomeworkCompletion() | B |
+| H | TEKS | String | logHomeworkCompletion() | 4.3F |
+| I | Source | String | logHomeworkCompletion() | homework |
+
+### QuestionLog
+
+| Column | Name | Data Type | Written By | Example Value |
+|---|---|---|---|---|
+| A | Timestamp | DateTime | logQuestion_() | 2026-04-10T08:31:00 |
+| B | Child | String | logQuestion_() | buggsy |
+| C | Subject | String | logQuestion_() | math |
+| D | Question | String | logQuestion_() | What is 3/4 + 1/2? |
+| E | StudentAnswer | String | logQuestion_() | 5/4 |
+| F | CorrectAnswer | String | logQuestion_() | 5/4 |
+| G | Correct | Boolean | logQuestion_() | TRUE |
+| H | TEKS | String | logQuestion_() | 4.3F |
+| I | SessionId | String | logQuestion_() | abc123 |
+
+### KH_LessonRuns
+
+| Column | Name | Data Type | Written By | Example Value |
+|---|---|---|---|---|
+| A | Timestamp | DateTime | logLessonRun_() | 2026-04-10T08:25:00 |
+| B | Child | String | logLessonRun_() | jj |
+| C | Module | String | logLessonRun_() | sparkle |
+| D | Topic | String | logLessonRun_() | letter-sounds |
+| E | Duration | Number | logLessonRun_() | 420 |
+| F | QuestionsAttempted | Number | logLessonRun_() | 10 |
+| G | QuestionsCorrect | Number | logLessonRun_() | 8 |
+| H | CompletionStatus | String | logLessonRun_() | completed |
+
+---
+
+## Ownership Rules
+
+- Only the Owner Module should write to a tab
+- Cross-module reads are fine — cross-module writes are forbidden
+- If you need to write to a tab you do not own, add a function to the owner module and call that
+- Every write function should use `waitLock(30000)`
+- Every `google.script.run` call must have `withFailureHandler()`
+
+---
+
+## Safe Wrapper Pattern
+
+```javascript
+// Pattern: every public function gets a Safe wrapper
+function doThingSafe(args) {
+  return withMonitor_('doThingSafe', function() {
+    var lock = LockService.getScriptLock();
+    lock.waitLock(30000);
+    try {
+      return doThing_(args);
+    } finally {
+      lock.releaseLock();
+    }
+  });
+}
+```
+
+---
+
+## Downstream Consumer Map
+
+Which surfaces depend on which tabs:
+
+- **ThePulse:** Dashboard_Export, Debt_Export
+- **TheVein:** Dashboard_Export
+- **KidsHub (Buggsy/JJ boards):** KH_Chores, KH_History
+- **Parent Dashboard:** KH_Chores, KH_History, KH_Education
+- **ProgressReport:** KH_Education, KH_History, KH_LessonRuns, QuestionLog
+- **Daily Missions:** KH_Education (completion state)
+- **EducationAlerts:** KH_Education, QuestionLog
+
+---
+
+## Guardrails
+
+- Never write to a sheet tab owned by another module
+- Never use emoji in tab name references — TAB_MAP handles that
+- Always verify column positions by grepping actual code before writing
+- DataEngine.gs is ~4000 lines — always chunk-read (1500 lines at a time)
+- If a new tab is needed, add it to TAB_MAP first, then build the read/write functions

--- a/.claude/commands/grading-review-pipeline.md
+++ b/.claude/commands/grading-review-pipeline.md
@@ -1,0 +1,119 @@
+---
+name: grading-review-pipeline
+description: >
+  End-to-end grading and review workflow for the Thompson education platform.
+  Use when building, debugging, or auditing the path from student submission
+  through auto-grading, Gemini first-pass, parent review, and ring/star award.
+  Covers MC auto-grade, short answer review, CER/ECR rubric scoring, parent
+  approval flow, and award timing. Trigger on: grading, review, auto-grade,
+  Gemini, parent review, pending review, ring award, star award, score,
+  rubric, CER, ECR, approval, grade pipeline.
+---
+
+1. **Cardinal Rule:** "Rings and stars are not awarded until the grading pipeline completes. For MC, that's instant. For open-ended responses, that means Gemini first-pass PLUS parent review. Premature awards break parent trust."
+
+2. **The Pipeline (4 stages):**
+
+```
+Student submits answer
+  → Stage 1: Type Classification
+    MC → auto-grade immediately (correct/incorrect)
+    Short Answer → Stage 2
+    CER (3 sentences) → Stage 2
+    ECR (4 paragraphs) → Stage 2
+  → Stage 2: Gemini First-Pass
+    Sends response + rubric + TEKS code to ContentEngine.gs
+    Returns structured JSON: score, rubricScores, feedback, confidence, suggestedRings, misconception
+    If confidence = "low" → always flag for parent review
+    If confidence = "high" AND score >= 70% → auto-approve with suggested rings
+    If confidence = "medium" → flag for parent review with Gemini's suggestion visible
+  → Stage 3: Parent Review
+    Parent sees: student response, Gemini feedback, suggested score, suggested rings
+    Parent can: approve as-is, adjust score, adjust rings, add notes
+    Parent approval triggers Stage 4
+  → Stage 4: Award
+    Rings/Stars awarded based on final approved score
+    Logged to KH_Education and Notion Homework Tracker
+    Pushover notification to child (optional)
+```
+
+3. **MC Auto-Grade Rules:**
+   - Instant comparison: selected === correct
+   - Feedback via ExecSkills.showFeedback() — green for correct, amber/purple for wrong
+   - Wrong answers tracked for Monday Error Journal
+   - Rings awarded immediately for MC-only modules (no parent gate)
+   - Score logged to KH_Education with TEKS tag
+
+4. **Gemini Grading Contract:**
+   - Function: `gradeResponseWithGemini_()` in ContentEngine.gs
+   - Output schema (strict — must match exactly):
+   ```json
+   {
+     "score": 7,
+     "maxScore": 9,
+     "rubricScores": {"claim": 3, "evidence": 2, "reasoning": 2},
+     "feedback": "Your claim is clear but your evidence needs a specific text reference.",
+     "confidence": "medium",
+     "suggestedRings": 2,
+     "misconception": "Student may be confusing opinion with evidence"
+   }
+   ```
+   - Feedback rules: constructive only, never "wrong" or "incorrect", Wolfkid framing for Buggsy
+   - CER rubric: Claim (1-3), Evidence (1-3), Reasoning (1-3) = max 9
+   - ECR rubric: Intro (1-4), Evidence1 (1-4), Evidence2 (1-4), Conclusion (1-4) = max 16
+
+5. **Ring/Star Economy (from thompson-teacher):**
+
+| Activity | Buggsy Rings | JJ Stars |
+|----------|-------------|----------|
+| Daily module (MC) | 8 | 2 |
+| Perfect sprint | +2 | — |
+| Writing quality (CER/ECR) | +3 | — |
+| Wolfkid Episode | 10-13 | — |
+| Comic Studio | 5 | — |
+| Review quiz 80%+ | +5 | — |
+| Weekly completion | +10 | +3 |
+| SparkleLearn session | — | 2 |
+| Name practice | — | 1 |
+
+   - Award timing: MC rings = immediate. Open-ended rings = after parent approval.
+   - Minimum award: always award SOMETHING for completing the module. Zero rings kills motivation.
+   - Award function: `awardRingsSafe(child, count, source)` in KidsHub.gs
+
+6. **Parent Review Surface:**
+   - Location: Parent Dashboard (/parent) → Education section → Pending Review
+   - Data source: KH_Education rows where Status = 'pending_review'
+   - Also: Notion Homework Tracker via `getPendingReviewsSafe()`
+   - Alert: Pushover after 48h if still pending (via EducationAlerts.js)
+
+7. **Status Flow:**
+```
+submitted → auto-graded (MC) → rings awarded
+submitted → pending_review (open-ended) → parent reviews → approved → remaining rings awarded
+```
+
+8. **Logging Contract:**
+   - KH_Education row: child, subject, assignment, score, teksCode, difficulty, date, status, timeSpent, geminiScore, parentScore, notes
+   - Notion Homework Tracker: mirrors KH_Education with richer metadata
+   - QuestionLog: per-question breakdown for trend analysis
+   - All logging happens exactly ONCE — no double-logging on retry
+
+9. **Error Journal Integration (Monday only):**
+   - After module completion on Monday, if missedQuestions.length > 0:
+   - Show ExecSkills.showErrorJournal() with missed questions
+   - Student picks one, explains WHY they got it wrong
+   - Journal entry logged to Notion with timestamp
+
+10. **Friday Reflection Integration:**
+    - After module completion on Friday:
+    - Show ExecSkills.showFridayReflection()
+    - Two prompts: "What was hardest?" and "What are you proud of?"
+    - Reflection logged to Notion with timestamp
+
+11. **Guardrails:**
+    - Never award rings before the grading pipeline completes
+    - Never show Gemini feedback to the child — it goes to the parent
+    - Never auto-approve low-confidence Gemini grades
+    - Never skip parent review for CER/ECR (even if Gemini is confident)
+    - Never log the same submission twice
+    - Always show the child constructive feedback via ExecSkills, regardless of score

--- a/.claude/commands/incident-response.md
+++ b/.claude/commands/incident-response.md
@@ -1,0 +1,104 @@
+---
+name: incident-response
+description: >
+  Triage and recovery runbook for Thompson platform incidents. Use when
+  deploy proof fails, production tests return errors, routes break,
+  ErrorLog fills up, Pushover alerts fire, the review-fixer stalls, or
+  any system behaves unexpectedly. Trigger on: incident, error, broken,
+  down, alert, ErrorLog, test failed, deploy failed, route broken, blank
+  screen, stalled, rollback, triage, on-call, production issue.
+---
+
+1. **Cardinal Rule:** "Diagnose before you fix. Read the error, check the logs, identify the scope. A rushed fix to the wrong layer makes two incidents out of one."
+
+2. **Severity Classification:**
+
+| Severity | Definition | Response Time | Examples |
+|---|---|---|---|
+| P1 — Down | A primary surface is unreachable or showing wrong data | Immediate | Blank screen on /buggsy, wrong child's data, data loss |
+| P2 — Degraded | A surface works but key features are broken | Same session | Missing audio, broken save/resume, wrong theme |
+| P3 — Cosmetic | Visual or non-blocking issues | Next deploy | Alignment off, wrong animation, stale copy |
+| P4 — Enhancement | Not broken, could be better | Backlog | UX improvement, performance optimization |
+
+3. **Incident Triage Flowchart:**
+```
+Is a surface blank or unreachable?
+  YES → Route issue (check CF → GAS → HTML chain)
+  NO ↓
+Is production test failing?
+  YES → Check ErrorLog (last 5 min), check ?action=runTests output
+  NO ↓
+Is data wrong or stale?
+  YES → Check sheet tab, check cache, check Tiller sync
+  NO ↓
+Is a feature broken post-deploy?
+  YES → Compare deployed version vs expected, check clasp deployments
+  NO ↓
+Is an alert firing?
+  YES → Read the alert, check the source system, verify the threshold
+```
+
+4. **Common Incidents and Playbooks:**
+
+**Deploy proof fails (`?action=runTests` not PASS):**
+1. Read the full JSON response — which tests failed?
+2. Check ErrorLog for new entries in last 5 minutes
+3. If smoke tests fail: likely a function signature change or missing Safe wrapper
+4. If regression tests fail: likely a behavior change in a hot file
+5. Do NOT deploy further. Fix the failing test, re-push, re-run.
+6. If test infrastructure itself is broken: run `diagPreQA()` to isolate
+
+**Blank screen on a route:**
+1. `curl -s -o /dev/null -w "%{http_code}" https://thompsonfams.com/<route>` — is CF returning 200?
+2. If not 200: check CF worker, check PATH_ROUTES, verify `wrangler deploy` was run
+3. If 200 but blank: check GAS router in Code.gs — does the case exist for this page?
+4. If case exists: check the backing HTML file — does it exist? Was it pushed?
+5. Check browser console for JS errors — ES6 in an HTML file will silently break
+
+**ErrorLog filling up:**
+1. Read last 10 entries: what function, what error, what time?
+2. Group by function — is it one function failing repeatedly?
+3. Check if it correlates with a recent deploy
+4. Common causes: missing sheet tab, renamed function, lock timeout, Notion API failure
+5. Fix the source, verify with `diagPreQA()`
+
+**Review-fixer stalled:**
+1. Check PR: how many `[review-fix-N]` commits exist?
+2. If N >= 3: manual intervention required (cycle cap)
+3. Check if `PIPELINE_BOT_TOKEN` is configured — without it, bot pushes don't retrigger CI
+4. Check `review-watcher.yml` — is the workflow enabled?
+5. Check the unresolved threads — are they mechanical (auto-fixable) or architectural (needs human)?
+
+**Pushover alerts not firing:**
+1. Check Script Properties: PUSHOVER_TOKEN, PUSHOVER_USER_LT, PUSHOVER_USER_JT
+2. Run `sendPush_('Test', 'Test message', 'LT', PUSHOVER_PRIORITY.CHORE_APPROVAL)` from GAS editor
+3. If no delivery: check Pushover API status, check token validity
+4. If delivery works but alerts aren't firing: check the trigger function schedule
+
+**Stale Tiller data:**
+1. Check Tiller sync status in the sheet
+2. CF worker HYG-09 cron should alert if data > threshold hours old
+3. If alert didn't fire: check CF worker scheduled() function, check wrangler.toml cron
+4. If Tiller is down: manual bank data entry until sync restores
+
+5. **Post-Incident Checklist:**
+   - [ ] Root cause identified and documented
+   - [ ] Fix deployed and verified
+   - [ ] ErrorLog clean for 30 min post-fix
+   - [ ] Affected surfaces verified at target viewport
+   - [ ] If deploy-related: full deploy proof captured
+   - [ ] Notion thread handoff updated with incident details
+   - [ ] Pushover confirmation that alerts are flowing again (if alert-related)
+
+6. **Rollback Decision:**
+   - Can you fix forward in < 30 minutes? → Fix forward
+   - Is the broken version causing data corruption? → Rollback immediately
+   - Is it a visual-only regression? → Fix forward, mark P3
+   - Rollback method: `clasp deploy -i <previous-deployment-id>` — but you need the previous ID from `clasp deployments` output
+
+7. **Guardrails:**
+   - Never "fix" by deleting ErrorLog entries — they're diagnostic evidence
+   - Never rollback without checking if the old version has its own issues
+   - Never silence a Pushover alert by removing the trigger — fix the source
+   - Never skip post-incident verification — "it stopped erroring" is not "it's fixed"
+   - Always capture evidence before fixing — screenshots, log entries, test output

--- a/.claude/commands/notion-contracts.md
+++ b/.claude/commands/notion-contracts.md
@@ -1,0 +1,166 @@
+---
+name: notion-contracts
+description: >
+  Single source of truth for all Notion database contracts in the Thompson
+  platform. Use when building, debugging, or auditing any code that reads
+  from or writes to Notion databases. Covers field names, data types, status
+  flows, and which modules own which writes. Trigger on: Notion, database,
+  homework tracker, pre-k prep, story factory, notion logging, notion query,
+  page create, page update.
+---
+
+# Notion Database Contracts
+**Single source of truth for every Notion integration in the Thompson platform.**
+
+## Cardinal Rule
+The field name in your code must exactly match the Notion property name. Fetch the page first if you're unsure. A typo silently creates a new property instead of updating the existing one.
+
+---
+
+## Database Registry
+
+| DB Name | DB ID | Owner Module | Write Functions | Read Functions |
+|---------|-------|--------------|-----------------|----------------|
+| Homework Tracker | `9164c6a594b448028426366ff62952b5` | NotionEngine.gs | `logHomeworkToNotion_()`, `updateHomeworkStatus_()` | `queryPendingReviews_()`, ProgressReport.html |
+| Pre-K Prep | `ac28bcfa-e972-428e-812d-f2281df55af9` | NotionEngine.gs | `logSparkleToNotion_()` | ProgressReport.html |
+| Story Factory | `a899ee9786024ece8d09ae8432642b2a` | StoryFactory.gs | (story generation) | StoryLibrary.html |
+| Characters DB | `1225d281b4d44a8094d3c817202f3288` | StoryFactory.gs | (character data) | ComicStudio.html |
+| Canon Log | `d29ae2d2ee614ae0b27f8ccf9ac4dd81` | StoryFactory.gs | (story canon) | StoryReader.html |
+| Audio Clip Queue | `f4fee7eb444f45a5ad80e19e39ce1780` | (manual) | (audio generation queue) | generate-audio.js |
+| Active Versions | `collection://158238c5-...` | (deploy pipeline) | (version tracking) | Session start |
+
+---
+
+## Field Schemas
+
+### Homework Tracker (`9164c6a594b448028426366ff62952b5`)
+
+| Property Name | Notion Type | Valid Values | Written By | Example |
+|---------------|-------------|--------------|------------|---------|
+| Assignment | title | (free text) | `logHomeworkToNotion_()` | `"Math Module W3"` |
+| Subject | select | Math, Science, Reading, Writing, Social Studies | `logHomeworkToNotion_()` | `"Math"` |
+| Status | select | Not Started, In Progress, Done, pending_review, approved, Turned In | `updateHomeworkStatus_()` | `"pending_review"` |
+| Score | number | 0-100 | `updateHomeworkStatus_()` | `85` |
+| Date | date | ISO date string | `logHomeworkToNotion_()` | `"2026-04-10"` |
+| TEKS | rich_text | (TEKS code string) | `logHomeworkToNotion_()` | `"4.3D"` |
+| Difficulty | select | Easy, Medium, Hard | `logHomeworkToNotion_()` | `"Medium"` |
+| Notes | rich_text | (free text) | `logHomeworkToNotion_()` | `"TEKS: 4.3D \| Difficulty: Medium"` |
+| Student | select | Buggsy, JJ | `logHomeworkToNotion_()` | `"Buggsy"` |
+| Module | rich_text | (module identifier) | `logHomeworkToNotion_()` | `"homework-module"` |
+| Duration | number | (minutes) | `updateHomeworkStatus_()` | `15` |
+| Attempts | number | (count) | `updateHomeworkStatus_()` | `2` |
+
+### Pre-K Prep (`ac28bcfa-e972-428e-812d-f2281df55af9`)
+
+| Property Name | Notion Type | Valid Values | Written By | Example |
+|---------------|-------------|--------------|------------|---------|
+| Skill | title | (free text) | `logSparkleToNotion_()` | `"Letter Recognition - B"` |
+| Category | select | Letters, Numbers, Shapes, Colors, Phonics, Motor Skills | `logSparkleToNotion_()` | `"Letters"` |
+| Status | select | Not Introduced, Practicing, Getting It, Mastered | `logSparkleToNotion_()` | `"Practicing"` |
+| Date | date | ISO date string | `logSparkleToNotion_()` | `"2026-04-10"` |
+| Notes | rich_text | (free text) | `logSparkleToNotion_()` | `"Recognized B in name, traced 3x"` |
+| Student | select | JJ | `logSparkleToNotion_()` | `"JJ"` |
+| Confidence | number | 1-5 | `logSparkleToNotion_()` | `3` |
+| Module | rich_text | (module identifier) | `logSparkleToNotion_()` | `"sparkle-learn"` |
+
+---
+
+## Status Flows
+
+### Homework Tracker
+```
+Not Started --> In Progress --> Done --> pending_review --> approved --> Turned In
+```
+- `Not Started`: Assignment created, not yet attempted
+- `In Progress`: Student has started working
+- `Done`: Student submitted answers, auto-scored
+- `pending_review`: Awaiting parent review
+- `approved`: Parent approved the work
+- `Turned In`: Delivered to teacher / final state
+
+### Pre-K Prep
+```
+Not Introduced --> Practicing --> Getting It --> Mastered
+```
+- `Not Introduced`: Skill not yet shown to JJ
+- `Practicing`: Actively working on it, needs support
+- `Getting It`: Shows understanding, occasional errors
+- `Mastered`: Consistent independent success
+
+---
+
+## API Patterns
+
+### Create a Page
+```javascript
+var payload = {
+  parent: { database_id: DB_ID },
+  properties: {
+    // Title property
+    "Assignment": { "title": [{ "text": { "content": "Math Module W3" } }] },
+    // Select property
+    "Status": { "select": { "name": "pending_review" } },
+    // Number property
+    "Score": { "number": 85 },
+    // Date property
+    "Date": { "date": { "start": "2026-04-10" } },
+    // Rich text property
+    "Notes": { "rich_text": [{ "text": { "content": "TEKS: 4.3D | Difficulty: Medium" } }] },
+    // Checkbox property
+    "Reviewed": { "checkbox": true },
+    // URL property
+    "Link": { "url": "https://example.com" }
+  }
+};
+```
+
+### Update a Page
+```javascript
+var payload = {
+  properties: {
+    "Status": { "select": { "name": "approved" } },
+    "Score": { "number": 92 }
+  }
+};
+// PATCH https://api.notion.com/v1/pages/{page_id}
+```
+
+### Property Type Quick Reference
+```javascript
+// Title
+{ "PropName": { "title": [{ "text": { "content": "value" } }] } }
+// Rich text
+{ "PropName": { "rich_text": [{ "text": { "content": "value" } }] } }
+// Select
+{ "PropName": { "select": { "name": "value" } } }
+// Multi-select
+{ "PropName": { "multi_select": [{ "name": "tag1" }, { "name": "tag2" }] } }
+// Number
+{ "PropName": { "number": 42 } }
+// Date
+{ "PropName": { "date": { "start": "2026-04-10" } } }
+// Checkbox
+{ "PropName": { "checkbox": true } }
+// URL
+{ "PropName": { "url": "https://..." } }
+```
+
+---
+
+## Guardrails
+
+1. **Never guess a property name** -- fetch the database schema first if unsure. Use `queryDatabase_()` or the Notion MCP `notion-fetch` tool to inspect properties before writing.
+2. **Never write to a DB you don't own** -- check the Owner column in the Database Registry above. If your module isn't listed as the owner, route through the owning module's API.
+3. **Always use the Safe wrapper** -- never call the Notion API directly from client code. All writes go through `NotionEngine.gs` or `StoryFactory.gs` server-side functions wrapped in `withMonitor_()`.
+4. **MCP table cell updates are unreliable** -- use `NotionEngine.gs` server-side functions instead. If you must use MCP, verify the write succeeded by reading back.
+5. **Test Notion writes in sandbox mode before production** -- use the test database IDs or dry-run flags when available.
+
+---
+
+## Known Issues
+
+1. **MCP table cell updates fail silently** -- the MCP `notion-update-page` tool sometimes reports success but the cell value is unchanged. Always read back after write. Flag for manual edit if the value doesn't stick.
+2. **Notion icon + title update together causes double-emoji bug** -- when updating a page, set the title only. Do not include an icon property in the same PATCH call. Update icon separately if needed.
+3. **old_str/new_str requires EXACT whitespace matching when updating via MCP** -- if you're using MCP tools to edit Notion content blocks, whitespace (including trailing spaces and newlines) must match exactly or the update will silently fail.
+4. **Select values are case-sensitive** -- `"pending_review"` is not the same as `"Pending_Review"`. Always match the exact casing from the schema above.
+5. **Date properties require ISO format** -- always use `"YYYY-MM-DD"` format. Notion rejects other date formats silently.

--- a/.claude/commands/route-contracts.md
+++ b/.claude/commands/route-contracts.md
@@ -1,0 +1,107 @@
+---
+name: route-contracts
+description: >
+  Cloudflare Worker route mapping and proxy contracts for the Thompson
+  platform. Use when adding routes, debugging 404s, verifying deploy
+  integrity, or auditing the path from public URL to GAS handler to
+  backing HTML file. Trigger on: route, URL, Cloudflare, proxy, 404,
+  page not found, clean URL, API proxy, worker, thompsonfams.com,
+  route integrity, CF verify.
+---
+
+# Route Contracts — Cloudflare Worker + GAS Router
+
+## Cardinal Rule
+
+A working route requires three things in agreement: a Cloudflare PATH_ROUTES entry, a GAS Code.gs router case, and a backing HTML file. If any one is missing, the route returns a blank page or 404. Always verify all three.
+
+---
+
+## The Three-Layer Route Stack
+
+```
+User -> thompsonfams.com/sparkle
+  -> Cloudflare Worker (PATH_ROUTES['/sparkle'] -> {page: 'sparkle'})
+    -> GAS (servePage -> Code.gs router -> case 'sparkle')
+      -> HTML (SparkleLearning.html)
+```
+
+---
+
+## Complete Route Map
+
+| Public URL | CF Route Key | GAS page= | Backing HTML | Device | Viewport | Access |
+|---|---|---|---|---|---|---|
+| /pulse | /pulse | pulse | ThePulse.html | JT S25 | 412x915 | Finance (PIN) |
+| /vein | /vein | vein | TheVein.html | LT Desktop | 1920x1080 | Finance (PIN) |
+| /parent | /parent | kidshub (view=parent) | KidsHub.html | JT S25 | 412x915 | Parents |
+| /buggsy | /buggsy | kidshub (child=buggsy) | KidsHub.html | A9 Tablet | 1340x800 | Buggsy |
+| /jj | /jj | kidshub (child=jj) | KidsHub.html | A7 Tablet | 1340x800 | JJ |
+| /spine | /spine | spine | TheSpine.html | Fire Stick | 980x551 | Adults |
+| /soul | /soul | soul | TheSoul.html | Fire Stick | 980x551 | Everyone |
+| /daily-missions | /daily-missions | daily-missions | daily-missions.html | Surface Pro | 1368x912 | Buggsy |
+| /daily-adventures | /daily-adventures | daily-missions (child=jj) | daily-missions.html | S10 FE | 1920x1200 | JJ |
+| /sparkle | /sparkle | sparkle | SparkleLearning.html | S10 FE | 1920x1200 | JJ |
+| /sparkle-free | /sparkle-free | sparkle (mode=freeplay) | SparkleLearning.html | S10 FE | 1920x1200 | JJ |
+| /homework | /homework | homework | HomeworkModule.html | Surface Pro | 1368x912 | Buggsy |
+| /wolfkid | /wolfkid | wolfkid | WolfkidCER.html | Surface Pro | 1368x912 | Buggsy |
+| /reading | /reading | reading | reading-module.html | Surface Pro | 1368x912 | Buggsy |
+| /writing | /writing | writing | writing-module.html | Surface Pro | 1368x912 | Buggsy |
+| /facts | /facts | facts | fact-sprint.html | Surface Pro | 1368x912 | Buggsy |
+| /investigation | /investigation | investigation | investigation-module.html | Surface Pro | 1368x912 | Buggsy |
+| /baseline | /baseline | baseline | BaselineDiagnostic.html | Surface Pro | 1368x912 | Both |
+| /progress | /progress | progress | ProgressReport.html | JT S25 | 412x915 | Parents |
+| /comic-studio | /comic-studio | comic-studio | ComicStudio.html | Surface Pro | 1368x912 | Buggsy |
+| /story-library | /story-library | story-library | StoryLibrary.html | Any | Responsive | Everyone |
+| /story | /story | story | StoryReader.html | Any | Responsive | Everyone |
+| /vault | /vault | vault | Vault.html | LT Desktop | 1920x1080 | LT |
+| /dashboard | /dashboard | wolfdome | DesignDashboard.html | LT Desktop | 1920x1080 | LT |
+| /power-scan | /power-scan | power-scan | (TBD) | Surface Pro | 1368x912 | Buggsy |
+
+---
+
+## API Proxy Contract
+
+- POST to `/api?fn=FUNCTION_NAME` -> proxied to GAS google.script.run
+- GET `/api/verify-pin` -> PIN verification for finance surfaces
+- Finance surfaces (/pulse, /vein) require cookie auth via PIN gate
+- All other surfaces are open access via Cloudflare proxy
+
+---
+
+## Adding a New Route -- Checklist
+
+1. Add entry to PATH_ROUTES in `cloudflare-worker.js`
+2. Add case to Code.gs router (`serveHtml_` or `servePage` handler)
+3. Create backing HTML file
+4. Add route to CLAUDE.md route tables (CF routes + File Map)
+5. Add viewport entry to Device Viewport Map in CLAUDE.md
+6. Add to Playwright screenshot spec if visual regression is needed
+7. Deploy CF worker: `wrangler deploy`
+8. Verify: `curl -s -o /dev/null -w "%{http_code}" https://thompsonfams.com/newroute`
+
+---
+
+## Caching Rules
+
+- `/soul` and `/spine`: cached 60s at CF edge (ambient, auto-refresh)
+- All other routes: no-cache (dynamic content)
+- `/api`: never cached
+
+---
+
+## Route Integrity Verification
+
+- `audit-source.sh` includes route integrity check
+- CF worker routes -> GAS routes -> backing HTML files must all align
+- Post-deploy: curl all routes, expect 200
+- Any mismatch = P1 bug
+
+---
+
+## Guardrails
+
+- Never add a CF route without a matching GAS case
+- Never rename an HTML file without updating the GAS router
+- Never deploy CF worker changes without verifying all routes return 200
+- The route map is the contract — if it is not in the table, it does not exist

--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -147,6 +147,18 @@ SYSTEM_PROMPT = (
     "9. Error logging not using logError_() pattern\n"
     "10. Sheet-writing functions missing waitLock()\n\n"
 
+    "EDUCATION MODULE RULES (apply when .html education files are changed):\n"
+    "11. ExecSkills wiring: education modules must call ExecSkills.showPlanYourAttack() "
+    "before questions start, ExecSkills.showCompletion() at end. Check for presence.\n"
+    "12. Wrong-answer color: must use soft purple (#a855f7) or amber (#fbbf24), "
+    "NEVER red (#EF4444, #ff4444, rgb(239,68,68)). Flag any red in wrong-answer CSS.\n"
+    "13. Timer direction: homework/education timers must count UP (elapsed time), "
+    "not countdown, unless it is explicitly a speed game (fact-sprint).\n"
+    "14. TEKS tagging: generated questions should include TEKS code tags like [TEKS 4.3D]. "
+    "Flag education content without TEKS references if the module is TEKS-aligned.\n"
+    "15. Ring/Star award: verify awardRings/awardStars calls have a withFailureHandler. "
+    "Award calls without error handling silently lose earned rewards.\n\n"
+
     "DATA FLOW TRACING (critical — this catches real bugs):\n"
     "- Trace newly introduced values from source to sink. If a variable is set\n"
     "  in one place and consumed in another, verify the value is valid at both.\n"

--- a/ContentEngine.js
+++ b/ContentEngine.js
@@ -1,0 +1,597 @@
+// ════════════════════════════════════════════════════════════════════════════
+// ContentEngine.gs — Gemini-powered grading + content generation
+// READS FROM: 💻 QuestionLog (via SSID + TAB_MAP)
+// DEPENDENCIES: SSID, TAB_MAP, logError_, withMonitor_ (GASHardening.gs)
+// DO NOT redeclare var TAB_MAP in this file.
+// ════════════════════════════════════════════════════════════════════════════
+
+function getContentEngineVersion() { return 1; }
+
+// ════════════════════════════════════════════════════════════════════════════
+// SECTION 1: Gemini API Wrapper
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Reads GEMINI_API_KEY from Script Properties.
+ * @return {string} The API key
+ * @private
+ */
+function getGeminiKey_() {
+  var key = PropertiesService.getScriptProperties().getProperty('GEMINI_API_KEY');
+  if (!key) throw new Error('GEMINI_API_KEY not set in Script Properties');
+  return key;
+}
+
+/**
+ * Calls Gemini API with retry logic (1 retry on 429/500 with 2s delay).
+ * @param {string} prompt - The prompt text
+ * @param {Object} [options] - Optional settings
+ * @param {number} [options.temperature=0.3] - Temperature for generation
+ * @param {number} [options.maxOutputTokens=2048] - Max output tokens
+ * @param {string} [options.systemInstruction] - System instruction text
+ * @return {Object} Parsed JSON response from Gemini
+ * @private
+ */
+function callGemini_(prompt, options) {
+  var opts = options || {};
+  var temperature = typeof opts.temperature === 'number' ? opts.temperature : 0.3;
+  var maxOutputTokens = opts.maxOutputTokens || 2048;
+  var apiKey = getGeminiKey_();
+  var url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=' + apiKey;
+
+  var payload = {
+    contents: [{ parts: [{ text: prompt }] }],
+    generationConfig: {
+      temperature: temperature,
+      maxOutputTokens: maxOutputTokens
+    }
+  };
+
+  if (opts.systemInstruction) {
+    payload.systemInstruction = {
+      parts: [{ text: opts.systemInstruction }]
+    };
+  }
+
+  var fetchOpts = {
+    method: 'post',
+    contentType: 'application/json',
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
+  };
+
+  var maxAttempts = 2;
+  for (var attempt = 0; attempt < maxAttempts; attempt++) {
+    var resp = UrlFetchApp.fetch(url, fetchOpts);
+    var code = resp.getResponseCode();
+
+    if (code === 200) {
+      var json = JSON.parse(resp.getContentText());
+      if (json.candidates && json.candidates[0] && json.candidates[0].content) {
+        return json;
+      }
+      throw new Error('Gemini returned no candidates: ' + resp.getContentText().substring(0, 300));
+    }
+
+    // Retry on 429 (rate limit) or 500 (server error), but only once
+    if ((code === 429 || code >= 500) && attempt < maxAttempts - 1) {
+      Utilities.sleep(2000);
+      continue;
+    }
+
+    throw new Error('Gemini API error ' + code + ': ' + resp.getContentText().substring(0, 300));
+  }
+}
+
+/**
+ * Extracts text content from a Gemini response object.
+ * @param {Object} geminiResponse - Parsed Gemini API response
+ * @return {string} The text content
+ * @private
+ */
+function extractGeminiText_(geminiResponse) {
+  return geminiResponse.candidates[0].content.parts[0].text;
+}
+
+/**
+ * Extracts text from Gemini response and parses as JSON.
+ * Strips markdown code fences if present.
+ * @param {Object} geminiResponse - Parsed Gemini API response
+ * @return {Object} Parsed JSON object
+ * @private
+ */
+function extractGeminiJSON_(geminiResponse) {
+  var text = extractGeminiText_(geminiResponse);
+  // Strip markdown code fences (```json ... ``` or ``` ... ```)
+  text = text.replace(/^```(?:json)?\s*\n?/i, '').replace(/\n?```\s*$/i, '').trim();
+  return JSON.parse(text);
+}
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// SECTION 2: Grading (Structured Output)
+// ════════════════════════════════════════════════════════════════════════════
+
+var CER_RUBRIC_TEMPLATE = [
+  'CER Rubric (Claim / Evidence / Reasoning):',
+  '  Claim (1-3): 1 = no claim or off-topic, 2 = partial claim, 3 = clear accurate claim',
+  '  Evidence (1-3): 1 = no evidence cited, 2 = partial/vague evidence, 3 = specific relevant evidence',
+  '  Reasoning (1-3): 1 = no reasoning connecting evidence to claim, 2 = partial reasoning, 3 = clear logical reasoning'
+].join('\n');
+
+var ECR_RUBRIC_TEMPLATE = [
+  'ECR Rubric (Extended Constructed Response):',
+  '  Introduction (1-4): 1 = missing, 2 = weak, 3 = adequate, 4 = strong thesis',
+  '  Evidence 1 (1-4): 1 = missing, 2 = weak/irrelevant, 3 = adequate, 4 = strong text evidence',
+  '  Evidence 2 (1-4): 1 = missing, 2 = weak/irrelevant, 3 = adequate, 4 = strong text evidence',
+  '  Conclusion (1-4): 1 = missing, 2 = weak, 3 = restates, 4 = synthesizes and extends'
+].join('\n');
+
+var GRADING_SYSTEM_PROMPT = [
+  'You are Wolfkid, a friendly and encouraging learning coach for Buggsy, a 4th grade student.',
+  'Your job is to grade student responses using a structured rubric and provide constructive, growth-oriented feedback.',
+  '',
+  'CRITICAL RULES:',
+  '- NEVER use the words "wrong", "incorrect", "bad", or "failure".',
+  '- Frame ALL feedback positively: what was good, what could be even better.',
+  '- Use encouraging language: "Great start!", "You\'re on the right track!", "Next time try..."',
+  '- If the student clearly misunderstood the question, identify the likely misconception.',
+  '- If your confidence in the grade is "low", include a note that this should be reviewed by a parent.',
+  '- Keep feedback under 100 words. Be specific, not generic.',
+  '',
+  'You MUST respond with ONLY valid JSON matching this exact schema (no markdown, no explanation):',
+  '{',
+  '  "score": <number - total score>,',
+  '  "maxScore": <number - maximum possible score>,',
+  '  "rubricScores": { "<component>": <number>, ... },',
+  '  "feedback": "<string - constructive, never punitive>",',
+  '  "confidence": "high|medium|low",',
+  '  "suggestedRings": <number - 0 to 5 rings based on quality>,',
+  '  "misconception": "<string or null - what the student likely misunderstood>"',
+  '}'
+].join('\n');
+
+/**
+ * Grades a student response using Gemini with structured JSON output.
+ * @param {string} studentResponse - The student's written response
+ * @param {string} rubric - The rubric text (CER or ECR)
+ * @param {string} teksCode - The TEKS standard code
+ * @param {string} questionText - The original question
+ * @return {Object} Grading result matching the schema
+ * @private
+ */
+function gradeResponseWithGemini_(studentResponse, rubric, teksCode, questionText) {
+  var prompt = [
+    'Grade the following student response using the rubric provided.',
+    '',
+    'TEKS Standard: ' + (teksCode || 'N/A'),
+    'Question: ' + (questionText || 'N/A'),
+    '',
+    rubric,
+    '',
+    'Student Response:',
+    '"""',
+    studentResponse || '(no response provided)',
+    '"""',
+    '',
+    'Return ONLY the JSON grading object. No other text.'
+  ].join('\n');
+
+  var resp = callGemini_(prompt, {
+    temperature: 0.2,
+    maxOutputTokens: 1024,
+    systemInstruction: GRADING_SYSTEM_PROMPT
+  });
+
+  var result = extractGeminiJSON_(resp);
+
+  // Validate required fields
+  if (typeof result.score !== 'number') throw new Error('Grading result missing score');
+  if (typeof result.maxScore !== 'number') throw new Error('Grading result missing maxScore');
+  if (!result.feedback) throw new Error('Grading result missing feedback');
+  if (!result.confidence) result.confidence = 'medium';
+  if (typeof result.suggestedRings !== 'number') result.suggestedRings = 0;
+  if (!result.rubricScores) result.rubricScores = {};
+
+  return result;
+}
+
+/**
+ * Safe wrapper: Grade a CER (Claim/Evidence/Reasoning) response.
+ * @param {string} studentResponse - The student's response text
+ * @param {string} questionText - The original question
+ * @param {string} teksCode - The TEKS standard code
+ * @return {Object} Grading result
+ */
+function gradeCERSafe(studentResponse, questionText, teksCode) {
+  return withMonitor_('gradeCERSafe', function() {
+    return gradeResponseWithGemini_(studentResponse, CER_RUBRIC_TEMPLATE, teksCode, questionText);
+  });
+}
+
+/**
+ * Safe wrapper: Grade an ECR (Extended Constructed Response).
+ * @param {string} studentResponse - The student's response text
+ * @param {string} questionText - The original question
+ * @param {string} teksCode - The TEKS standard code
+ * @return {Object} Grading result
+ */
+function gradeECRSafe(studentResponse, questionText, teksCode) {
+  return withMonitor_('gradeECRSafe', function() {
+    return gradeResponseWithGemini_(studentResponse, ECR_RUBRIC_TEMPLATE, teksCode, questionText);
+  });
+}
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// SECTION 3: Content Generation
+// ════════════════════════════════════════════════════════════════════════════
+
+var FACT_SPRINT_SYSTEM_PROMPT = [
+  'You are an expert Texas education content creator specializing in TEKS-aligned assessment items.',
+  '',
+  'RULES:',
+  '- Every question MUST align to the specified TEKS standard.',
+  '- All 4 answer options must be plausible. No joke answers.',
+  '- No trick questions or intentionally misleading wording.',
+  '- Distractors should reflect common student misconceptions.',
+  '- Use grade-appropriate vocabulary and sentence structure.',
+  '- correctIndex is 0-based (0 = first option).',
+  '',
+  'Return ONLY a valid JSON array. No markdown, no explanation.'
+].join('\n');
+
+/**
+ * Generates multiple-choice fact sprint questions using Gemini.
+ * @param {string} subject - Subject area (e.g., "Math", "Science")
+ * @param {string} teksCode - TEKS standard code
+ * @param {number} [count=20] - Number of questions to generate
+ * @param {string} [difficulty="medium"] - Difficulty level: easy, medium, hard
+ * @return {Array<Object>} Array of question objects
+ * @private
+ */
+function generateFactSprintQuestions_(subject, teksCode, count, difficulty) {
+  count = count || 20;
+  difficulty = difficulty || 'medium';
+
+  var prompt = [
+    'Generate exactly ' + count + ' multiple-choice questions for a 4th grade ' + subject + ' fact sprint.',
+    '',
+    'TEKS Standard: ' + teksCode,
+    'Difficulty: ' + difficulty,
+    '',
+    'Return a JSON array where each element has this exact structure:',
+    '{',
+    '  "question": "<question text>",',
+    '  "options": ["<option A>", "<option B>", "<option C>", "<option D>"],',
+    '  "correctIndex": <0-3>,',
+    '  "teksCode": "' + teksCode + '",',
+    '  "difficulty": "' + difficulty + '",',
+    '  "type": "MC"',
+    '}',
+    '',
+    'Return ONLY the JSON array.'
+  ].join('\n');
+
+  var resp = callGemini_(prompt, {
+    temperature: 0.7,
+    maxOutputTokens: 4096,
+    systemInstruction: FACT_SPRINT_SYSTEM_PROMPT
+  });
+
+  var questions = extractGeminiJSON_(resp);
+
+  if (!Array.isArray(questions)) throw new Error('generateFactSprintQuestions_: expected array, got ' + typeof questions);
+  // Validate each question
+  for (var i = 0; i < questions.length; i++) {
+    var q = questions[i];
+    if (!q.question || !Array.isArray(q.options) || q.options.length !== 4 || typeof q.correctIndex !== 'number') {
+      throw new Error('generateFactSprintQuestions_: invalid question at index ' + i);
+    }
+    q.teksCode = teksCode;
+    q.difficulty = difficulty;
+    q.type = 'MC';
+  }
+
+  return questions;
+}
+
+/**
+ * Generates comprehension questions from a passage at specified DOK levels.
+ * @param {string} passage - The reading passage
+ * @param {number} [count=5] - Number of questions to generate
+ * @param {Array<number>} [dokLevels=[1,2,3]] - DOK levels to target
+ * @return {Array<Object>} Array of question objects
+ * @private
+ */
+function generateComprehensionQuestions_(passage, count, dokLevels) {
+  count = count || 5;
+  dokLevels = dokLevels || [1, 2, 3];
+
+  var prompt = [
+    'Read the following passage and generate exactly ' + count + ' comprehension questions.',
+    'Distribute questions across DOK levels: ' + dokLevels.join(', ') + '.',
+    '',
+    'Passage:',
+    '"""',
+    passage,
+    '"""',
+    '',
+    'Return a JSON array where each element has this exact structure:',
+    '{',
+    '  "question": "<question text>",',
+    '  "options": ["<option A>", "<option B>", "<option C>", "<option D>"],',
+    '  "correctIndex": <0-3>,',
+    '  "teksCode": "<inferred TEKS code or empty string>",',
+    '  "dok": <DOK level 1-4>,',
+    '  "type": "MC"',
+    '}',
+    '',
+    'Return ONLY the JSON array.'
+  ].join('\n');
+
+  var systemPrompt = [
+    'You are an expert reading comprehension assessment creator for 4th grade students.',
+    'DOK 1 = Recall, DOK 2 = Skill/Concept, DOK 3 = Strategic Thinking, DOK 4 = Extended Thinking.',
+    'All distractors must be plausible. No trick questions.',
+    'Return ONLY valid JSON. No markdown, no explanation.'
+  ].join('\n');
+
+  var resp = callGemini_(prompt, {
+    temperature: 0.5,
+    maxOutputTokens: 4096,
+    systemInstruction: systemPrompt
+  });
+
+  var questions = extractGeminiJSON_(resp);
+  if (!Array.isArray(questions)) throw new Error('generateComprehensionQuestions_: expected array');
+
+  for (var i = 0; i < questions.length; i++) {
+    var q = questions[i];
+    if (!q.question || !Array.isArray(q.options) || q.options.length !== 4) {
+      throw new Error('generateComprehensionQuestions_: invalid question at index ' + i);
+    }
+    q.type = 'MC';
+  }
+
+  return questions;
+}
+
+/**
+ * Generates plausible distractors for a correct answer.
+ * @param {string} correctAnswer - The correct answer
+ * @param {string} subject - Subject area
+ * @param {number} [count=3] - Number of distractors to generate
+ * @return {Array<string>} Array of distractor strings
+ * @private
+ */
+function generateDistractors_(correctAnswer, subject, count) {
+  count = count || 3;
+
+  var prompt = [
+    'The correct answer to a 4th grade ' + subject + ' question is: "' + correctAnswer + '"',
+    '',
+    'Generate exactly ' + count + ' plausible but incorrect answers (distractors).',
+    'Each distractor should reflect a common student misconception or calculation error.',
+    'Do NOT include the correct answer.',
+    '',
+    'Return ONLY a JSON array of strings. No markdown, no explanation.',
+    'Example: ["distractor1", "distractor2", "distractor3"]'
+  ].join('\n');
+
+  var resp = callGemini_(prompt, {
+    temperature: 0.6,
+    maxOutputTokens: 512
+  });
+
+  var distractors = extractGeminiJSON_(resp);
+  if (!Array.isArray(distractors)) throw new Error('generateDistractors_: expected array');
+  return distractors;
+}
+
+/**
+ * Generates grade-appropriate context sentences for vocabulary/spelling words.
+ * @param {Array<string>} words - Array of spelling/vocab words
+ * @param {number} [gradeLevel=4] - Grade level for age-appropriate sentences
+ * @return {Array<Object>} Array of {word, sentence, definition}
+ * @private
+ */
+function generateVocabSentences_(words, gradeLevel) {
+  gradeLevel = gradeLevel || 4;
+
+  var prompt = [
+    'For each of the following words, provide a grade ' + gradeLevel + '-appropriate context sentence and a short definition.',
+    '',
+    'Words: ' + JSON.stringify(words),
+    '',
+    'Return a JSON array where each element has this exact structure:',
+    '{',
+    '  "word": "<the word>",',
+    '  "sentence": "<a context sentence using the word>",',
+    '  "definition": "<a grade-appropriate definition>"',
+    '}',
+    '',
+    'Return ONLY the JSON array. No markdown, no explanation.'
+  ].join('\n');
+
+  var resp = callGemini_(prompt, {
+    temperature: 0.4,
+    maxOutputTokens: 2048
+  });
+
+  var results = extractGeminiJSON_(resp);
+  if (!Array.isArray(results)) throw new Error('generateVocabSentences_: expected array');
+  return results;
+}
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// SECTION 4: Adaptive Difficulty / Remediation
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Reads recent QuestionLog performance for a child on a specific TEKS code.
+ * @param {string} child - Child name (e.g., "buggsy")
+ * @param {string} teksCode - The weak TEKS code to analyze
+ * @param {number} [lookbackRows=200] - How many recent rows to scan
+ * @return {Object} Performance summary: {total, correct, pct, recentMisses: string[]}
+ * @private
+ */
+function readQuestionLogPerformance_(child, teksCode, lookbackRows) {
+  lookbackRows = lookbackRows || 200;
+  var ss = SpreadsheetApp.openById(SSID);
+  var tabName = (typeof TAB_MAP !== 'undefined' && TAB_MAP['QuestionLog']) || 'QuestionLog';
+  var sheet = ss.getSheetByName(tabName);
+  if (!sheet) return { total: 0, correct: 0, pct: 0, recentMisses: [] };
+
+  var lastRow = sheet.getLastRow();
+  if (lastRow <= 1) return { total: 0, correct: 0, pct: 0, recentMisses: [] };
+
+  var startRow = Math.max(2, lastRow - lookbackRows + 1);
+  var numRows = lastRow - startRow + 1;
+  // Columns: A=Question_UID, B=Child, C=Date, D=Day_Of_Week, E=Subject, F=TEKS_Code,
+  //          G=Question_Type, H=Distractor_Level, I=Difficulty, J=Correct,
+  //          K=Time_Spent_Seconds, L=Session_Module, M=Timestamp
+  var data = sheet.getRange(startRow, 1, numRows, 13).getValues();
+
+  var total = 0;
+  var correct = 0;
+  var recentMisses = [];
+  var childLower = String(child).toLowerCase();
+
+  for (var i = 0; i < data.length; i++) {
+    var row = data[i];
+    if (String(row[1]).toLowerCase() !== childLower) continue;
+    if (String(row[5]).trim() !== teksCode) continue;
+    total++;
+    if (String(row[9]).toLowerCase() === 'true' || row[9] === true || row[9] === 1) {
+      correct++;
+    } else {
+      // Capture the question UID for missed questions
+      if (recentMisses.length < 10) recentMisses.push(String(row[0]));
+    }
+  }
+
+  return {
+    total: total,
+    correct: correct,
+    pct: total > 0 ? Math.round((correct / total) * 100) : 0,
+    recentMisses: recentMisses
+  };
+}
+
+/**
+ * Generates targeted remediation questions for a child's weak TEKS code.
+ * Analyzes recent QuestionLog performance, then generates DOK 1-2 questions
+ * that address likely misconceptions.
+ * @param {string} child - Child name (e.g., "buggsy")
+ * @param {string} weakTeksCode - The TEKS code to remediate
+ * @param {number} [count=10] - Number of questions to generate
+ * @return {Array<Object>} Array of question objects (same format as fact sprint)
+ * @private
+ */
+function generateRemediationQuestions_(child, weakTeksCode, count) {
+  count = count || 10;
+
+  var perf = readQuestionLogPerformance_(child, weakTeksCode);
+
+  var prompt = [
+    'Generate exactly ' + count + ' remediation questions for a 4th grade student.',
+    '',
+    'TEKS Standard: ' + weakTeksCode,
+    'Student Performance on this standard: ' + perf.correct + '/' + perf.total + ' correct (' + perf.pct + '%)',
+    perf.total > 0
+      ? 'The student has missed ' + (perf.total - perf.correct) + ' questions on this standard recently.'
+      : 'No prior data available — generate foundational questions.',
+    '',
+    'Generate questions at DOK levels 1 and 2 only (recall and skill/concept).',
+    'Focus on building confidence and addressing common misconceptions.',
+    'Start with easier questions and gradually increase difficulty.',
+    '',
+    'Return a JSON array where each element has this exact structure:',
+    '{',
+    '  "question": "<question text>",',
+    '  "options": ["<option A>", "<option B>", "<option C>", "<option D>"],',
+    '  "correctIndex": <0-3>,',
+    '  "teksCode": "' + weakTeksCode + '",',
+    '  "difficulty": "easy|medium",',
+    '  "type": "MC"',
+    '}',
+    '',
+    'Return ONLY the JSON array.'
+  ].join('\n');
+
+  var systemPrompt = [
+    'You are a remediation specialist creating targeted practice for a struggling student.',
+    'Questions should scaffold from simple recall (DOK 1) to basic application (DOK 2).',
+    'All distractors must be plausible and reflect common misconceptions.',
+    'Do NOT include trick questions. The goal is to build confidence and fill gaps.',
+    'Return ONLY valid JSON. No markdown, no explanation.'
+  ].join('\n');
+
+  var resp = callGemini_(prompt, {
+    temperature: 0.5,
+    maxOutputTokens: 4096,
+    systemInstruction: systemPrompt
+  });
+
+  var questions = extractGeminiJSON_(resp);
+  if (!Array.isArray(questions)) throw new Error('generateRemediationQuestions_: expected array');
+
+  for (var i = 0; i < questions.length; i++) {
+    var q = questions[i];
+    if (!q.question || !Array.isArray(q.options) || q.options.length !== 4) {
+      throw new Error('generateRemediationQuestions_: invalid question at index ' + i);
+    }
+    q.teksCode = weakTeksCode;
+    q.type = 'MC';
+  }
+
+  return questions;
+}
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// SAFE WRAPPERS (for google.script.run)
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Safe wrapper: Generate fact sprint questions.
+ * @param {string} subject - Subject area
+ * @param {string} teksCode - TEKS standard code
+ * @param {number} [count=20] - Number of questions
+ * @param {string} [difficulty="medium"] - Difficulty level
+ * @return {Array<Object>} Array of question objects
+ */
+function generateFactSprintSafe(subject, teksCode, count, difficulty) {
+  return withMonitor_('generateFactSprintSafe', function() {
+    return generateFactSprintQuestions_(subject, teksCode, count, difficulty);
+  });
+}
+
+/**
+ * Safe wrapper: Generate comprehension questions from a passage.
+ * @param {string} passage - The reading passage
+ * @param {number} [count=5] - Number of questions
+ * @return {Array<Object>} Array of question objects
+ */
+function generateComprehensionSafe(passage, count) {
+  return withMonitor_('generateComprehensionSafe', function() {
+    return generateComprehensionQuestions_(passage, count);
+  });
+}
+
+/**
+ * Safe wrapper: Grade a short answer response.
+ * Uses CER rubric for short-form grading.
+ * @param {string} studentResponse - The student's response
+ * @param {string} correctAnswer - The expected correct answer (included in question context)
+ * @param {string} teksCode - The TEKS standard code
+ * @return {Object} Grading result
+ */
+function gradeShortAnswerSafe(studentResponse, correctAnswer, teksCode) {
+  return withMonitor_('gradeShortAnswerSafe', function() {
+    var questionText = 'Expected answer: ' + (correctAnswer || 'N/A');
+    return gradeResponseWithGemini_(studentResponse, CER_RUBRIC_TEMPLATE, teksCode, questionText);
+  });
+}

--- a/EducationAlerts.js
+++ b/EducationAlerts.js
@@ -1,0 +1,347 @@
+// Version history tracked in Notion deploy page. Do not add version comments here.
+// ════════════════════════════════════════════════════════════════════
+// EducationAlerts.gs v1 — Education-Specific Pushover Alerts
+// WRITES TO: (Pushover API only — no sheet writes)
+// READS FROM: 🧹📅 KH_Education (via TAB_MAP)
+// DEPENDS ON: AlertEngine (sendPush_, PUSHOVER_PRIORITY), NotionEngine (queryPendingReviews_)
+// ════════════════════════════════════════════════════════════════════
+
+function getEducationAlertsVersion() { return 1; }
+
+// ── HELPERS ─────────────────────────────────────────────────────────
+
+/**
+ * Returns KH_Education data as 2D array (header + rows).
+ * Uses SSID and TAB_MAP from global scope.
+ */
+function _getEducationData_() {
+  const ss = SpreadsheetApp.openById(SSID);
+  const tabName = TAB_MAP['KH_Education'] || 'KH_Education';
+  const sheet = ss.getSheetByName(tabName);
+  if (!sheet || sheet.getLastRow() < 2) return null;
+  return sheet.getDataRange().getValues();
+}
+
+/**
+ * Returns ISO date string (YYYY-MM-DD) for a Date object.
+ */
+function _eduIsoDate_(d) {
+  const m = d.getMonth() + 1;
+  const day = d.getDate();
+  return d.getFullYear() + '-' + (m < 10 ? '0' : '') + m + '-' + (day < 10 ? '0' : '') + day;
+}
+
+/**
+ * Returns ISO date string for N days ago from today.
+ */
+function _daysAgoISO_(n) {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return _eduIsoDate_(d);
+}
+
+/**
+ * Parses a row's timestamp into ISO date string.
+ */
+function _rowToISO_(ts) {
+  if (ts instanceof Date) return _eduIsoDate_(ts);
+  return String(ts || '').slice(0, 10);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION 1: Streak Broken Alert
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Checks if a child's education streak has been broken.
+ * Reads KH_Education for the last 3 days. If they had a streak >= 3 days
+ * and no activity today, fires a Pushover alert.
+ * @param {string} child — 'buggsy' or 'jj'
+ */
+function checkStreakBroken_(child) {
+  const data = _getEducationData_();
+  if (!data || data.length < 2) return;
+
+  const headers = data[0].map(String);
+  const iChild = headers.indexOf('Child');
+  const iTimestamp = headers.indexOf('Timestamp');
+  if (iChild < 0 || iTimestamp < 0) return;
+
+  const childLower = String(child).toLowerCase();
+  const todayISO = _eduIsoDate_(new Date());
+
+  // Collect unique activity dates for this child in the last 30 days
+  const thirtyAgo = _daysAgoISO_(30);
+  const activeDates = {};
+  let hasToday = false;
+
+  for (let i = 1; i < data.length; i++) {
+    if (String(data[i][iChild] || '').toLowerCase() !== childLower) continue;
+    const dateISO = _rowToISO_(data[i][iTimestamp]);
+    if (dateISO < thirtyAgo) continue;
+    activeDates[dateISO] = true;
+    if (dateISO === todayISO) hasToday = true;
+  }
+
+  if (hasToday) return; // Active today — no broken streak
+
+  // Count consecutive days ending yesterday
+  let streakCount = 0;
+  const checkDate = new Date();
+  checkDate.setDate(checkDate.getDate() - 1); // start from yesterday
+
+  for (let d = 0; d < 30; d++) {
+    const iso = _eduIsoDate_(checkDate);
+    if (activeDates[iso]) {
+      streakCount++;
+      checkDate.setDate(checkDate.getDate() - 1);
+    } else {
+      break;
+    }
+  }
+
+  if (streakCount < 3) return; // No meaningful streak to alert about
+
+  const displayName = childLower === 'buggsy' ? 'Buggsy' : 'JJ';
+  const title = "Streak Alert: " + displayName + "'s " + streakCount + "-day streak ended";
+  const message = displayName + " had a " + streakCount + "-day education streak but hasn't completed any activities today. A quick session would restart the streak!";
+
+  sendPush_(title, message, 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION 2: Pending Review Age Alert
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Checks for homework items pending review for more than 48 hours.
+ * Uses queryPendingReviews_() from NotionEngine.
+ */
+function checkPendingReviewAge_() {
+  const items = queryPendingReviews_();
+  if (!items || items.length === 0) return;
+
+  const stale = items.filter(item => item.age_hours > 48);
+  if (stale.length === 0) return;
+
+  const title = stale.length + " homework item" + (stale.length === 1 ? '' : 's') + " pending review > 48h";
+  const lines = stale.map(item =>
+    "- " + item.assignment + " (" + item.subject + ") — " + item.age_hours + "h old"
+  );
+  const message = "The following assignments need parent review:\n" + lines.join("\n");
+
+  sendPush_(title, message, 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION 3: Accuracy Drop Alert
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Checks if a child's accuracy in any subject dropped more than 15%
+ * compared to the previous week. Requires at least 5 questions each week
+ * per subject to fire.
+ * @param {string} child — 'buggsy' or 'jj'
+ */
+function checkAccuracyDrop_(child) {
+  const data = _getEducationData_();
+  if (!data || data.length < 2) return;
+
+  const headers = data[0].map(String);
+  const iChild = headers.indexOf('Child');
+  const iTimestamp = headers.indexOf('Timestamp');
+  const iSubject = headers.indexOf('Subject');
+  const iScore = headers.indexOf('Score');
+  const iAutoGraded = headers.indexOf('AutoGraded');
+  if (iChild < 0 || iTimestamp < 0 || iSubject < 0 || iScore < 0) return;
+
+  const childLower = String(child).toLowerCase();
+  const today = new Date();
+
+  // This week: last 7 days. Last week: days 8-14 ago.
+  const thisWeekStart = _daysAgoISO_(7);
+  const lastWeekStart = _daysAgoISO_(14);
+  const todayISO = _eduIsoDate_(today);
+
+  // Aggregate scores by subject per week
+  // { subjectName: { thisWeek: { sum, count }, lastWeek: { sum, count } } }
+  const subjects = {};
+
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    if (String(row[iChild] || '').toLowerCase() !== childLower) continue;
+
+    // Only count auto-graded rows (objective scores)
+    if (iAutoGraded >= 0 && String(row[iAutoGraded]) !== 'true' && row[iAutoGraded] !== true) continue;
+
+    const dateISO = _rowToISO_(row[iTimestamp]);
+    const subject = String(row[iSubject] || 'General');
+    const score = Number(row[iScore]) || 0;
+
+    if (!subjects[subject]) {
+      subjects[subject] = {
+        thisWeek: { sum: 0, count: 0 },
+        lastWeek: { sum: 0, count: 0 }
+      };
+    }
+
+    if (dateISO >= thisWeekStart && dateISO <= todayISO) {
+      subjects[subject].thisWeek.sum += score;
+      subjects[subject].thisWeek.count++;
+    } else if (dateISO >= lastWeekStart && dateISO < thisWeekStart) {
+      subjects[subject].lastWeek.sum += score;
+      subjects[subject].lastWeek.count++;
+    }
+  }
+
+  // Check each subject for >15% drop with min 5 Qs each week
+  const displayName = childLower === 'buggsy' ? 'Buggsy' : 'JJ';
+
+  for (const subject of Object.keys(subjects)) {
+    const s = subjects[subject];
+    if (s.thisWeek.count < 5 || s.lastWeek.count < 5) continue;
+
+    const thisAvg = s.thisWeek.sum / s.thisWeek.count;
+    const lastAvg = s.lastWeek.sum / s.lastWeek.count;
+
+    if (lastAvg === 0) continue; // avoid division by zero
+    const dropPct = ((lastAvg - thisAvg) / lastAvg) * 100;
+
+    if (dropPct > 15) {
+      const title = "Heads Up: " + displayName + "'s " + subject + " accuracy dropped";
+      const message = displayName + "'s " + subject + " accuracy dropped from " +
+        Math.round(lastAvg) + "% last week to " + Math.round(thisAvg) + "% this week " +
+        "(-" + Math.round(dropPct) + "%). Consider reviewing recent assignments for patterns.";
+
+      sendPush_(title, message, 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL);
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION 4: Weekly Digest
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Sends a weekly education digest summarizing both kids' progress.
+ * Designed to run Sunday 6pm via GAS time trigger.
+ */
+function sendWeeklyDigest_() {
+  const data = _getEducationData_();
+  const weekStart = _daysAgoISO_(7);
+  const todayISO = _eduIsoDate_(new Date());
+
+  const kids = ['buggsy', 'jj'];
+  const summaries = [];
+
+  for (const child of kids) {
+    const displayName = child === 'buggsy' ? 'Buggsy' : 'JJ';
+    let sessions = 0;
+    let scoreSum = 0;
+    let scoreCount = 0;
+    let pendingReview = 0;
+    const activeDays = {};
+
+    if (data && data.length >= 2) {
+      const headers = data[0].map(String);
+      const iChild = headers.indexOf('Child');
+      const iTimestamp = headers.indexOf('Timestamp');
+      const iScore = headers.indexOf('Score');
+      const iAutoGraded = headers.indexOf('AutoGraded');
+      const iStatus = headers.indexOf('Status');
+
+      for (let i = 1; i < data.length; i++) {
+        const row = data[i];
+        if (String(row[iChild] || '').toLowerCase() !== child) continue;
+        const dateISO = _rowToISO_(row[iTimestamp]);
+        if (dateISO < weekStart || dateISO > todayISO) continue;
+
+        sessions++;
+        activeDays[dateISO] = true;
+
+        if (iAutoGraded >= 0 && (String(row[iAutoGraded]) === 'true' || row[iAutoGraded] === true)) {
+          scoreSum += Number(row[iScore]) || 0;
+          scoreCount++;
+        }
+        if (iStatus >= 0 && String(row[iStatus]) === 'pending_review') {
+          pendingReview++;
+        }
+      }
+    }
+
+    const streakDays = Object.keys(activeDays).length;
+    const avgScore = scoreCount > 0 ? Math.round(scoreSum / scoreCount) : 0;
+
+    let line = displayName + ": " + sessions + " sessions, " + streakDays + " active days";
+    if (scoreCount > 0) {
+      line += ", " + avgScore + "% avg accuracy";
+    }
+    if (pendingReview > 0) {
+      line += ", " + pendingReview + " pending review";
+    }
+    summaries.push(line);
+  }
+
+  // Also include Notion pending reviews count
+  let notionPending = 0;
+  try {
+    const pendingItems = queryPendingReviews_();
+    notionPending = pendingItems ? pendingItems.length : 0;
+  } catch (e) {
+    // Notion query failed — note it but don't block the digest
+    summaries.push("(Notion pending review check failed: " + e.message + ")");
+  }
+
+  const title = "Weekly Education Digest";
+  let message = summaries.join("\n");
+  if (notionPending > 0) {
+    message += "\n\nNotion: " + notionPending + " homework item" + (notionPending === 1 ? '' : 's') + " still pending review.";
+  }
+
+  sendPush_(title, message, 'BOTH', PUSHOVER_PRIORITY.HYGIENE_REPORT_LOW);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION 5: Milestone Alert
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Fires a Pushover alert for mastery events / achievements.
+ * @param {string} child — 'buggsy' or 'jj'
+ * @param {string} milestone — description of the achievement
+ */
+function sendMilestoneAlert_(child, milestone) {
+  const displayName = String(child).toLowerCase() === 'buggsy' ? 'Buggsy' : 'JJ';
+  const title = displayName + " Achievement!";
+  const message = String(milestone);
+
+  sendPush_(title, message, 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION 6: Trigger Installation
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Installs the Sunday 6pm trigger for sendWeeklyDigest_.
+ * Run once from Apps Script editor.
+ */
+function installWeeklyDigestTrigger_() {
+  // Remove existing triggers for this function
+  const triggers = ScriptApp.getProjectTriggers();
+  for (const trigger of triggers) {
+    if (trigger.getHandlerFunction() === 'sendWeeklyDigest_') {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  }
+
+  ScriptApp.newTrigger('sendWeeklyDigest_')
+    .timeBased()
+    .onWeekDay(ScriptApp.WeekDay.SUNDAY)
+    .atHour(18)
+    .create();
+
+  Logger.log('Trigger installed: sendWeeklyDigest_() every Sunday ~6 PM');
+}
+
+// EOF — EducationAlerts.gs v1

--- a/NotionEngine.js
+++ b/NotionEngine.js
@@ -1,0 +1,360 @@
+// Version history tracked in Notion deploy page. Do not add version comments here.
+// ════════════════════════════════════════════════════════════════════
+// NotionEngine.gs v1 — Notion API Wrapper for Education Modules
+// WRITES TO: Notion (Homework Tracker, Pre-K Prep, Story Factory)
+// READS FROM: Script Properties (NOTION_TOKEN)
+// ════════════════════════════════════════════════════════════════════
+
+function getNotionEngineVersion() { return 1; }
+
+// ── NOTION DB IDs ───────────────────────────────────────────────────
+const NOTION_DB = {
+  HOMEWORK_TRACKER: '9164c6a594b448028426366ff62952b5',
+  PREK_PREP:        'ac28bcfa-e972-428e-812d-f2281df55af9',
+  STORY_FACTORY:    'a899ee9786024ece8d09ae8432642b2a'
+};
+
+const NOTION_BASE_URL = 'https://api.notion.com/v1';
+const NOTION_VERSION = '2022-06-28';
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION 1: Core API Functions
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Reads NOTION_TOKEN from Script Properties.
+ */
+function getNotionToken_() {
+  const token = PropertiesService.getScriptProperties().getProperty('NOTION_TOKEN');
+  if (!token) {
+    throw new Error('NOTION_TOKEN not set in Script Properties. Go to Project Settings → Script Properties → Add NOTION_TOKEN.');
+  }
+  return token;
+}
+
+/**
+ * Returns standard Notion API headers (auth + version).
+ */
+function notionHeaders_() {
+  return {
+    'Authorization': 'Bearer ' + getNotionToken_(),
+    'Notion-Version': NOTION_VERSION,
+    'Content-Type': 'application/json'
+  };
+}
+
+/**
+ * Creates a new page in a Notion database.
+ * @param {string} dbId — database UUID
+ * @param {object} properties — Notion property schema object
+ * @returns {object} parsed API response
+ */
+function notionCreatePage_(dbId, properties) {
+  const payload = {
+    parent: { database_id: dbId },
+    properties: properties
+  };
+
+  const response = UrlFetchApp.fetch(NOTION_BASE_URL + '/pages', {
+    method: 'post',
+    headers: notionHeaders_(),
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
+  });
+
+  const code = response.getResponseCode();
+  const body = JSON.parse(response.getContentText());
+
+  if (code !== 200 && code !== 201) {
+    throw new Error('Notion createPage failed (' + code + '): ' + JSON.stringify(body));
+  }
+  return body;
+}
+
+/**
+ * Updates an existing Notion page's properties.
+ * @param {string} pageId — page UUID
+ * @param {object} properties — Notion property schema object (partial update)
+ * @returns {object} parsed API response
+ */
+function notionUpdatePage_(pageId, properties) {
+  const response = UrlFetchApp.fetch(NOTION_BASE_URL + '/pages/' + pageId, {
+    method: 'patch',
+    headers: notionHeaders_(),
+    payload: JSON.stringify({ properties: properties }),
+    muteHttpExceptions: true
+  });
+
+  const code = response.getResponseCode();
+  const body = JSON.parse(response.getContentText());
+
+  if (code !== 200) {
+    throw new Error('Notion updatePage failed (' + code + '): ' + JSON.stringify(body));
+  }
+  return body;
+}
+
+/**
+ * Queries a Notion database with optional filter, sorts, and page size.
+ * @param {string} dbId — database UUID
+ * @param {object} [filter] — Notion filter object (omit for all rows)
+ * @param {Array} [sorts] — array of sort objects
+ * @param {number} [pageSize] — results per page (max 100, default 100)
+ * @returns {object} parsed API response with .results array
+ */
+function notionQueryDb_(dbId, filter, sorts, pageSize) {
+  const payload = {};
+  if (filter) payload.filter = filter;
+  if (sorts) payload.sorts = sorts;
+  payload.page_size = pageSize || 100;
+
+  const response = UrlFetchApp.fetch(NOTION_BASE_URL + '/databases/' + dbId + '/query', {
+    method: 'post',
+    headers: notionHeaders_(),
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
+  });
+
+  const code = response.getResponseCode();
+  const body = JSON.parse(response.getContentText());
+
+  if (code !== 200) {
+    throw new Error('Notion queryDb failed (' + code + '): ' + JSON.stringify(body));
+  }
+  return body;
+}
+
+/**
+ * Gets a single Notion page by ID.
+ * @param {string} pageId — page UUID
+ * @returns {object} parsed page object
+ */
+function notionGetPage_(pageId) {
+  const response = UrlFetchApp.fetch(NOTION_BASE_URL + '/pages/' + pageId, {
+    method: 'get',
+    headers: notionHeaders_(),
+    muteHttpExceptions: true
+  });
+
+  const code = response.getResponseCode();
+  const body = JSON.parse(response.getContentText());
+
+  if (code !== 200) {
+    throw new Error('Notion getPage failed (' + code + '): ' + JSON.stringify(body));
+  }
+  return body;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION 2: Education Convenience Functions
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Logs a completed homework assignment to the Homework Tracker DB.
+ * @param {object} data — { assignment, subject, date, status, score, teks, difficulty, timeSpent, notes }
+ * @returns {object} created page
+ */
+function logHomeworkToNotion_(data) {
+  const properties = {
+    'Assignment': {
+      title: [{ text: { content: String(data.assignment || 'Untitled') } }]
+    },
+    'Subject': {
+      select: { name: String(data.subject || 'General') }
+    },
+    'Date': {
+      date: { start: String(data.date || new Date().toISOString().slice(0, 10)) }
+    },
+    'Status': {
+      select: { name: String(data.status || 'auto-graded') }
+    },
+    'Score': {
+      number: Number(data.score) || 0
+    },
+    'TEKS': {
+      rich_text: [{ text: { content: String(data.teks || '') } }]
+    },
+    'Difficulty': {
+      select: { name: String(data.difficulty || 'medium') }
+    },
+    'TimeSpent': {
+      number: Number(data.timeSpent) || 0
+    },
+    'Notes': {
+      rich_text: [{ text: { content: String(data.notes || '') } }]
+    }
+  };
+
+  return notionCreatePage_(NOTION_DB.HOMEWORK_TRACKER, properties);
+}
+
+/**
+ * Updates status, grade, and notes on an existing Homework Tracker page.
+ * @param {string} pageId — Notion page UUID
+ * @param {string} status — new status value (e.g. 'approved', 'needs_revision')
+ * @param {number} grade — updated grade/score
+ * @param {string} notes — parent review notes
+ * @returns {object} updated page
+ */
+function updateHomeworkStatus_(pageId, status, grade, notes) {
+  const properties = {
+    'Status': {
+      select: { name: String(status) }
+    }
+  };
+  if (grade !== undefined && grade !== null) {
+    properties['Score'] = { number: Number(grade) };
+  }
+  if (notes) {
+    properties['Notes'] = {
+      rich_text: [{ text: { content: String(notes) } }]
+    };
+  }
+  return notionUpdatePage_(pageId, properties);
+}
+
+/**
+ * Creates or updates a skill record in the Pre-K Prep DB.
+ * @param {object} data — { skill, category, status, phase, practiceCount, funRating }
+ * @returns {object} created page
+ */
+function logSparkleToNotion_(data) {
+  const properties = {
+    'Skill': {
+      title: [{ text: { content: String(data.skill || 'Unknown Skill') } }]
+    },
+    'Category': {
+      select: { name: String(data.category || 'General') }
+    },
+    'Status': {
+      select: { name: String(data.status || 'practicing') }
+    },
+    'Phase': {
+      select: { name: String(data.phase || 'intro') }
+    },
+    'PracticeCount': {
+      number: Number(data.practiceCount) || 0
+    },
+    'FunRating': {
+      number: Number(data.funRating) || 0
+    }
+  };
+
+  return notionCreatePage_(NOTION_DB.PREK_PREP, properties);
+}
+
+/**
+ * Queries Homework Tracker for assignments with Status = 'pending_review'.
+ * Returns array of { pageId, assignment, subject, date, age_hours }.
+ */
+function queryPendingReviews_() {
+  const filter = {
+    property: 'Status',
+    select: { equals: 'pending_review' }
+  };
+  const sorts = [{ property: 'Date', direction: 'ascending' }];
+
+  const result = notionQueryDb_(NOTION_DB.HOMEWORK_TRACKER, filter, sorts);
+  const now = new Date().getTime();
+  const items = [];
+
+  for (const page of result.results) {
+    const props = page.properties;
+    const assignment = (props['Assignment'] && props['Assignment'].title && props['Assignment'].title.length > 0)
+      ? props['Assignment'].title[0].plain_text
+      : 'Untitled';
+    const subject = (props['Subject'] && props['Subject'].select)
+      ? props['Subject'].select.name
+      : 'Unknown';
+    const dateVal = (props['Date'] && props['Date'].date)
+      ? props['Date'].date.start
+      : null;
+    const ageMs = dateVal ? (now - new Date(dateVal).getTime()) : 0;
+    const ageHours = Math.round(ageMs / 3600000);
+
+    items.push({
+      pageId: page.id,
+      assignment: assignment,
+      subject: subject,
+      date: dateVal,
+      age_hours: ageHours
+    });
+  }
+
+  return items;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION 3: Safe Wrappers (public-facing)
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Safe wrapper for logHomeworkToNotion_. Called by modules via google.script.run.
+ * @param {object} data — homework completion data
+ * @returns {string} JSON result
+ */
+function logHomeworkCompletionSafe(data) {
+  try {
+    const page = logHomeworkToNotion_(data);
+    return JSON.stringify({ status: 'ok', pageId: page.id });
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('logHomeworkCompletionSafe', e);
+    return JSON.stringify({ status: 'error', message: e.message });
+  }
+}
+
+/**
+ * Safe wrapper for logSparkleToNotion_. Called by modules via google.script.run.
+ * @param {object} data — sparkle progress data
+ * @returns {string} JSON result
+ */
+function logSparkleProgressSafe(data) {
+  try {
+    const page = logSparkleToNotion_(data);
+    return JSON.stringify({ status: 'ok', pageId: page.id });
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('logSparkleProgressSafe', e);
+    return JSON.stringify({ status: 'error', message: e.message });
+  }
+}
+
+/**
+ * Safe wrapper for queryPendingReviews_.
+ * @returns {string} JSON array of pending review items
+ */
+function getPendingReviewsSafe() {
+  try {
+    const items = queryPendingReviews_();
+    return JSON.stringify({ status: 'ok', items: items, count: items.length });
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('getPendingReviewsSafe', e);
+    return JSON.stringify({ status: 'error', message: e.message, items: [] });
+  }
+}
+
+/**
+ * Safe wrapper for approving homework: updates Notion status + awards remaining rings.
+ * @param {string} pageId — Notion page UUID
+ * @param {number} grade — final grade
+ * @param {string} notes — parent notes
+ * @returns {string} JSON result
+ */
+function approveHomeworkSafe(pageId, grade, notes) {
+  try {
+    // Update Notion page status to 'approved'
+    updateHomeworkStatus_(pageId, 'approved', grade, notes);
+
+    // Award remaining rings if kh_awardEducationPoints_ is available
+    if (typeof kh_awardEducationPoints_ === 'function') {
+      const ringsForApproval = 5; // standard ring award for parent-approved homework
+      kh_awardEducationPoints_('buggsy', ringsForApproval, 'Homework approved by parent');
+    }
+
+    return JSON.stringify({ status: 'ok', pageId: pageId, approved: true });
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('approveHomeworkSafe', e);
+    return JSON.stringify({ status: 'error', message: e.message });
+  }
+}
+
+// EOF — NotionEngine.gs v1

--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -173,12 +173,21 @@ async function servePage(request, url) {
       html = html.replace('</body>', shim + '\n</body>');
     }
 
-    return new Response(html, {
-      headers: {
-        'Content-Type': 'text/html; charset=utf-8',
-        'Cache-Control': 'no-cache'
-      }
-    });
+    var pageName = params.get('page');
+    var cacheControl = 'no-cache';
+    var headers = {
+      'Content-Type': 'text/html; charset=utf-8'
+    };
+
+    if (pageName === 'soul' || pageName === 'spine') {
+      // Ambient surfaces: cache 60s — they auto-refresh on a client timer
+      cacheControl = 'public, max-age=60';
+      headers['CDN-Cache-Control'] = 'public, max-age=60';
+    }
+
+    headers['Cache-Control'] = cacheControl;
+
+    return new Response(html, { headers: headers });
   } catch(err) {
     return errorPage('Fetch failed: ' + err.message);
   }

--- a/tests/tbm/education-workflows.spec.js
+++ b/tests/tbm/education-workflows.spec.js
@@ -1,0 +1,406 @@
+/**
+ * education-workflows.spec.js — Playwright workflow tests for TBM education surfaces.
+ *
+ * Uses the gas-shim fixture module to intercept /api calls so tests run
+ * deterministically against sandbox data without hitting the real GAS backend.
+ *
+ * ES5-compatible Node.js syntax throughout.
+ */
+
+var test = require('@playwright/test').test;
+var expect = require('@playwright/test').expect;
+var gasShim = require('./fixtures/gas-shim');
+
+var shimGAS = gasShim.shimGAS;
+var clockOverride = gasShim.clockOverride;
+var FIXTURES = gasShim.EDUCATION_FIXTURES;
+
+var BASE_URL = process.env.TBM_BASE_URL || '';
+
+var DEVICES = {
+  s25: { width: 390, height: 844 },
+  a9: { width: 800, height: 1280 },
+  surface_pro: { width: 1368, height: 912 },
+  s10fe: { width: 1920, height: 1200 }
+};
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeEach(function() {
+  test.skip(!BASE_URL, 'Set TBM_BASE_URL to a staging or local deployment before running education workflow tests.');
+});
+
+function collectErrors(page) {
+  var errors = [];
+  page.on('console', function(msg) {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+  page.on('pageerror', function(err) {
+    errors.push(err.message);
+  });
+  return errors;
+}
+
+function filterRealErrors(errors) {
+  return errors.filter(function(e) {
+    return e.indexOf('favicon') === -1 && e.indexOf('net::ERR') === -1;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Homework Module
+// ---------------------------------------------------------------------------
+
+test.describe('Homework: Plan Your Attack → answer flow → completion', function() {
+  test('loads plan-attack screen, starts session, answers a question', async function({ page }) {
+    test.setTimeout(60000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    // Plan Your Attack screen should be visible
+    await expect(page.locator('.es-plan-attack')).toBeVisible({ timeout: 15000 });
+
+    // Click ready button to start session
+    await page.locator('.es-ready-btn').click();
+    await page.waitForTimeout(2000);
+
+    // Session timer should appear
+    await expect(page.locator('.es-session-timer')).toBeVisible({ timeout: 10000 });
+
+    // Answer the first question by clicking the correct option
+    var firstOption = page.locator('.q-option').first();
+    await expect(firstOption).toBeVisible({ timeout: 10000 });
+    await firstOption.click();
+    await page.waitForTimeout(1500);
+
+    // Feedback should be visible after answering
+    var feedback = page.locator('.q-feedback, .es-feedback, [class*="feedback"]').first();
+    await expect(feedback).toBeVisible({ timeout: 5000 });
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});
+
+test.describe('Homework: wrong answer shows purple not red', function() {
+  test('incorrect answer option uses purple (#a855f7), never red', async function({ page }) {
+    test.setTimeout(60000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    // Start the session
+    await page.locator('.es-ready-btn').click();
+    await page.waitForTimeout(2000);
+
+    // Find all options and click a wrong one.
+    // The fixture q1 correct index is 1 (second option), so click the first option (index 0).
+    var options = page.locator('.q-option');
+    await expect(options.first()).toBeVisible({ timeout: 10000 });
+    await options.nth(0).click();
+    await page.waitForTimeout(1500);
+
+    // Check the wrong-answer element's background color
+    var wrongOption = page.locator('.q-option.wrong-answer').first();
+    await expect(wrongOption).toBeVisible({ timeout: 5000 });
+
+    var bgColor = await wrongOption.evaluate(function(el) {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+
+    // Must contain purple (168, 85, 247) — NOT red (239, 68, 68)
+    expect(bgColor).toContain('168, 85, 247');
+    expect(bgColor).not.toContain('239, 68, 68');
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});
+
+test.describe('Homework: brain break fires after 4 answers', function() {
+  test('brain-break overlay appears after answering 4 questions', async function({ page }) {
+    test.setTimeout(90000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    await page.locator('.es-ready-btn').click();
+    await page.waitForTimeout(2000);
+
+    // Answer 4 questions in sequence
+    for (var i = 0; i < 4; i++) {
+      var option = page.locator('.q-option').first();
+      await expect(option).toBeVisible({ timeout: 10000 });
+      await option.click();
+      await page.waitForTimeout(2000);
+
+      // If there is a next-question button, click it
+      var nextBtn = page.locator('.es-next-btn, .q-next, [class*="next"]').first();
+      var hasNext = await nextBtn.isVisible({ timeout: 2000 }).catch(function() { return false; });
+      if (hasNext) {
+        await nextBtn.click();
+        await page.waitForTimeout(1500);
+      }
+    }
+
+    // Brain break overlay should appear
+    await expect(page.locator('#brain-break-overlay')).toBeVisible({ timeout: 10000 });
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});
+
+test.describe('Homework: Monday Error Journal appears', function() {
+  test('error journal renders when clock is set to Monday', async function({ page }) {
+    test.setTimeout(90000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+
+    // Set clock to Monday 2026-04-06 08:00 CT
+    await clockOverride(page, '2026-04-06T08:00:00');
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    // Start and complete the module (answer all 6 questions quickly)
+    await page.locator('.es-ready-btn').click();
+    await page.waitForTimeout(2000);
+
+    for (var i = 0; i < 6; i++) {
+      var option = page.locator('.q-option').first();
+      var optionVisible = await option.isVisible({ timeout: 5000 }).catch(function() { return false; });
+      if (!optionVisible) break;
+      await option.click();
+      await page.waitForTimeout(1500);
+
+      var nextBtn = page.locator('.es-next-btn, .q-next, [class*="next"]').first();
+      var hasNext = await nextBtn.isVisible({ timeout: 2000 }).catch(function() { return false; });
+      if (hasNext) {
+        await nextBtn.click();
+        await page.waitForTimeout(1500);
+      }
+    }
+
+    // Monday Error Journal should appear after completion
+    await expect(page.locator('.es-error-journal')).toBeVisible({ timeout: 15000 });
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});
+
+test.describe('Homework: Friday Reflection appears', function() {
+  test('reflection panel renders when clock is set to Friday', async function({ page }) {
+    test.setTimeout(90000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+
+    // Set clock to Friday 2026-04-10 08:00 CT
+    await clockOverride(page, '2026-04-10T08:00:00');
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    await page.locator('.es-ready-btn').click();
+    await page.waitForTimeout(2000);
+
+    for (var i = 0; i < 6; i++) {
+      var option = page.locator('.q-option').first();
+      var optionVisible = await option.isVisible({ timeout: 5000 }).catch(function() { return false; });
+      if (!optionVisible) break;
+      await option.click();
+      await page.waitForTimeout(1500);
+
+      var nextBtn = page.locator('.es-next-btn, .q-next, [class*="next"]').first();
+      var hasNext = await nextBtn.isVisible({ timeout: 2000 }).catch(function() { return false; });
+      if (hasNext) {
+        await nextBtn.click();
+        await page.waitForTimeout(1500);
+      }
+    }
+
+    // Friday Reflection should appear after completion
+    await expect(page.locator('.es-reflection')).toBeVisible({ timeout: 15000 });
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sparkle Module
+// ---------------------------------------------------------------------------
+
+test.describe('Sparkle: session loads with star counter', function() {
+  test('star counter and activity content are visible on load', async function({ page }) {
+    test.setTimeout(60000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/sparkle', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    // Star counter should be visible
+    var starCounter = page.locator('[class*="star-count"], [class*="starCount"], .star-counter, [id*="star"]').first();
+    await expect(starCounter).toBeVisible({ timeout: 10000 });
+
+    // Some activity content should have loaded
+    var body = await page.locator('body').textContent();
+    expect(body.length).toBeGreaterThan(100);
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});
+
+test.describe('Sparkle: reload preserves star count', function() {
+  test('star count persists across page reload', async function({ page }) {
+    test.setTimeout(90000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/sparkle', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    // Grab current star count text
+    var starCounter = page.locator('[class*="star-count"], [class*="starCount"], .star-counter, [id*="star"]').first();
+    await expect(starCounter).toBeVisible({ timeout: 10000 });
+    var starsBefore = await starCounter.textContent();
+
+    // Reload page (shim is still active on the route)
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    var starCounterAfter = page.locator('[class*="star-count"], [class*="starCount"], .star-counter, [id*="star"]').first();
+    await expect(starCounterAfter).toBeVisible({ timeout: 10000 });
+    var starsAfter = await starCounterAfter.textContent();
+
+    expect(starsAfter).toBe(starsBefore);
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Daily Missions / Adventures
+// ---------------------------------------------------------------------------
+
+test.describe('Daily Missions: JJ gets Sparkle theme', function() {
+  test('/daily-adventures shows Sparkle Kingdom purple gradient', async function({ page }) {
+    test.setTimeout(60000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/daily-adventures', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    // Verify purple gradient background (Sparkle Kingdom theming)
+    var body = page.locator('body');
+    var bgStyle = await body.evaluate(function(el) {
+      var cs = window.getComputedStyle(el);
+      return (cs.background || '') + ' ' + (cs.backgroundImage || '') + ' ' + (cs.backgroundColor || '');
+    });
+
+    // Also check a wrapper/container for the gradient
+    var container = page.locator('[class*="sparkle"], [class*="kingdom"], [class*="adventure"], main, .container').first();
+    var containerBg = '';
+    var containerVisible = await container.isVisible({ timeout: 3000 }).catch(function() { return false; });
+    if (containerVisible) {
+      containerBg = await container.evaluate(function(el) {
+        var cs = window.getComputedStyle(el);
+        return (cs.background || '') + ' ' + (cs.backgroundImage || '') + ' ' + (cs.backgroundColor || '');
+      });
+    }
+
+    var allBg = bgStyle + ' ' + containerBg;
+
+    // Should have purple tones, not dark/grid Wolfdome theme
+    var hasPurple = /purple|#[89a-f][0-9a-f]?[0-9a-f]?[5-9a-f][0-9a-f]?[fF]|128|168.*85.*247|147.*51.*234|rgba?\(\s*1[2-6]\d/i.test(allBg) ||
+                    allBg.indexOf('gradient') !== -1;
+    expect(hasPurple).toBe(true);
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});
+
+test.describe('Daily Missions: Buggsy gets Wolfdome theme', function() {
+  test('/daily-missions shows dark Wolfdome theme elements', async function({ page }) {
+    test.setTimeout(60000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/daily-missions', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    // Look for dark theme indicators (dark background, Wolfdome text, grid patterns)
+    var body = page.locator('body');
+    var bodyBg = await body.evaluate(function(el) {
+      var cs = window.getComputedStyle(el);
+      return cs.backgroundColor || '';
+    });
+
+    var bodyText = await body.textContent();
+
+    // Should have dark theme elements — dark bg or Wolfdome references
+    var hasDark = /rgb\(\s*[0-3]\d\s*,\s*[0-3]\d\s*,\s*[0-5]\d\s*\)/i.test(bodyBg) ||
+                  /wolfdome|wolf|mission/i.test(bodyText.toLowerCase()) ||
+                  bodyBg.indexOf('rgb(0') !== -1;
+    expect(hasDark).toBe(true);
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fact Sprint
+// ---------------------------------------------------------------------------
+
+test.describe('Fact Sprint: timer counts UP not down', function() {
+  test('timer starts at 0:00 and increments upward', async function({ page }) {
+    test.setTimeout(60000);
+    var errors = collectErrors(page);
+    await page.setViewportSize(DEVICES.a9);
+    await shimGAS(page, FIXTURES);
+
+    await page.goto(BASE_URL + '/facts', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    // Start the sprint
+    var startBtn = page.locator('button:has-text("Start"), button:has-text("Go"), .es-ready-btn, .start-btn, [class*="start"]').first();
+    await expect(startBtn).toBeVisible({ timeout: 10000 });
+    await startBtn.click();
+    await page.waitForTimeout(2500);
+
+    // Read the timer value
+    var timer = page.locator('[class*="timer"], [class*="stopwatch"], [id*="timer"], .es-session-timer').first();
+    await expect(timer).toBeVisible({ timeout: 5000 });
+
+    var timerText = await timer.textContent();
+
+    // Timer should show 0:0X format (counting up from 0), e.g. 0:02 or 0:03
+    // It should NOT show a high number counting down (e.g. 4:58, 9:57)
+    var match = timerText.match(/(\d+):(\d+)/);
+    expect(match).not.toBeNull();
+
+    var minutes = parseInt(match[1], 10);
+    var seconds = parseInt(match[2], 10);
+
+    // After ~2.5s the timer should be between 0:01 and 0:10 if counting up
+    expect(minutes).toBe(0);
+    expect(seconds).toBeGreaterThan(0);
+    expect(seconds).toBeLessThan(15);
+
+    expect(filterRealErrors(errors)).toHaveLength(0);
+  });
+});

--- a/tests/tbm/fixtures/gas-shim.js
+++ b/tests/tbm/fixtures/gas-shim.js
@@ -1,0 +1,164 @@
+/**
+ * gas-shim.js — Reusable GAS API shim for Playwright education workflow tests.
+ *
+ * Intercepts /api?fn=FUNCTION_NAME calls and returns fixture data
+ * so tests run deterministically without hitting the real GAS backend.
+ *
+ * ES5-compatible Node.js syntax throughout.
+ */
+
+var EDUCATION_FIXTURES = {
+  getTodayContentSafe: {
+    questions: [
+      {
+        id: 'q1',
+        subject: 'math',
+        teks: '4.4A',
+        stem: 'What is 3/4 + 1/4?',
+        options: ['1/2', '1', '3/8', '2/4'],
+        correctIndex: 1
+      },
+      {
+        id: 'q2',
+        subject: 'math',
+        teks: '4.4B',
+        stem: 'Which fraction is equivalent to 2/6?',
+        options: ['1/3', '1/2', '2/3', '3/6'],
+        correctIndex: 0
+      },
+      {
+        id: 'q3',
+        subject: 'science',
+        teks: '4.8A',
+        stem: 'What causes day and night on Earth?',
+        options: [
+          'Earth orbiting the Sun',
+          'Earth rotating on its axis',
+          'The Moon blocking the Sun',
+          'Clouds covering the sky'
+        ],
+        correctIndex: 1
+      },
+      {
+        id: 'q4',
+        subject: 'math',
+        teks: '4.5A',
+        stem: 'What is 7 x 8?',
+        options: ['54', '56', '48', '64'],
+        correctIndex: 1
+      },
+      {
+        id: 'q5',
+        subject: 'science',
+        teks: '4.9A',
+        stem: 'Which of these is a producer in a food chain?',
+        options: ['Hawk', 'Grass', 'Rabbit', 'Fox'],
+        correctIndex: 1
+      },
+      {
+        id: 'q6',
+        subject: 'math',
+        teks: '4.6A',
+        stem: 'What is the perimeter of a rectangle with length 5 and width 3?',
+        options: ['8', '15', '16', '30'],
+        correctIndex: 2
+      }
+    ]
+  },
+
+  logHomeworkCompletionSafe: { success: true },
+
+  awardRingsSafe: { success: true, newTotal: 42 },
+
+  getChildScheduleSafe: {
+    child: 'buggsy',
+    day: 'Monday',
+    missions: [
+      { id: 'm1', title: 'Homework Sprint', type: 'homework', order: 1, completed: false },
+      { id: 'm2', title: 'Fact Sprint', type: 'facts', order: 2, completed: false },
+      { id: 'm3', title: 'Reading Log', type: 'reading', order: 3, completed: false },
+      { id: 'm4', title: 'Wolfdome Builder', type: 'wolfdome', order: 4, locked: true },
+      { id: 'm5', title: 'Free Choice', type: 'free', order: 5, completed: false }
+    ]
+  },
+
+  getSparkleProgressSafe: {
+    stars: 12,
+    lettersCompleted: ['K', 'I', 'N', 'D']
+  },
+
+  logSparkleProgressSafe: { success: true }
+};
+
+/**
+ * Intercept /api calls and return fixture data based on the `fn` query parameter.
+ *
+ * @param {import('@playwright/test').Page} page  Playwright page object
+ * @param {Object} fixtures  Map of function names to response payloads
+ */
+async function shimGAS(page, fixtures) {
+  await page.route('**/api**', function(route) {
+    var url = route.request().url();
+    var match = url.match(/[?&]fn=([^&]+)/);
+    if (!match) {
+      route.continue();
+      return;
+    }
+
+    var fnName = match[1];
+    if (fixtures.hasOwnProperty(fnName)) {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(fixtures[fnName])
+      });
+    } else {
+      route.continue();
+    }
+  });
+}
+
+/**
+ * Override Date.now() inside the page context so day-specific logic
+ * (Monday Error Journal, Friday Reflection, etc.) triggers deterministically.
+ *
+ * @param {import('@playwright/test').Page} page     Playwright page object
+ * @param {string}                          isoDate  ISO-8601 date string, e.g. '2026-04-06T08:00:00'
+ */
+async function clockOverride(page, isoDate) {
+  var timestamp = new Date(isoDate).getTime();
+  await page.addInitScript(function(ts) {
+    var _OrigDate = Date;
+    var _now = ts;
+    // Override Date.now
+    Date.now = function() { return _now; };
+    // Override new Date() with no args
+    var OriginalDate = _OrigDate;
+    /* eslint-disable no-global-assign */
+    Date = function DateShim(a, b, c, d, e, f, g) {
+      if (arguments.length === 0) {
+        return new OriginalDate(_now);
+      }
+      switch (arguments.length) {
+        case 1: return new OriginalDate(a);
+        case 2: return new OriginalDate(a, b);
+        case 3: return new OriginalDate(a, b, c);
+        case 4: return new OriginalDate(a, b, c, d);
+        case 5: return new OriginalDate(a, b, c, d, e);
+        case 6: return new OriginalDate(a, b, c, d, e, f);
+        default: return new OriginalDate(a, b, c, d, e, f, g);
+      }
+    };
+    Date.now = function() { return _now; };
+    Date.parse = OriginalDate.parse;
+    Date.UTC = OriginalDate.UTC;
+    Date.prototype = OriginalDate.prototype;
+    /* eslint-enable no-global-assign */
+  }, timestamp);
+}
+
+module.exports = {
+  shimGAS: shimGAS,
+  clockOverride: clockOverride,
+  EDUCATION_FIXTURES: EDUCATION_FIXTURES
+};


### PR DESCRIPTION
## Summary

- **3 new GAS engines:** NotionEngine.js (Notion API wrapper), ContentEngine.js (Gemini grading + content generation), EducationAlerts.js (streak/accuracy/digest alerts)
- **6 new skill files:** notion-contracts, data-contracts, route-contracts, grading-review-pipeline, audio-pipeline, incident-response
- **10 new Playwright tests:** education workflow E2E — Plan Your Attack, wrong-answer color (#a855f7), brain break, Error Journal, Friday Reflection, Sparkle star counter, persistence, JJ/Buggsy theme checks, Fact Sprint timer
- **Cloudflare:** 60s Cache-Control for soul/spine ambient routes
- **Codex:** Education domain rules added to PR review prompt (ExecSkills, colors, timers, TEKS, awards)

## Setup Required (manual)
- Configure GAS Script Properties: `NOTION_TOKEN`, `GEMINI_API_KEY`
- Install Sunday digest trigger: run `installWeeklyDigestTrigger_()` from GAS editor

## Still Open
- GitHub PR template CI check (require linked issues)
- GitHub release automation post-merge
- CacheService for education payloads
- Pre-commit hook wiring for audit-source.sh

## Test plan
- [ ] `?action=runTests` returns `overall: PASS`
- [ ] NotionEngine safe wrappers callable from GAS editor without error
- [ ] ContentEngine `gradeResponseWithGemini_()` returns structured JSON schema
- [ ] EducationAlerts `sendWeeklyDigest_()` fires to Pushover
- [ ] Playwright: `npx playwright test tests/tbm/education-workflows.spec.js` — all 10 pass
- [ ] CF routes /soul and /spine return `Cache-Control: public, max-age=60` header
- [ ] Codex review flags wrong-answer color violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)