### PR TITLE
infra: education CacheService, pre-commit hook, PR issue check, release automation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/bash
+# TBM pre-commit hook — runs audit-source.sh before every commit.
+# Install once per clone: git config core.hooksPath .githooks
+# Or run: bash scripts/setup-hooks.sh
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+if [ ! -f "$REPO_ROOT/audit-source.sh" ]; then
+  echo "⚠️  audit-source.sh not found — skipping pre-commit audit"
+  exit 0
+fi
+
+echo "Running TBM pre-commit audit..."
+bash "$REPO_ROOT/audit-source.sh"
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+  echo ""
+  echo "❌ Pre-commit audit FAILED — commit blocked."
+  echo "   Fix the issues above, then re-commit."
+  echo "   To skip (emergency only): git commit --no-verify"
+  exit 1
+fi
+
+exit 0

--- a/.github/workflows/deploy-and-notify.yml
+++ b/.github/workflows/deploy-and-notify.yml
@@ -147,8 +147,8 @@ jobs:
           gh release create "$TAG" \
             --title "TBM ${TAG}" \
             --notes "Deployed from commit ${SHA_SHORT}. Smoke test: PASS." \
-            --target main
-          echo "✅ Release $TAG created."
+            --target "$GITHUB_SHA"
+          echo "✅ Release $TAG created at ${SHA_SHORT}."
 
       - name: Pushover — deploy success
         if: success()

--- a/.github/workflows/deploy-and-notify.yml
+++ b/.github/workflows/deploy-and-notify.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write   # required for gh release create
 
 jobs:
   deploy:
@@ -126,6 +126,29 @@ jobs:
             echo "::error::Structured assertion failed: overall=$OVERALL smoke.overall=$SMOKE_OVERALL"
             exit 1
           fi
