### PR TITLE
feat(#180): split StoryFactory into phased Write→Illustrate→Assemble pipeline

### DIFF
--- a/StoryFactory.js
+++ b/StoryFactory.js
@@ -3,7 +3,7 @@
 // STORY FACTORY — Google Apps Script Agent
 // WRITES TO: (Notion + Google Drive — no sheet writes)
 // READS FROM: (Notion DBs for character/story data, Script Properties for stored stories)
-// Version: 16.0
+// Version: 16.1
 // Pipeline (phased): Idea→Writing→Written→Illustrating→Illustrated→Assembling→Ready
 //   Phase 1 (Write):     Character Fetch → Memory Inject → Gemini Story → Canon Extract → persist JSON to Drive
 //   Phase 2 (Illustrate): Load story JSON → Gemini Images → persist blobs to Drive folder
@@ -11,7 +11,7 @@
 // Each phase runs in a separate poll cycle — any phase failure is isolated and retried independently.
 // ============================================================
 
-function getStoryFactoryVersion() { return 16.0; }
+function getStoryFactoryVersion() { return 16.1; }
 
 // v30: API cost tracking — returns counts for parent dashboard
 function getStoryApiStats() {
@@ -1135,21 +1135,30 @@ if (extraProps) {
 try {
   notionPatch('pages/' + pageId, payload);
 } catch (e) {
-  // Gracefully drop any optional field not yet in the Notion DB schema, then retry.
-  var errStr = String(e);
+  // Gracefully drop optional fields not in the Notion DB schema. Strips exactly one
+  // field per attempt so multiple unknown fields (e.g. 'Images Saved' AND 'Failed Phase'
+  // both absent) are each removed before the next retry instead of aborting after one pass.
   var OPTIONAL_FIELDS = ['Resume Hint', 'Story Draft URL', 'Images Folder URL', 'Images Saved', 'Failed Phase'];
-  var stripped = false;
-  for (var fi = 0; fi < OPTIONAL_FIELDS.length; fi++) {
-    if (errStr.indexOf(OPTIONAL_FIELDS[fi]) !== -1 && payload.properties[OPTIONAL_FIELDS[fi]]) {
-      delete payload.properties[OPTIONAL_FIELDS[fi]];
-      stripped = true;
+  var lastError = e;
+  for (var attempt = 0; attempt < OPTIONAL_FIELDS.length; attempt++) {
+    var errStr = String(lastError);
+    var stripped = false;
+    for (var fi = 0; fi < OPTIONAL_FIELDS.length; fi++) {
+      if (errStr.indexOf(OPTIONAL_FIELDS[fi]) !== -1 && payload.properties[OPTIONAL_FIELDS[fi]]) {
+        delete payload.properties[OPTIONAL_FIELDS[fi]];
+        stripped = true;
+        break; // One field per attempt — loop will retry
+      }
+    }
+    if (!stripped) throw lastError; // Not an optional-field error — re-throw
+    try {
+      notionPatch('pages/' + pageId, payload);
+      return; // Succeeded after stripping
+    } catch (e2) {
+      lastError = e2; // Another field rejected — continue stripping
     }
   }
-  if (stripped) {
-    notionPatch('pages/' + pageId, payload);
-  } else {
-    throw e;
-  }
+  throw lastError; // All optional fields exhausted — give up
 }
 }
 
@@ -1191,11 +1200,16 @@ function sf_loadStoryDraft_(driveFileUrl) {
 
 // Saves scene image blobs to a per-story Drive folder. Returns { url, count }.
 // Files named 'scene-N.png'. Nulls in imageBlobs array are skipped.
+// Clears any existing files first so that illustration retries don't mix stale
+// scene-N.png files from a prior failed attempt with new ones.
 function sf_saveSceneImages_(pageId, imageBlobs) {
   var draftsFolder = sf_getDraftsFolder_();
   var folderName = 'images-' + pageId;
   var it = draftsFolder.getFoldersByName(folderName);
   var imgFolder = it.hasNext() ? it.next() : draftsFolder.createFolder(folderName);
+  // Trash stale files before writing so retry runs start with a clean folder.
+  var existing = imgFolder.getFiles();
+  while (existing.hasNext()) existing.next().setTrashed(true);
   var saved = 0;
   for (var i = 0; i < imageBlobs.length; i++) {
     if (!imageBlobs[i]) continue;
@@ -1531,6 +1545,43 @@ return { success: false, error: e.message, resumeHint: hint };
 
 // ── POLL NOTION FOR NEW REQUESTS ─────────────────────────────
 
+// ── STALE CLAIM RECOVERY ──────────────────────────────────────
+// Rows stuck in transitional statuses (Writing/Illustrating/Assembling) longer than
+// STALE_CLAIM_MS indicate a GAS crash/timeout mid-phase. This function resets them to
+// the previous stable status so the next poll cycle can safely retry.
+function sf_recoverStaleClaims_() {
+  var STALE_CLAIM_MS = 30 * 60 * 1000; // 30 minutes
+  var staleBefore = new Date(Date.now() - STALE_CLAIM_MS).toISOString();
+  var result = notionPost('databases/' + CONFIG.STORY_DB_ID + '/query', {
+    filter: {
+      and: [
+        {
+          or: [
+            { property: 'Status', select: { equals: 'Writing' } },
+            { property: 'Status', select: { equals: 'Illustrating' } },
+            { property: 'Status', select: { equals: 'Assembling' } }
+          ]
+        },
+        { timestamp: 'last_edited_time', last_edited_time: { before: staleBefore } }
+      ]
+    },
+    page_size: 10
+  });
+  if (!result.results || result.results.length === 0) return;
+  var REVERT_MAP = { 'Writing': 'Idea', 'Illustrating': 'Written', 'Assembling': 'Illustrated' };
+  for (var ri = 0; ri < result.results.length; ri++) {
+    var page = result.results[ri];
+    var stuck = page.properties['Status'] && page.properties['Status'].select
+      ? page.properties['Status'].select.name : null;
+    if (!stuck || !REVERT_MAP[stuck]) continue;
+    var revertTo = REVERT_MAP[stuck];
+    Logger.log('[StaleRecovery] Row ' + page.id + ' stuck in "' + stuck + '" >30 min — reverting to "' + revertTo + '".');
+    updateNotionRow(page.id, null, revertTo,
+      'Auto-recovered from stale "' + stuck + '" claim (GAS crash/timeout). Reverted to "' + revertTo + '" for retry.'
+    );
+  }
+}
+
 // v16: Three-phase poll — handles Idea (Write), Written (Illustrate), Illustrated (Assemble).
 // Phase failures are isolated: only the failing phase is retried on the next poll cycle.
 // Circuit breaker still operates per consecutive-fail count across all phases.
@@ -1570,6 +1621,8 @@ return;
 }
 
 try {
+// Recover any rows stuck in transitional statuses from a prior crash/timeout before polling.
+sf_recoverStaleClaims_();
 Logger.log('Polling for story work (Idea | Written | Illustrated)...');
 // Query all three actionable statuses, oldest first so the queue drains in order.
 var result = notionPost('databases/' + CONFIG.STORY_DB_ID + '/query', {
@@ -2159,5 +2212,5 @@ function sf_getFailureSummary_(days) {
   };
 }
 
-// END OF FILE — StoryFactory v16.0
+// END OF FILE — StoryFactory v16.1
 // ════════════════════════════════════════════════════════════════════

--- a/StoryFactory.js
+++ b/StoryFactory.js
@@ -3,12 +3,15 @@
 // STORY FACTORY — Google Apps Script Agent
 // WRITES TO: (Notion + Google Drive — no sheet writes)
 // READS FROM: (Notion DBs for character/story data, Script Properties for stored stories)
-// Version: 15.5
-// Pipeline: Notion Trigger → Phase 1 (Write) → Phase 2 (Illustrate) → Phase 3 (Assemble)
-// Each phase runs in its own poll cycle to avoid the 6-minute GAS execution limit.
+// Version: 16.0
+// Pipeline (phased): Idea→Writing→Written→Illustrating→Illustrated→Assembling→Ready
+//   Phase 1 (Write):     Character Fetch → Memory Inject → Gemini Story → Canon Extract → persist JSON to Drive
+//   Phase 2 (Illustrate): Load story JSON → Gemini Images → persist blobs to Drive folder
+//   Phase 3 (Assemble):  Load story + images → PDF on Drive → Notion Catalogue Page
+// Each phase runs in a separate poll cycle — any phase failure is isolated and retried independently.
 // ============================================================
 
-function getStoryFactoryVersion() { return 15.5; }
+function getStoryFactoryVersion() { return 16.0; }
 
 // v30: API cost tracking — returns counts for parent dashboard
 function getStoryApiStats() {
@@ -48,8 +51,6 @@ MEMORY_STORY_COUNT: 5,
 MEMORY_CANON_COUNT: 20,
 MIN_IMAGES_REQUIRED: 1, // Throw IMAGE_GATE_FAILED if fewer than this many images succeed (LT can set to 4 for strict mode)
 FAILURE_LOG_SHEET_NAME: 'SF_FailureLog', // v15.2 telemetry: append-only failure log tab in TillerBudgetMaster (set to '' to disable)
-IMAGE_SUBFOLDER_PREFIX: 'sf-images-',
-STORY_DATA_CHUNK_SIZE: 1900,
 };
 
 function sf_logError_(context, error) {
@@ -157,93 +158,6 @@ Logger.log('notionPatch FAILED: ' + endpoint + ' — ' + e.message.substring(0, 
 sf_logError_('notionPatch', e.message);
 return 500;
 }
-}
-
-// ── UPDATE NOTION ROW ────────────────────────────────────────
-
-function updateNotionRow(pageId, storyLink, status, resumeHint) {
-var payload = { properties: { 'Status': { select: { name: status } } } };
-if (storyLink) payload.properties['Story Link'] = { url: storyLink };
-if (resumeHint) {
-  payload.properties['Resume Hint'] = { rich_text: [{ text: { content: String(resumeHint).substring(0, 2000) } }] };
-}
-try {
-  notionPatch('pages/' + pageId, payload);
-} catch (e) {
-  // Resume Hint property may not exist in Notion DB yet — retry without it
-  if (resumeHint && String(e).indexOf('Resume Hint') !== -1) {
-    delete payload.properties['Resume Hint'];
-    notionPatch('pages/' + pageId, payload);
-  } else {
-    throw e;
-  }
-}
-}
-
-// ── STORY DATA PERSISTENCE HELPERS ──────────────────────────
-
-// Serialize storyData to JSON, chunk into 1900-char segments, PATCH to Story Data rich_text field.
-function sf_saveStoryData_(pageId, storyData) {
-  var json = JSON.stringify(storyData);
-  var size = CONFIG.STORY_DATA_CHUNK_SIZE;
-  var chunks = [];
-  for (var i = 0; i < json.length; i += size) {
-    chunks.push(json.substring(i, i + size));
-  }
-
-  var richText = [];
-  for (var c = 0; c < chunks.length; c++) {
-    richText.push({ type: 'text', text: { content: chunks[c] } });
-  }
-
-  notionPatch('pages/' + pageId, {
-    properties: {
-      'Story Data': { rich_text: richText }
-    }
-  });
-  Logger.log('sf_saveStoryData_: saved ' + json.length + ' chars in ' + chunks.length + ' chunk(s)');
-}
-
-// Read Story Data rich_text from page object, rejoin chunks, JSON.parse. Returns null on any failure.
-function sf_loadStoryData_(page) {
-  try {
-    var prop = page && page.properties && page.properties['Story Data'];
-    if (!prop || !prop.rich_text || prop.rich_text.length === 0) {
-      Logger.log('sf_loadStoryData_: Story Data property is empty or missing');
-      return null;
-    }
-    var json = '';
-    for (var i = 0; i < prop.rich_text.length; i++) {
-      json += prop.rich_text[i].plain_text || '';
-    }
-    if (!json) {
-      Logger.log('sf_loadStoryData_: rejoined string is empty');
-      return null;
-    }
-    return JSON.parse(json);
-  } catch(e) {
-    Logger.log('sf_loadStoryData_ FAILED: ' + e.message);
-    return null;
-  }
-}
-
-// Single PATCH: Status=Failed, Failed Phase=phaseName, Resume Hint=hint (first 2000 chars).
-function sf_updateFailedPhase_(pageId, phaseName, hint) {
-  var hintStr = String(hint || '').substring(0, 2000);
-  var payload = {
-    properties: {
-      'Status':       { select: { name: 'Failed' } },
-      'Failed Phase': { rich_text: [{ type: 'text', text: { content: phaseName } }] },
-      'Resume Hint':  { rich_text: [{ type: 'text', text: { content: hintStr } }] }
-    }
-  };
-  try {
-    notionPatch('pages/' + pageId, payload);
-  } catch(e) {
-    // Failed Phase or Resume Hint may not exist yet — fall back to just Status
-    Logger.log('sf_updateFailedPhase_ full PATCH failed, retrying with Status only: ' + e.message);
-    notionPatch('pages/' + pageId, { properties: { 'Status': { select: { name: 'Failed' } } } });
-  }
 }
 
 // ── PHASE 1: CHARACTER TRUTH FROM NOTION ─────────────────────
@@ -1201,6 +1115,243 @@ if (result.object === 'error') throw new Error('Notion error: ' + result.message
 return result.url;
 }
 
+// ── UPDATE NOTION ROW ────────────────────────────────────────
+
+// v16: extraProps — optional map of additional Notion property payloads to write alongside Status.
+// Used by phased pipeline to persist Story Draft URL, Images Folder URL, etc.
+// Any property that doesn't exist in the Notion DB yet is silently dropped on retry.
+function updateNotionRow(pageId, storyLink, status, resumeHint, extraProps) {
+var payload = { properties: { 'Status': { select: { name: status } } } };
+if (storyLink) payload.properties['Story Link'] = { url: storyLink };
+if (resumeHint) {
+  payload.properties['Resume Hint'] = { rich_text: [{ text: { content: String(resumeHint).substring(0, 2000) } }] };
+}
+if (extraProps) {
+  var eKeys = Object.keys(extraProps);
+  for (var ek = 0; ek < eKeys.length; ek++) {
+    payload.properties[eKeys[ek]] = extraProps[eKeys[ek]];
+  }
+}
+try {
+  notionPatch('pages/' + pageId, payload);
+} catch (e) {
+  // Gracefully drop any optional field not yet in the Notion DB schema, then retry.
+  var errStr = String(e);
+  var OPTIONAL_FIELDS = ['Resume Hint', 'Story Draft URL', 'Images Folder URL', 'Images Saved', 'Failed Phase'];
+  var stripped = false;
+  for (var fi = 0; fi < OPTIONAL_FIELDS.length; fi++) {
+    if (errStr.indexOf(OPTIONAL_FIELDS[fi]) !== -1 && payload.properties[OPTIONAL_FIELDS[fi]]) {
+      delete payload.properties[OPTIONAL_FIELDS[fi]];
+      stripped = true;
+    }
+  }
+  if (stripped) {
+    notionPatch('pages/' + pageId, payload);
+  } else {
+    throw e;
+  }
+}
+}
+
+// ── NOTION URL PROPERTY READER ────────────────────────────────
+// Safely reads a url-type Notion property (different shape from rich_text).
+function sf_getNotionUrlProp_(properties, fieldName) {
+  var prop = properties[fieldName];
+  if (!prop) return null;
+  if (prop.type === 'url') return prop.url || null;
+  return null;
+}
+
+// ── DRIVE PERSISTENCE HELPERS (v16: phased pipeline) ─────────
+// All draft files live in a 'story-drafts' subfolder inside CONFIG.STORY_FOLDER_ID.
+
+function sf_getDraftsFolder_() {
+  var storyFolder = DriveApp.getFolderById(CONFIG.STORY_FOLDER_ID);
+  var it = storyFolder.getFoldersByName('story-drafts');
+  return it.hasNext() ? it.next() : storyFolder.createFolder('story-drafts');
+}
+
+// Saves story JSON to Drive. Returns the file URL (stored in Notion 'Story Draft URL').
+function sf_saveStoryDraft_(pageId, storyData) {
+  var folder = sf_getDraftsFolder_();
+  var name = 'draft-' + pageId + '.json';
+  var existing = folder.getFilesByName(name);
+  while (existing.hasNext()) existing.next().setTrashed(true);
+  var blob = Utilities.newBlob(JSON.stringify(storyData), 'application/json', name);
+  var file = folder.createFile(blob);
+  return file.getUrl();
+}
+
+// Loads story JSON from a Drive file URL (from Notion 'Story Draft URL').
+function sf_loadStoryDraft_(driveFileUrl) {
+  var m = driveFileUrl.match(/\/d\/([^\/\?]+)/);
+  if (!m) throw new Error('Cannot extract file ID from URL: ' + driveFileUrl);
+  return JSON.parse(DriveApp.getFileById(m[1]).getBlob().getDataAsString());
+}
+
+// Saves scene image blobs to a per-story Drive folder. Returns { url, count }.
+// Files named 'scene-N.png'. Nulls in imageBlobs array are skipped.
+function sf_saveSceneImages_(pageId, imageBlobs) {
+  var draftsFolder = sf_getDraftsFolder_();
+  var folderName = 'images-' + pageId;
+  var it = draftsFolder.getFoldersByName(folderName);
+  var imgFolder = it.hasNext() ? it.next() : draftsFolder.createFolder(folderName);
+  var saved = 0;
+  for (var i = 0; i < imageBlobs.length; i++) {
+    if (!imageBlobs[i]) continue;
+    imageBlobs[i].setName('scene-' + i + '.png');
+    imgFolder.createFile(imageBlobs[i]);
+    saved++;
+  }
+  return { url: imgFolder.getUrl(), count: saved };
+}
+
+// Loads scene blobs from a Drive folder URL (from Notion 'Images Folder URL').
+// Returns a 6-element array (null where no image was saved for that scene index).
+function sf_loadSceneImages_(folderUrl) {
+  var m = folderUrl.match(/\/folders\/([^\/\?]+)/);
+  if (!m) throw new Error('Cannot extract folder ID from URL: ' + folderUrl);
+  var folder = DriveApp.getFolderById(m[1]);
+  var blobs = [];
+  for (var i = 0; i < 6; i++) blobs.push(null);
+  var files = folder.getFiles();
+  while (files.hasNext()) {
+    var file = files.next();
+    var idx = file.getName().match(/scene-(\d+)/);
+    if (idx) {
+      var n = parseInt(idx[1], 10);
+      if (n >= 0 && n < blobs.length) blobs[n] = file.getBlob();
+    }
+  }
+  return blobs;
+}
+
+// ── PHASE 1: WRITE ────────────────────────────────────────────
+// Generates story text + audit + canon, saves JSON to Drive.
+// Covers the cheapest and most reliable phase — text never gets discarded after this.
+function sf_phaseWrite_(pageId, topic, character, tone) {
+  try {
+    if (!CONFIG.GEMINI_API_KEY) throw new Error('GEMINI_API_KEY not configured.');
+    if (!CONFIG.NOTION_TOKEN) throw new Error('NOTION_TOKEN not configured.');
+    _refImageCache = {};
+    topic = String(topic || '').trim();
+    if (!topic) throw new Error('Story topic is required.');
+    if (topic.length > 500) topic = topic.substring(0, 500);
+
+    Logger.log('[Phase 1: Write] Fetching character from Notion...');
+    var characters = sf_getCharacterFromNotion_(character);
+    if (!characters.length) throw new Error('No active characters found for: ' + character);
+
+    Logger.log('[Phase 1: Write] Fetching story memory...');
+    var recentStories = sf_getRecentStories_(character);
+    var canonFacts = sf_getCanonFacts_(character);
+
+    Logger.log('[Phase 1: Write] Generating story...');
+    var storyData = generateStory(topic, character, tone || 'Funny', characters, recentStories, canonFacts);
+    storyData.topic = topic;
+    if (!storyData.scenes || storyData.scenes.length < 6) {
+      Logger.log('WARN: Only ' + (storyData.scenes ? storyData.scenes.length : 0) + ' scenes — retrying...');
+      storyData = generateStory(topic, character, tone || 'Funny', characters, recentStories, canonFacts);
+      storyData.topic = topic;
+      if (!storyData.scenes || storyData.scenes.length < 6) {
+        throw new Error('Story generation failed: only ' + (storyData.scenes ? storyData.scenes.length : 0) + ' scenes after retry (need 6).');
+      }
+    }
+    for (var v = 0; v < storyData.scenes.length; v++) {
+      if (!storyData.scenes[v].text || storyData.scenes[v].text.trim().length < 20) {
+        Logger.log('WARN: Scene ' + (v + 1) + ' has short/empty text.');
+      }
+    }
+    Logger.log('[Phase 1: Write] Story: "' + storyData.title + '"');
+
+    var audit = auditStoryText_(storyData, character);
+    storyData._audit = audit;
+
+    Logger.log('[Phase 1: Write] Extracting canon...');
+    var canonData = extractCanonFromStory(storyData);
+    // Embed metadata needed by downstream phases so they don't re-fetch from Notion
+    storyData._canon = canonData;
+    storyData._character = character;
+    storyData._tone = tone || 'Funny';
+
+    Logger.log('[Phase 1: Write] Saving story draft to Drive...');
+    var draftUrl = sf_saveStoryDraft_(pageId, storyData);
+    Logger.log('[Phase 1: Write] Draft saved: ' + draftUrl);
+
+    return { success: true, storyDriveUrl: draftUrl, title: storyData.title };
+  } catch (e) {
+    sf_logError_('sf_phaseWrite_', e);
+    return { success: false, error: 'Write phase: ' + e.message };
+  }
+}
+
+// ── PHASE 2: ILLUSTRATE ───────────────────────────────────────
+// Loads story JSON from Drive, generates scene images, saves blobs to Drive folder.
+// Most failure-prone phase — isolated so text is never lost if images fail.
+// On failure: pollForNewStories resets Status to Written so the NEXT poll retries images only.
+function sf_phaseIllustrate_(pageId, storyDriveUrl) {
+  try {
+    Logger.log('[Phase 2: Illustrate] Loading story draft from Drive...');
+    var storyData = sf_loadStoryDraft_(storyDriveUrl);
+    var character = storyData._character || 'JJ';
+    _refImageCache = {};
+
+    Logger.log('[Phase 2: Illustrate] Fetching character data...');
+    var characters = sf_getCharacterFromNotion_(character);
+
+    Logger.log('[Phase 2: Illustrate] Generating scene images...');
+    var imageBlobs = generateSceneImages(storyData.scenes, characters);
+
+    var successCount = 0;
+    for (var i = 0; i < imageBlobs.length; i++) {
+      if (imageBlobs[i]) successCount++;
+    }
+    var minRequired = (CONFIG.MIN_IMAGES_REQUIRED != null) ? CONFIG.MIN_IMAGES_REQUIRED : 1;
+    if (successCount < minRequired) {
+      return { success: false, error: 'IMAGE_GATE_FAILED: ' + successCount + '/' + CONFIG.IMAGE_SCENES.length + ' images generated (min: ' + minRequired + ').' };
+    }
+    Logger.log('[Phase 2: Illustrate] ' + successCount + ' image(s) generated — saving to Drive...');
+
+    var saved = sf_saveSceneImages_(pageId, imageBlobs);
+    Logger.log('[Phase 2: Illustrate] Images folder: ' + saved.url);
+
+    return { success: true, imagesFolderUrl: saved.url, imagesSaved: saved.count };
+  } catch (e) {
+    sf_logError_('sf_phaseIllustrate_', e);
+    return { success: false, error: 'Illustrate phase: ' + e.message };
+  }
+}
+
+// ── PHASE 3: ASSEMBLE ─────────────────────────────────────────
+// Loads story JSON + scene image blobs from Drive, builds PDF, creates Notion catalogue page.
+// Near-zero failure rate since all inputs are already persisted.
+// On failure: pollForNewStories resets Status to Illustrated so NEXT poll retries assembly only.
+function sf_phaseAssemble_(pageId, storyDriveUrl, imagesFolderUrl) {
+  try {
+    Logger.log('[Phase 3: Assemble] Loading story draft from Drive...');
+    var storyData = sf_loadStoryDraft_(storyDriveUrl);
+    var canonData = storyData._canon || {};
+    var tone = storyData._tone || 'Funny';
+
+    Logger.log('[Phase 3: Assemble] Loading scene images from Drive...');
+    var imageBlobs = sf_loadSceneImages_(imagesFolderUrl);
+
+    var bookNumber = getNextBookNumber();
+    Logger.log('[Phase 3: Assemble] Building PDF for Book #' + bookNumber + '...');
+    var pdf = buildStoryPDF(storyData, imageBlobs, bookNumber);
+    Logger.log('[Phase 3: Assemble] PDF: ' + pdf.url);
+
+    Logger.log('[Phase 3: Assemble] Creating Notion catalogue page...');
+    var notionUrl = buildNotionCataloguePage(storyData, pdf.url, bookNumber, canonData, tone);
+    Logger.log('[Phase 3: Assemble] Notion page: ' + notionUrl);
+
+    return { success: true, pdfUrl: pdf.url, notionUrl: notionUrl, title: storyData.title, bookNumber: bookNumber };
+  } catch (e) {
+    sf_logError_('sf_phaseAssemble_', e);
+    return { success: false, error: 'Assemble phase: ' + e.message };
+  }
+}
+
 // ── GET NEXT BOOK NUMBER ─────────────────────────────────────
 
 function getNextBookNumber() {
@@ -1216,373 +1367,15 @@ return (lastNum && lastNum.number ? lastNum.number : 0) + 1;
 return 7;
 }
 
-// ── THREE-PHASE PIPELINE HANDLERS ────────────────────────────
+// ── MAIN PIPELINE ────────────────────────────────────────────
 
-// Phase 1: Write the story. Saves storyData, canonData, bookNumber, tone to Notion page.
-// On success sets Status='Written'. On error sets Status='Failed' and increments SF_CONSECUTIVE_FAILS.
-function sf_runPhase1Write_(pageId, topic, character, tone) {
-  Logger.log('=== Phase 1: Write === pageId=' + pageId);
-  var props = PropertiesService.getScriptProperties();
-
-  try {
-    updateNotionRow(pageId, null, 'Writing');
-
-    // Config validation
-    if (!CONFIG.GEMINI_API_KEY) throw new Error('GEMINI_API_KEY not configured. Set "JJ Stories" in Script Properties.');
-    if (!CONFIG.NOTION_TOKEN) throw new Error('NOTION_TOKEN not configured. Set "NOTION_TOKEN" in Script Properties.');
-
-    // Clear ref image cache from any prior execution on this instance
-    _refImageCache = {};
-
-    // Input validation
-    if (!topic || String(topic).trim().length === 0) throw new Error('Story topic is required.');
-    if (String(topic).length > 500) topic = String(topic).substring(0, 500);
-    topic = String(topic).trim();
-
-    // Fetch character truth
-    Logger.log('Fetching character data from Notion...');
-    var characters = sf_getCharacterFromNotion_(character);
-    if (characters.length === 0) throw new Error('No active characters found in Notion for: ' + character);
-
-    // Fetch story memory
-    Logger.log('Fetching story memory...');
-    var recentStories = sf_getRecentStories_(character);
-    var canonFacts = sf_getCanonFacts_(character);
-
-    // Generate story
-    Logger.log('Generating story...');
-    var storyData = generateStory(topic, character, tone || 'Funny', characters, recentStories, canonFacts);
-    storyData.topic = topic;
-
-    // Validate scene count — retry once if under 6 scenes
-    if (!storyData.scenes || storyData.scenes.length < 6) {
-      Logger.log('WARN: Only ' + (storyData.scenes ? storyData.scenes.length : 0) + ' scenes returned. Retrying...');
-      storyData = generateStory(topic, character, tone || 'Funny', characters, recentStories, canonFacts);
-      storyData.topic = topic;
-      if (!storyData.scenes || storyData.scenes.length < 6) {
-        throw new Error('Story generation failed: only ' + (storyData.scenes ? storyData.scenes.length : 0) + ' scenes after retry (need 6).');
-      }
-    }
-
-    // Validate scene text content
-    for (var v = 0; v < storyData.scenes.length; v++) {
-      if (!storyData.scenes[v].text || storyData.scenes[v].text.trim().length < 20) {
-        Logger.log('WARN: Scene ' + (v + 1) + ' has empty/short text: "' + (storyData.scenes[v].text || '').substring(0, 50) + '"');
-      }
-    }
-    Logger.log('Story: "' + storyData.title + '" (' + storyData.scenes.length + ' scenes)');
-
-    // Post-generation audit
-    var audit = auditStoryText_(storyData, character);
-    storyData._audit = audit;
-
-    // Extract canon
-    Logger.log('Extracting canon from story...');
-    var canonData = extractCanonFromStory(storyData);
-
-    // Get next book number — must happen here, saved with story data
-    var bookNumber = getNextBookNumber();
-    Logger.log('Assigned Book #' + bookNumber);
-
-    // Persist story data to Notion page
-    sf_saveStoryData_(pageId, { storyData: storyData, canonData: canonData, bookNumber: bookNumber, tone: tone || 'Funny' });
-
-    // Success
-    updateNotionRow(pageId, null, 'Written');
-    props.setProperty('SF_CONSECUTIVE_FAILS', '0');
-    Logger.log('Phase 1 complete: Book #' + bookNumber + ' "' + storyData.title + '" — Status set to Written');
-
-  } catch(e) {
-    Logger.log('Phase 1 FAILED: ' + e.message);
-    Logger.log('Stack: ' + e.stack);
-    sf_logError_('sf_runPhase1Write_', e);
-    sf_updateFailedPhase_(pageId, 'write', 'Phase 1 (Write) failed: ' + e.message);
-    var fails = parseInt(props.getProperty('SF_CONSECUTIVE_FAILS') || '0') + 1;
-    props.setProperty('SF_CONSECUTIVE_FAILS', String(fails));
-  }
-}
-
-// Phase 2: Generate and persist scene images to Drive subfolder.
-// Resumes from where it left off (skips already-generated scenes).
-// On full success sets Status='Illustrated'. On partial run resets to 'Written' with hint (no fail increment).
-// On hard exception sets Status='Failed' and increments SF_CONSECUTIVE_FAILS.
-function sf_runPhase2Illustrate_(pageId, page) {
-  Logger.log('=== Phase 2: Illustrate === pageId=' + pageId);
-  var props = PropertiesService.getScriptProperties();
-
-  try {
-    updateNotionRow(pageId, null, 'Illustrating');
-
-    // Load saved story data
-    var saved = sf_loadStoryData_(page);
-    if (!saved) {
-      sf_updateFailedPhase_(pageId, 'illustrate', 'Story Data missing or unreadable. Re-run Phase 1: set Status back to Idea.');
-      var fails = parseInt(props.getProperty('SF_CONSECUTIVE_FAILS') || '0') + 1;
-      props.setProperty('SF_CONSECUTIVE_FAILS', String(fails));
-      return;
-    }
-
-    var storyData = saved.storyData;
-    var characters = sf_getCharacterFromNotion_(storyData.character);
-
-    // Get or create Drive subfolder for this page's images
-    var pageProps = page.properties || {};
-    var imageFolderIdProp = pageProps['Image Folder ID'];
-    var existingFolderId = imageFolderIdProp && imageFolderIdProp.rich_text && imageFolderIdProp.rich_text.length > 0
-      ? (imageFolderIdProp.rich_text[0].plain_text || '')
-      : '';
-
-    var subfolder;
-    if (existingFolderId) {
-      Logger.log('Using existing image subfolder: ' + existingFolderId);
-      subfolder = DriveApp.getFolderById(existingFolderId);
-    } else {
-      Logger.log('Creating new image subfolder...');
-      var parentFolder = DriveApp.getFolderById(CONFIG.STORY_FOLDER_ID);
-      subfolder = parentFolder.createFolder(CONFIG.IMAGE_SUBFOLDER_PREFIX + pageId);
-      Logger.log('Created subfolder: ' + subfolder.getId());
-    }
-
-    // List existing scene files (scene-N.png) to determine which are missing
-    var existingFiles = {};
-    var fileIter = subfolder.getFiles();
-    while (fileIter.hasNext()) {
-      var f = fileIter.next();
-      var fname = f.getName(); // e.g. "scene-1.png"
-      var m = fname.match(/^scene-(\d+)\.png$/);
-      if (m) {
-        existingFiles[parseInt(m[1]) - 1] = f; // keyed by 0-based scene index
-      }
-    }
-    Logger.log('Existing scene files: ' + Object.keys(existingFiles).length);
-
-    // Determine which IMAGE_SCENES indices are missing
-    var missingScenes = [];
-    for (var mi = 0; mi < CONFIG.IMAGE_SCENES.length; mi++) {
-      var sceneIdx = CONFIG.IMAGE_SCENES[mi];
-      if (!existingFiles[sceneIdx]) {
-        missingScenes.push(sceneIdx);
-      }
-    }
-    Logger.log('Missing scenes to generate: ' + missingScenes.map(function(i) { return i + 1; }).join(', '));
-
-    // Download character reference images
-    _refImageCache = {};
-    var refImages = sf_getCharacterRefImages_(characters);
-
-    // Build character lookup maps
-    var charVisualMap = {};
-    var charRefMap = {};
-    for (var ci = 0; ci < characters.length; ci++) {
-      var charName = characters[ci].name.split(' ')[0].toUpperCase();
-      charVisualMap[charName] = 'CHARACTER: ' + characters[ci].visualTraits;
-      for (var ri = 0; ri < refImages.length; ri++) {
-        if (refImages[ri].name.toUpperCase() === charName || refImages[ri].name === characters[ci].name) {
-          charRefMap[charName] = refImages[ri];
-        }
-      }
-    }
-
-    var scenes = storyData.scenes;
-    var newlyGenerated = 0;
-
-    for (var idx = 0; idx < missingScenes.length; idx++) {
-      var sceneIndex = missingScenes[idx];
-      Logger.log('Generating image for scene ' + (sceneIndex + 1) + '...');
-
-      // Scene-level character filtering
-      var sceneChars = scenes[sceneIndex].characters_in_scene || [];
-      var sceneVisuals = '';
-      var sceneRefImages = [];
-
-      if (sceneChars.length > 0) {
-        for (var sc = 0; sc < sceneChars.length; sc++) {
-          var scKey = sceneChars[sc].toUpperCase().split(' ')[0];
-          if (scKey === 'MOM' || scKey === 'LT') scKey = 'MOM';
-          if (scKey === 'DAD' || scKey === 'JT') scKey = 'DAD';
-          if (scKey === 'NATHAN') scKey = 'BUGGSY';
-          if (charVisualMap[scKey]) sceneVisuals += charVisualMap[scKey] + '\\n';
-          if (charRefMap[scKey]) sceneRefImages.push(charRefMap[scKey]);
-        }
-      } else {
-        for (var allKey in charVisualMap) {
-          sceneVisuals += charVisualMap[allKey] + '\\n';
-        }
-        sceneRefImages = refImages;
-      }
-
-      var fullPrompt = scenes[sceneIndex].image_prompt;
-      var _scText = (scenes[sceneIndex].text || '').toLowerCase();
-      var _setting = 'casual';
-      if (_scText.indexOf('pool') >= 0 || _scText.indexOf('swim') >= 0 || _scText.indexOf('beach') >= 0) _setting = 'beach';
-      else if (_scText.indexOf('school') >= 0 || _scText.indexOf('class') >= 0) _setting = 'school';
-      else if (_scText.indexOf('bed') >= 0 || _scText.indexOf('sleep') >= 0 || _scText.indexOf('pajama') >= 0 || _scText.indexOf('pillow') >= 0) _setting = 'bedtime';
-      else if (_scText.indexOf('formal') >= 0 || _scText.indexOf('church') >= 0 || _scText.indexOf('wedding') >= 0) _setting = 'formal';
-      else if (_scText.indexOf('sport') >= 0 || _scText.indexOf('basket') >= 0 || _scText.indexOf('soccer') >= 0) _setting = 'sports';
-      var _wardrobeNames = sceneChars.length > 0 ? sceneChars : ['Buggsy', 'JJ'];
-      var _wardrobeBlock = buildWardrobePrompt_(_wardrobeNames, _setting);
-      if (_wardrobeBlock) fullPrompt = _wardrobeBlock + '\\n' + fullPrompt;
-      if (sceneVisuals) fullPrompt = sceneVisuals + '\\n\\n' + fullPrompt;
-      fullPrompt += '\\n\\nIMPORTANT: Centered composition. All characters fully visible within the frame. No cropping.';
-
-      var blob = generateWithRetry(fullPrompt, sceneIndex + 1, sceneRefImages);
-      if (blob && blob.data) {
-        var fileBlob = Utilities.newBlob(
-          Utilities.base64Decode(blob.data),
-          blob.mimeType,
-          'scene-' + (sceneIndex + 1) + '.png'
-        );
-        subfolder.createFile(fileBlob);
-        existingFiles[sceneIndex] = true; // mark as now existing
-        newlyGenerated++;
-        Logger.log('Scene ' + (sceneIndex + 1) + ' saved to Drive');
-      } else {
-        Logger.log('Scene ' + (sceneIndex + 1) + ' failed — will be retried next poll');
-      }
-
-      if (idx < missingScenes.length - 1) {
-        Utilities.sleep(CONFIG.IMAGE_COOLDOWN);
-      }
-    }
-
-    // Always persist Image Folder ID before checking gate
-    notionPatch('pages/' + pageId, {
-      properties: {
-        'Image Folder ID': { rich_text: [{ type: 'text', text: { content: subfolder.getId() } }] }
-      }
-    });
-
-    // Count total images (existing + new)
-    var totalImages = 0;
-    for (var ti = 0; ti < CONFIG.IMAGE_SCENES.length; ti++) {
-      if (existingFiles[CONFIG.IMAGE_SCENES[ti]]) totalImages++;
-    }
-    Logger.log('Total images in subfolder: ' + totalImages + '/' + CONFIG.IMAGE_SCENES.length);
-
-    var minRequired = (CONFIG.MIN_IMAGES_REQUIRED != null) ? CONFIG.MIN_IMAGES_REQUIRED : 1;
-
-    if (totalImages >= minRequired) {
-      updateNotionRow(pageId, null, 'Illustrated');
-      Logger.log('Phase 2 complete: ' + totalImages + ' images. Status set to Illustrated');
-    } else {
-      // Partial run — not a hard failure, will retry next poll
-      var hint = totalImages + '/' + CONFIG.IMAGE_SCENES.length + ' images generated. Retrying next poll.';
-      updateNotionRow(pageId, null, 'Written', hint);
-      Logger.log('Phase 2 partial: ' + hint + ' — reset to Written for retry');
-      // Do NOT increment SF_CONSECUTIVE_FAILS for partial runs
-    }
-
-  } catch(e) {
-    Logger.log('Phase 2 FAILED: ' + e.message);
-    Logger.log('Stack: ' + e.stack);
-    sf_logError_('sf_runPhase2Illustrate_', e);
-    sf_updateFailedPhase_(pageId, 'illustrate', 'Phase 2 (Illustrate) failed: ' + e.message);
-    var fails2 = parseInt(props.getProperty('SF_CONSECUTIVE_FAILS') || '0') + 1;
-    props.setProperty('SF_CONSECUTIVE_FAILS', String(fails2));
-  }
-}
-
-// Phase 3: Read images from Drive subfolder, build PDF, create Notion catalogue page.
-// On success sets Status='Ready'. On exception sets Status='Failed'.
-function sf_runPhase3Assemble_(pageId, page) {
-  Logger.log('=== Phase 3: Assemble === pageId=' + pageId);
-  var props = PropertiesService.getScriptProperties();
-
-  try {
-    updateNotionRow(pageId, null, 'Assembling');
-
-    // Load saved story data
-    var saved = sf_loadStoryData_(page);
-    if (!saved) {
-      sf_updateFailedPhase_(pageId, 'assemble', 'Story Data missing or unreadable. Re-run Phase 1: set Status back to Idea.');
-      var fails = parseInt(props.getProperty('SF_CONSECUTIVE_FAILS') || '0') + 1;
-      props.setProperty('SF_CONSECUTIVE_FAILS', String(fails));
-      return;
-    }
-
-    var storyData = saved.storyData;
-    var bookNumber = saved.bookNumber;
-    var canonData = saved.canonData;
-    var tone = saved.tone;
-
-    // Read Image Folder ID from page properties
-    var pageProps = page.properties || {};
-    var imageFolderIdProp = pageProps['Image Folder ID'];
-    var imageFolderId = imageFolderIdProp && imageFolderIdProp.rich_text && imageFolderIdProp.rich_text.length > 0
-      ? (imageFolderIdProp.rich_text[0].plain_text || '')
-      : '';
-
-    if (!imageFolderId) {
-      throw new Error('Image Folder ID not found on page. Phase 2 may not have completed successfully.');
-    }
-
-    // Read scene files from Drive subfolder, build imageBlobs array indexed by scene number
-    var subfolder = DriveApp.getFolderById(imageFolderId);
-    var imageBlobs = [];
-    for (var i = 0; i < storyData.scenes.length; i++) imageBlobs.push(null);
-
-    var fileIter = subfolder.getFiles();
-    while (fileIter.hasNext()) {
-      var f = fileIter.next();
-      var fname = f.getName();
-      var m = fname.match(/^scene-(\d+)\.png$/);
-      if (m) {
-        var sceneNum = parseInt(m[1]); // 1-based
-        var sceneIdx = sceneNum - 1;   // 0-based
-        if (sceneIdx >= 0 && sceneIdx < imageBlobs.length) {
-          try {
-            var fileBytes = f.getBlob().getBytes();
-            imageBlobs[sceneIdx] = {
-              data: Utilities.base64Encode(fileBytes),
-              mimeType: 'image/png',
-              sceneNumber: sceneNum
-            };
-            Logger.log('Loaded scene-' + sceneNum + '.png from Drive');
-          } catch(readErr) {
-            Logger.log('Could not read scene-' + sceneNum + '.png: ' + readErr.message);
-          }
-        }
-      }
-    }
-
-    var imageCount = 0;
-    for (var ic = 0; ic < imageBlobs.length; ic++) {
-      if (imageBlobs[ic]) imageCount++;
-    }
-    Logger.log('Loaded ' + imageCount + ' images from Drive subfolder');
-
-    // Build PDF
-    Logger.log('Building PDF for Book #' + bookNumber + '...');
-    var pdf = buildStoryPDF(storyData, imageBlobs, bookNumber);
-    Logger.log('PDF: ' + pdf.url);
-
-    // Build Notion catalogue page
-    Logger.log('Creating Notion catalogue page...');
-    var notionUrl = buildNotionCataloguePage(storyData, pdf.url, bookNumber, canonData, tone);
-    Logger.log('Notion: ' + notionUrl);
-
-    // Success
-    updateNotionRow(pageId, pdf.url, 'Ready');
-    props.setProperty('SF_CONSECUTIVE_FAILS', '0');
-    Logger.log('Phase 3 complete: Book #' + bookNumber + ' "' + storyData.title + '" — Status set to Ready');
-
-  } catch(e) {
-    Logger.log('Phase 3 FAILED: ' + e.message);
-    Logger.log('Stack: ' + e.stack);
-    sf_logError_('sf_runPhase3Assemble_', e);
-    sf_updateFailedPhase_(pageId, 'assemble', 'Phase 3 (Assemble) failed: ' + e.message);
-    var fails3 = parseInt(props.getProperty('SF_CONSECUTIVE_FAILS') || '0') + 1;
-    props.setProperty('SF_CONSECUTIVE_FAILS', String(fails3));
-  }
-}
-
-// ── MAIN PIPELINE (LEGACY — kept for testFactory()) ──────────
-
-function runStoryFactoryLegacy_(topic, character, tone) {
-Logger.log('=== Story Factory Legacy v15.5 ===');
+function runStoryFactory(topic, character, tone) {
+Logger.log('=== Story Factory v15.1 ===');
 Logger.log('Topic: ' + topic + ' | Character: ' + character + ' | Tone: ' + (tone || 'Funny'));
 
 // Run-state object — tracks which phases completed so the catch block can produce honest hints.
+// These are IN-MEMORY ONLY. There is no persistent checkpoint store — the only retry path is
+// setting Status back to Idea. Do not present any intermediate status as a resumable checkpoint.
 var state = {
   story_generated: false,
   audit_passed: false,
@@ -1592,8 +1385,8 @@ var state = {
   notion_updated: false,
   pdfUrl: null,
   successfulImageCount: 0,
-  character: character,
-  topic: topic
+  character: character,   // v15.2: captured for telemetry
+  topic: topic            // v15.2: captured for telemetry (pageId not available here — set by pollForNewStories)
 };
 
 try {
@@ -1709,10 +1502,12 @@ return { success: true, title: storyData.title, pdfUrl: pdf.url, notionUrl: noti
 } catch(e) {
 Logger.log('FAILED: ' + e.message);
 Logger.log('Stack: ' + e.stack);
-sf_logError_('runStoryFactoryLegacy_', e);
+sf_logError_('runStoryFactory', e);
 sf_logFailure_(state, e.message); // v15.2 telemetry — must never throw
 
-// v15.1: Honest resume hints
+// v15.1: Honest resume hints — no false checkpoint promises.
+// Every hint ends with "set Status back to Idea" — the ONLY retry path that works.
+// Intermediate statuses (Story Ready, Images Ready, etc.) are in-flight indicators only, NOT resumable.
 var hint;
 if (!state.story_generated) {
   hint = 'FAILED at story generation: ' + e.message + ' | To retry: set Status back to Idea.';
@@ -1736,8 +1531,11 @@ return { success: false, error: e.message, resumeHint: hint };
 
 // ── POLL NOTION FOR NEW REQUESTS ─────────────────────────────
 
+// v16: Three-phase poll — handles Idea (Write), Written (Illustrate), Illustrated (Assemble).
+// Phase failures are isolated: only the failing phase is retried on the next poll cycle.
+// Circuit breaker still operates per consecutive-fail count across all phases.
 function pollForNewStories() {
-// Circuit breaker — stop hammering if Gemini is down
+// Circuit breaker
 var props = PropertiesService.getScriptProperties();
 var consecutiveFails = parseInt(props.getProperty('SF_CONSECUTIVE_FAILS') || '0');
 var pausedUntil = parseInt(props.getProperty('SF_PAUSED_UNTIL') || '0');
@@ -1765,7 +1563,6 @@ return;
 }
 }
 
-// v15.1: Concurrency guard — skip this trigger fire if a previous invocation is still running.
 var sfLock = LockService.getScriptLock();
 if (!sfLock.tryLock(1000)) {
 Logger.log('Another pollForNewStories invocation is already running. Skipping this trigger fire.');
@@ -1773,57 +1570,129 @@ return;
 }
 
 try {
-Logger.log('Polling for new story requests (Idea / Written / Illustrated)...');
+Logger.log('Polling for story work (Idea | Written | Illustrated)...');
+// Query all three actionable statuses, oldest first so the queue drains in order.
 var result = notionPost('databases/' + CONFIG.STORY_DB_ID + '/query', {
-filter: {
-  or: [
-    { property: 'Status', select: { equals: 'Idea' } },
-    { property: 'Status', select: { equals: 'Written' } },
-    { property: 'Status', select: { equals: 'Illustrated' } }
-  ]
-}
+  filter: {
+    or: [
+      { property: 'Status', select: { equals: 'Idea' } },
+      { property: 'Status', select: { equals: 'Written' } },
+      { property: 'Status', select: { equals: 'Illustrated' } }
+    ]
+  },
+  sorts: [{ property: 'Created time', direction: 'ascending' }],
+  page_size: 1
 });
 
 if (!result.results || result.results.length === 0) {
-Logger.log('No new requests.');
+Logger.log('No actionable story rows found.');
 return;
 }
-
-Logger.log('Found ' + result.results.length + ' request(s)');
 
 var page = result.results[0];
 var pageId = page.id;
 var pageStatus = (page.properties['Status'] && page.properties['Status'].select)
-  ? page.properties['Status'].select.name
-  : 'Idea';
+  ? page.properties['Status'].select.name : 'Idea';
 var topic = getNotionText(page.properties['Topic'], 'rich_text') || 'A new adventure';
 var character = (page.properties['Character'] && page.properties['Character'].select)
-? page.properties['Character'].select.name
-: 'JJ';
+  ? page.properties['Character'].select.name : 'JJ';
 var tone = (page.properties['Tone'] && page.properties['Tone'].select)
-? page.properties['Tone'].select.name
-: 'Funny';
+  ? page.properties['Tone'].select.name : 'Funny';
 
-Logger.log('Dispatching pageId=' + pageId + ' status=' + pageStatus);
+Logger.log('Row ' + pageId + ' — status: ' + pageStatus);
+
+var phaseSuccess = false;
+var failMsg = '';
 
 if (pageStatus === 'Idea') {
-  sf_runPhase1Write_(pageId, topic, character, tone);
+  // ── Phase 1: Write ────────────────────────────────────────
+  // Atomically claim the row before expensive work (prevents double-processing on concurrent triggers).
+  updateNotionRow(pageId, null, 'Writing');
+  var wr = sf_phaseWrite_(pageId, topic, character, tone);
+  if (wr.success) {
+    updateNotionRow(pageId, null, 'Written', null, {
+      'Story Draft URL': { url: wr.storyDriveUrl }
+    });
+    Logger.log('Phase 1 done — "' + wr.title + '" saved. Status → Written.');
+    phaseSuccess = true;
+  } else {
+    // Phase 1 failure: nothing persisted — full retry needed. Status → Failed.
+    updateNotionRow(pageId, null, 'Failed',
+      'Write phase failed: ' + wr.error + ' | To retry: set Status back to Idea.',
+      { 'Failed Phase': { select: { name: 'Write' } } }
+    );
+    failMsg = wr.error;
+  }
+
 } else if (pageStatus === 'Written') {
-  sf_runPhase2Illustrate_(pageId, page);
+  // ── Phase 2: Illustrate ───────────────────────────────────
+  var storyDraftUrl = sf_getNotionUrlProp_(page.properties, 'Story Draft URL');
+  if (!storyDraftUrl) {
+    updateNotionRow(pageId, null, 'Failed',
+      'Story Draft URL missing from Written row — set Status to Idea to retry.',
+      { 'Failed Phase': { select: { name: 'Illustrate' } } }
+    );
+    failMsg = 'Missing Story Draft URL';
+  } else {
+    updateNotionRow(pageId, null, 'Illustrating');
+    var ir = sf_phaseIllustrate_(pageId, storyDraftUrl);
+    if (ir.success) {
+      updateNotionRow(pageId, null, 'Illustrated', null, {
+        'Images Folder URL': { url: ir.imagesFolderUrl },
+        'Images Saved': { number: ir.imagesSaved }
+      });
+      Logger.log('Phase 2 done — ' + ir.imagesSaved + ' image(s) saved. Status → Illustrated.');
+      phaseSuccess = true;
+    } else {
+      // Phase 2 failure: story text is safe in Drive. Reset to Written so next poll retries images only.
+      updateNotionRow(pageId, null, 'Written',
+        'Illustrate phase failed: ' + ir.error + ' | Status reset to Written — next poll retries images only.',
+        { 'Failed Phase': { select: { name: 'Illustrate' } } }
+      );
+      failMsg = ir.error;
+    }
+  }
+
 } else if (pageStatus === 'Illustrated') {
-  sf_runPhase3Assemble_(pageId, page);
+  // ── Phase 3: Assemble ─────────────────────────────────────
+  var storyDraftUrl2 = sf_getNotionUrlProp_(page.properties, 'Story Draft URL');
+  var imagesFolderUrl = sf_getNotionUrlProp_(page.properties, 'Images Folder URL');
+  if (!storyDraftUrl2 || !imagesFolderUrl) {
+    updateNotionRow(pageId, null, 'Failed',
+      'Illustrated row missing Story Draft URL or Images Folder URL — set Status to Idea to retry.',
+      { 'Failed Phase': { select: { name: 'Assemble' } } }
+    );
+    failMsg = 'Missing draft/images URL';
+  } else {
+    updateNotionRow(pageId, null, 'Assembling');
+    var ar = sf_phaseAssemble_(pageId, storyDraftUrl2, imagesFolderUrl);
+    if (ar.success) {
+      updateNotionRow(pageId, ar.pdfUrl, 'Ready');
+      Logger.log('Phase 3 done — Book #' + ar.bookNumber + ' "' + ar.title + '". Status → Ready.');
+      phaseSuccess = true;
+    } else {
+      // Phase 3 failure: story + images still in Drive. Reset to Illustrated so next poll retries assembly only.
+      updateNotionRow(pageId, null, 'Illustrated',
+        'Assemble phase failed: ' + ar.error + ' | Status reset to Illustrated — next poll retries assembly only.',
+        { 'Failed Phase': { select: { name: 'Assemble' } } }
+      );
+      failMsg = ar.error;
+    }
+  }
+}
+
+if (phaseSuccess) {
+  props.setProperty('SF_CONSECUTIVE_FAILS', '0');
 } else {
-  Logger.log('Unexpected status "' + pageStatus + '" — skipping');
+  consecutiveFails++;
+  props.setProperty('SF_CONSECUTIVE_FAILS', String(consecutiveFails));
+  sf_logError_('pollForNewStories', new Error(failMsg || 'unknown phase failure'));
+  if (consecutiveFails >= 3) {
+    var pauseDuration = 3600000; // 1 hour
+    props.setProperty('SF_PAUSED_UNTIL', String(Date.now() + pauseDuration));
+    Logger.log('Circuit breaker TRIPPED — ' + consecutiveFails + ' consecutive failures. Pausing 1 hour.');
+  }
 }
-
-// Re-read consecutive fails after dispatch (phase handlers update props directly)
-consecutiveFails = parseInt(props.getProperty('SF_CONSECUTIVE_FAILS') || '0');
-if (consecutiveFails >= 3) {
-  var pauseDuration = 3600000; // 1 hour
-  props.setProperty('SF_PAUSED_UNTIL', String(Date.now() + pauseDuration));
-  Logger.log('Circuit breaker TRIPPED — ' + consecutiveFails + ' consecutive failures. Pausing for 1 hour.');
-}
-
 } finally {
 sfLock.releaseLock();
 }
@@ -1842,34 +1711,15 @@ ScriptApp.newTrigger('pollForNewStories').timeBased().everyMinutes(5).create();
 Logger.log('Trigger installed — polling every 5 minutes.');
 }
 
-// ── TEST: Full pipeline (uses legacy single-run) ──────────────
+// ── TEST: Full pipeline ──────────────────────────────────────
 
 function testFactory() {
-var result = runStoryFactoryLegacy_(
+var result = runStoryFactory(
 'JJ goes to the grocery store and ends up running the whole place',
 'JJ',
 'Funny'
 );
 Logger.log(JSON.stringify(result, null, 2));
-}
-
-// ── TEST: Three-phase handlers ────────────────────────────────
-
-function testPhase1Write() {
-  var pageId = 'REPLACE_WITH_REAL_PAGE_ID';
-  sf_runPhase1Write_(pageId, 'A day at the museum', 'Buggsy', 'Funny');
-}
-
-function testPhase2Illustrate() {
-  var pageId = 'REPLACE_WITH_REAL_PAGE_ID';
-  var page = notionGet('pages/' + pageId);
-  sf_runPhase2Illustrate_(pageId, page);
-}
-
-function testPhase3Assemble() {
-  var pageId = 'REPLACE_WITH_REAL_PAGE_ID';
-  var page = notionGet('pages/' + pageId);
-  sf_runPhase3Assemble_(pageId, page);
 }
 
 // ── TEST: PDF only ───────────────────────────────────────────
@@ -2033,6 +1883,7 @@ function getStoryForReader(storyKey) {
     var props = PropertiesService.getScriptProperties();
     var raw = props.getProperty(meta.propertyKey);
     // v15.3: Fallback — try hyphenated key if underscore key not found
+    // (covers stories loaded directly to Props instead of via loadStoryToProps)
     if (!raw) {
       var hyphenKey = 'STORY_' + storyKey;
       raw = props.getProperty(hyphenKey);
@@ -2213,25 +2064,15 @@ function sf_logFailure_(state, errorMessage) {
       ]);
     }
 
-    // Detect which phase failed — use state.phase string if provided, else derive from flags
+    // Detect which phase failed using state flags from runStoryFactory
     var phase;
-    if (state.phase && typeof state.phase === 'string') {
-      phase = state.phase;
-    } else if (!state.story_generated) {
-      phase = 'story_generation';
-    } else if (!state.audit_passed) {
-      phase = 'audit';
-    } else if (!state.canon_extracted) {
-      phase = 'canon_extraction';
-    } else if (!state.images_generated) {
-      phase = 'image_generation';
-    } else if (!state.pdf_built) {
-      phase = 'pdf_build';
-    } else if (!state.notion_updated) {
-      phase = 'notion_write';
-    } else {
-      phase = 'unknown';
-    }
+    if (!state.story_generated) phase = 'story_generation';
+    else if (!state.audit_passed) phase = 'audit';
+    else if (!state.canon_extracted) phase = 'canon_extraction';
+    else if (!state.images_generated) phase = 'image_generation';
+    else if (!state.pdf_built) phase = 'pdf_build';
+    else if (!state.notion_updated) phase = 'notion_write';
+    else phase = 'unknown';
 
     // Classify error by message pattern
     var msg = String(errorMessage || '');
@@ -2265,6 +2106,9 @@ function sf_logFailure_(state, errorMessage) {
 }
 
 // Read the SF_FailureLog sheet and return a summary of failures in the last N days.
+// Run from Script Editor to make the checkpoint store unblock call (day 14).
+//   unblockCheckpointSpec: true → recoverable phase failures >= 2 AND total failures >= 3
+//   unblockCheckpointSpec: false → keep checkpoint store BLOCKED
 function sf_getFailureSummary_(days) {
   var d = days || 14;
   if (!CONFIG.FAILURE_LOG_SHEET_NAME) return { error: 'FAILURE_LOG_SHEET_NAME not configured' };
@@ -2315,5 +2159,5 @@ function sf_getFailureSummary_(days) {
   };
 }
 
-// END OF FILE — StoryFactory v15.5
+// END OF FILE — StoryFactory v16.0
 // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Replaces the monolithic `runStoryFactory()` pipeline with three independent phase functions, each capable of running in a separate 5-min poll cycle
- `pollForNewStories()` now queries `Idea | Written | Illustrated` (oldest first) and routes to the correct phase
- Phase failures are isolated — text is never discarded because of an image failure, assembly never fails because story was already persisted
- `updateNotionRow()` gains optional `extraProps` arg with graceful retry for missing Notion fields (no schema change required to ship)
- `runStoryFactory()` kept as-is for manual test runs and `testFactory()`

## New Notion fields (LT adds to Story DB before enabling phases 2+3)
| Field | Type | Purpose |
|-------|------|---------|
| `Story Draft URL` | url | Drive JSON file from Phase 1 |
| `Images Folder URL` | url | Drive folder from Phase 2 |
| `Images Saved` | number | Count of saved scene images |
| `Failed Phase` | select (Write/Illustrate/Assemble) | Targeted retry hint |

## New status flow
`Idea → Writing → Written → Illustrating → Illustrated → Assembling → Ready`

## Skills used
`/thompson-engineer`, `/notion-contracts`

## Test plan
- [ ] Set a Notion row to `Idea` → verify poll sets `Writing`, then `Written` + `Story Draft URL` populated
- [ ] Set row to `Written` with valid `Story Draft URL` → verify poll sets `Illustrating`, then `Illustrated` + `Images Folder URL`
- [ ] Set row to `Illustrated` with both URLs → verify poll sets `Assembling`, then `Ready` + PDF URL
- [ ] Kill Gemini API key mid-phase → verify Phase 1 failure sets `Failed`, Phase 2 failure resets to `Written`, Phase 3 failure resets to `Illustrated`
- [ ] Verify `story-drafts/` subfolder created in Story Drive folder
- [ ] `tbmSmokeTest()` + `tbmRegressionSuite()` both PASS

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)