### PR TITLE
fix(audio): Nia voice for individual letters + skill enforcement

### DIFF
--- a/SparkleLearning.html
+++ b/SparkleLearning.html
@@ -800,8 +800,8 @@ function autoMatchAudio(text) {
   var traceMatch = t.match(/trace the letter ([a-z])/);
   if (traceMatch) { return 'jj_trace_' + traceMatch[1].toUpperCase() + '.mp3'; }
 
-  // Single letter call: "K!" or just "K"
-  if (t.length <= 2 && t.match(/^[a-z]$/)) {
+  // Single letter call: "K!" or just "K" (case-insensitive — options arrive uppercase)
+  if (t.length <= 2 && t.match(/^[a-zA-Z]$/)) {
     return 'jj_letter_name_' + t.toUpperCase() + '.mp3';
   }
 


### PR DESCRIPTION
## Summary
- **Audio letter matching**: `autoMatchAudio` regex was `^[a-z]$` (lowercase only) but games pass uppercase letters. Changed to `^[a-zA-Z]$`. Individual letter names (M, D, P in Find the Letter) now route to `jj_letter_name_M.mp3` etc. instead of Web Speech API robot voice.
- **CLAUDE.md**: Added Skill Enforcement (MANDATORY) section — every education PR must list and invoke relevant skills before coding.

## Context
- Audio folder ID was fixed in PR #176 (correct Drive folder `1mKRtvjEPzx1L8LNks7QOL3rvH5RvF5tT`)
- 175 JJ + 30 Buggsy clips exist on Drive and load via `getAudioBatchSafe` (verified 200 OK)
- Instruction phrases ("Find the letter D!") played correctly, but individual letter options fell back to robot voice due to case mismatch

Closes #182

## Test plan
- [ ] Play Find the Letter on JJ tablet — individual letters should be Nia's voice, not robot
- [ ] Play Trace Letters — "Trace the letter K" should be Nia
- [ ] No mixed voices mid-activity

Skills used: `/audio-pipeline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)