+
+      - name: Create GitHub release
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODE_VERSION: ${{ steps.smoke.outputs.code_version }}
+        run: |
+          if [ -z "$CODE_VERSION" ] || [ "$CODE_VERSION" = "?" ]; then
+            echo "Version unknown — skipping release creation."
+            exit 0
+          fi
+          TAG="v${CODE_VERSION}"
+          # Skip if tag already exists (re-run protection)
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping."
+            exit 0
+          fi
+          SHA_SHORT="${GITHUB_SHA:0:7}"
+          gh release create "$TAG" \
+            --title "TBM ${TAG}" \
+            --notes "Deployed from commit ${SHA_SHORT}. Smoke test: PASS." \
+            --target main
+          echo "✅ Release $TAG created."
 
       - name: Pushover — deploy success
         if: success()

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -1,0 +1,65 @@
+# .github/workflows/pr-linked-issue.yml
+# Enforces that every PR body contains a linked issue keyword.
+# Blocks merge if no "Closes #NNN", "Fixes #NNN", or "Resolves #NNN" is found.
+# Exempt: PRs whose title starts with "chore" or "docs" or has the "skip-issue-link" label.
+
+name: PR Linked Issue Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-linked-issue:
+    name: Require linked issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body for linked issue
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          python3 - <<'PYEOF'
+          import os, sys, re, json
+
+          body  = os.environ.get('PR_BODY', '') or ''
+          title = os.environ.get('PR_TITLE', '') or ''
+          labels_raw = os.environ.get('PR_LABELS', '[]')
+
+          try:
+              labels = json.loads(labels_raw)
+          except Exception:
+              labels = []
+
+          # Exempt: skip-issue-link label present
+          if 'skip-issue-link' in labels:
+              print("ℹ️  skip-issue-link label present — check skipped.")
+              sys.exit(0)
+
+          # Exempt: chore or docs PRs (dependency bumps, pure docs)
+          title_lower = title.lower().strip()
+          if title_lower.startswith('chore') or title_lower.startswith('docs'):
+              print("ℹ️  chore/docs PR — issue link not required.")
+              sys.exit(0)
+
+          # Check body for closing keywords
+          pattern = r'(?i)(closes?|fixes?|resolves?)\s+#\d+'
+          if re.search(pattern, body):
+              print("✅ Linked issue found.")
+              sys.exit(0)
+
+          print("❌ No linked issue found in PR body.")
+          print("")
+          print("   Every PR must include a closing keyword, e.g.:")
+          print("     Closes #123")
+          print("     Fixes #42")
+          print("     Resolves #99")
+          print("")
+          print("   If this PR has no Issue (e.g. trivial fix), add the")
+          print("   'skip-issue-link' label to bypass this check.")
+          sys.exit(1)
+          PYEOF

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -7,7 +7,8 @@ name: PR Linked Issue Check
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    # labeled/unlabeled included so adding skip-issue-link label re-runs this check
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
 
 permissions:
   pull-requests: read

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v62 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v63 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 🧹📅 KH_LessonRuns, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 62; }
+function getKidsHubVersion() { return 63; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -3313,10 +3313,19 @@ function _buildChildReport_(child, bounds, histData, eduData, flags) {
 }
 
 
-// v37: getTodayContentSafe — thin wrapper around getTodayContent_
+// v63: getTodayContentSafe — CacheService layer (300s TTL) around getTodayContent_
+// Cache key includes date so stale-day content never bleeds into the next school day.
 function getTodayContentSafe(child) {
   return withMonitor_('getTodayContentSafe', function() {
-    return getTodayContent_(child);
+    var today = getTodayISO_();
+    var cacheKey = 'edu_today_content_' + String(child).toLowerCase() + '_' + today;
+    var cached = (typeof getCachedPayload_ === 'function') ? getCachedPayload_(cacheKey) : null;
+    if (cached !== null) return cached;
+    var result = getTodayContent_(child);
+    if (result !== null && typeof setCachedPayload_ === 'function') {
+      setCachedPayload_(cacheKey, result, 300);
+    }
+    return result;
   });
 }
 
@@ -4900,5 +4909,5 @@ function getComicStudioContextSafe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v62
+// END OF FILE — KidsHub.gs v63
 // ════════════════════════════════════════════════════════════════════

--- a/NotionEngine.js
+++ b/NotionEngine.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// NotionEngine.gs v2 — Notion API Wrapper for Education Modules
+// NotionEngine.gs v3 — Notion API Wrapper for Education Modules
 // WRITES TO: Notion (Homework Tracker, Pre-K Prep, Story Factory)
 // READS FROM: Script Properties (NOTION_TOKEN)
 // ════════════════════════════════════════════════════════════════════
 
-function getNotionEngineVersion() { return 2; }
+function getNotionEngineVersion() { return 3; }
 
 // ── NOTION DB IDs ───────────────────────────────────────────────────
 const NOTION_DB = {
@@ -326,9 +326,19 @@ function notionLogSparkleProgressSafe(data) {
  * @returns {string} JSON array of pending review items
  */
 function getPendingReviewsSafe() {
+  var CACHE_KEY = 'edu_pending_reviews';
+  var CACHE_TTL = 120; // 2 min — Notion API is slow; stale-ish is fine for parent dashboard polling
   try {
-    const items = queryPendingReviews_();
-    return JSON.stringify({ status: 'ok', items: items, count: items.length });
+    if (typeof getCachedPayload_ === 'function') {
+      var cached = getCachedPayload_(CACHE_KEY);
+      if (cached !== null) return JSON.stringify(cached);
+    }
+    var items = queryPendingReviews_();
+    var result = { status: 'ok', items: items, count: items.length };
+    if (typeof setCachedPayload_ === 'function') {
+      setCachedPayload_(CACHE_KEY, result, CACHE_TTL);
+    }
+    return JSON.stringify(result);
   } catch (e) {
     if (typeof logError_ === 'function') logError_('getPendingReviewsSafe', e);
     return JSON.stringify({ status: 'error', message: e.message, items: [] });
@@ -362,4 +372,4 @@ function notionApproveHomeworkSafe(pageId, grade, notes) {
   }
 }
 
-// EOF — NotionEngine.gs v2
+// EOF — NotionEngine.gs v3

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# TBM git hooks setup — run once per clone.
+# Wires .githooks/ as the active hooks directory.
+# Usage: bash scripts/setup-hooks.sh
+
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit
+echo "✅ Git hooks wired: .githooks/pre-commit will run audit-source.sh before every commit."
+echo "   To uninstall: git config --unset core.hooksPath"


### PR DESCRIPTION
Closes #178

## Summary

- **KidsHub v63:** `getTodayContentSafe` adds 300s CacheService layer — cache key `edu_today_content_<child>_<date>` so stale-day content never bleeds
- **NotionEngine v3:** `getPendingReviewsSafe` adds 120s CacheService layer — avoids Notion API hit on every parent dashboard poll
- **Pre-commit hook:** `.githooks/pre-commit` runs `audit-source.sh` before every commit. `scripts/setup-hooks.sh` wires it per clone (`git config core.hooksPath .githooks`)
- **PR linked issue check:** `.github/workflows/pr-linked-issue.yml` — blocks merge if no `Closes/Fixes/Resolves #NNN` in PR body. Exempt: chore/docs titles, `skip-issue-link` label
- **Release automation:** `deploy-and-notify.yml` auto-creates `gh release create vN` after every successful smoke test on merge to main

## Affected workflows
- Parent dashboard `getPendingReviewsSafe` call (cached, faster load)
- Education surfaces `getTodayContentSafe` (cached, sheet read only on cold miss)
- Every git commit now runs pre-commit audit gate
- Every PR now requires a linked issue or explicit bypass label
- Every successful deploy to main now creates a GitHub release

## Write paths affected
None — CacheService reads/writes only. No sheet writes.

## Pre-merge checklist
- [x] `bash audit-source.sh` passes (ran automatically via pre-commit hook)
- [x] Version bumped: KidsHub v62→v63, NotionEngine v2→v3 (all 3 locations each)
- [x] No ES5 changes (server-side .gs only)
- [x] `withFailureHandler()` not applicable (no new google.script.run calls)
- [ ] Smoke test after clasp push

## Note on hot-file lock
This PR touches `.github/workflows/` which is a hot path. PR #177 (full-stack-ownership-upgrade) only touches `.github/scripts/` — no overlap. Both can be in flight.

## Test plan
- [ ] `getTodayContentSafe('buggsy')` — first call reads sheet, second call returns from cache (verify via Logger: no sheet read on second call)
- [ ] `getPendingReviewsSafe()` — first call hits Notion API, second within 120s returns cached
- [ ] `git commit` on a branch with an ES6 violation — commit should be blocked by pre-commit hook
- [ ] Open a test PR without `Closes #NNN` — `pr-linked-issue` check should fail
- [ ] Open a test PR with chore prefix — check should pass without issue link
- [ ] Merge a test change to main — verify GitHub release `vN` is created automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)