### PR TITLE
fix(P1-1,P2-8): align version headers + add provisionEducationTabs()

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,6 +1,6 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// Code.gs v80 — Apps Script Router (TBM Consolidated)
+// Code.gs v81 — Apps Script Router (TBM Consolidated)
 // WRITES TO: (routes only — delegates to DataEngine, KidsHub, etc.)
 // READS FROM: (routes only — delegates to DataEngine, KidsHub, etc.)
 // ════════════════════════════════════════════════════════════════════
@@ -2040,4 +2040,4 @@ function getOpsHealthSafe() {
   });
 }
 
-// END OF FILE — Code.gs v80
+// END OF FILE — Code.gs v81

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,6 +1,6 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v63 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v65 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 🧹📅 KH_LessonRuns, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
@@ -3836,6 +3836,21 @@ function ensureKHVocabExposuresTab_() {
   return sheet;
 }
 
+/**
+ * One-time provisioning: creates KH_LessonRuns and KH_VocabExposures tabs
+ * if they don't already exist. Run from the GAS editor after deploy to
+ * clear the smoke-test WARN for missing education tabs.
+ */
+function provisionEducationTabs() {
+  var results = [];
+  var lr = ensureKHLessonRunsTab_();
+  results.push('KH_LessonRuns: ' + (lr ? 'OK (' + lr.getName() + ')' : 'FAILED'));
+  var ve = ensureKHVocabExposuresTab_();
+  results.push('KH_VocabExposures: ' + (ve ? 'OK (' + ve.getName() + ')' : 'FAILED'));
+  Logger.log('provisionEducationTabs → ' + results.join(', '));
+  return results;
+}
+
 function recordVocabExposure_(child, wordEntry, source, runId) {
   if (!child || !wordEntry || !wordEntry.word) return;
   var dateKey = getTodayISO_();
@@ -5004,5 +5019,5 @@ function getComicStudioContextSafe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v63
+// END OF FILE — KidsHub.gs v65
 // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- **P1-1**: Added `provisionEducationTabs()` public wrapper to create missing `KH_LessonRuns` and `KH_VocabExposures` tabs in production. Run once after deploy to clear the permanent WARN from smoke test.
- **P2-8**: Aligned Code.js header/EOF (v80→v81) and KidsHub.js header/EOF (v63→v65) to match their getter return values.

**Note:** The smoke WARN on this PR's CI is expected — the CI workbook doesn't have the production tabs. The fix is intentionally a manual one-time function (`provisionEducationTabs()`) per the original spec: "Run the existing creation functions against the production workbook." The smoke contract is NOT weakened; the gate clears once tabs exist.

## Skills Required
`/deploy-pipeline`, `/data-contracts`

## Test plan
- [ ] `audit-source.sh` passes (version consistency check)
- [ ] `clasp push` + `clasp deploy`
- [ ] Run `provisionEducationTabs()` from GAS editor — verify both tabs created
- [ ] `?action=runTests` returns `overall=PASS, smoke.overall=PASS`

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)