### PR TITLE
fix(P2-1): remove runTestsSafe from public API whitelist

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -426,7 +426,8 @@ function serveData(e) {
         'recordVocabExposuresSafe': recordVocabExposuresSafe,
         'getStoryForReaderSafe': getStoryForReaderSafe,
         'getStoryImagesSafe': getStoryImagesSafe,
-        'runTestsSafe': runTestsSafe,
+        // runTestsSafe removed — diagnostic endpoint should not be publicly callable via CF /api.
+        // Tests still run via ?action=runTests (direct GAS route, not proxied).
         'saveMissionStateSafe': saveMissionStateSafe,
         'getMissionStateSafe': getMissionStateSafe,
         'submitHomeworkSafe': submitHomeworkSafe,

--- a/Tbmsmoketest.js
+++ b/Tbmsmoketest.js
@@ -59,7 +59,7 @@ var CANONICAL_SAFE_FUNCTIONS = [
   'getSpellingWordsSafe',
   'recordVocabExposuresSafe',
   'updateMealPlanSafe', 'getStoryApiStatsSafe', 'khHealthCheckSafe',
-  'getDeployedVersionsSafe', 'reconcileVeinPulse', 'runTestsSafe',
+  'getDeployedVersionsSafe', 'reconcileVeinPulse',
   'seedStaarRlaSprintSafe', 'getDailyMissionsInitSafe',
   'startLessonRunSafe', 'saveLessonRunStateSafe', 'getLessonRunResumeSafe', 'completeLessonRunSafe',
   'qaGetEnvStatusSafe', 'qaListScenariosSafe', 'qaLoadScenarioSafe', 'qaSetClockSafe',


### PR DESCRIPTION
## Summary
- Removed `runTestsSafe` from `API_WHITELIST` in Code.js — diagnostic endpoint was callable unauthenticated via CF `/api` proxy, exposing internal versions, trigger inventory, and schema drift
- Removed from `CANONICAL_SAFE_FUNCTIONS` to keep whitelist/smoke-test in sync
- Tests still accessible via `?action=runTests` (direct GAS route, not proxied)

## Skills Required
`/route-contracts`, `/deploy-pipeline`

## Test plan
- [ ] `curl thompsonfams.com/api?fn=runTestsSafe` returns `{"error":"Unknown or missing function: runTestsSafe"}`
- [ ] `?action=runTests` on GAS exec URL still works
- [ ] Smoke test passes (runTestsSafe no longer in canonical list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #206