### PR TITLE
fix(P2-2,P2-3): fix version drift NameError + Playwright parser failure names

### DIFF
--- a/.github/scripts/check_version_drift.py
+++ b/.github/scripts/check_version_drift.py
@@ -97,11 +97,11 @@ def main():
                 'file': filename,
                 'source': source_ver,
                 'deployed': deployed_num,
-                'delta': source_ver - deployed_int,
+                'delta': source_ver - deployed_num,
             })
-            print('DRIFT ' + key + ': source=v' + str(source_ver) + ' deployed=v' + str(deployed_int))
+            print('DRIFT ' + key + ': source=v' + str(source_ver) + ' deployed=v' + str(deployed_num))
         else:
-            print('OK    ' + key + ': v' + str(deployed_int))
+            print('OK    ' + key + ': v' + str(deployed_num))
 
     has_findings = len(drifted) > 0
     set_output('has_findings', 'true' if has_findings else 'false')

--- a/.github/scripts/parse_playwright_results.py
+++ b/.github/scripts/parse_playwright_results.py
@@ -87,18 +87,32 @@ def format_comment(json_data, pw_exit, output_text):
         if failed > 0:
             lines.append("")
             lines.append("### Failures")
-            for suite in json_data.get("suites", []):
-                for spec in suite.get("specs", []):
-                    for test in spec.get("tests", []):
-                        if test.get("status") != "expected":
-                            title = spec.get("title", "?")
-                            status = test.get("status", "?")
-                            lines.append("- **%s**: %s" % (title, status))
-                            for result in test.get("results", []):
-                                err = result.get("error", {})
-                                msg = err.get("message", "")
-                                if msg:
-                                    lines.append("  `%s`" % msg[:200])
+            failure_entries = []
+
+            def collect_failures(suites, prefix=""):
+                for suite in suites:
+                    suite_title = suite.get("title", "")
+                    path = (prefix + " > " + suite_title) if prefix else suite_title
+                    for spec in suite.get("specs", []):
+                        spec_title = spec.get("title", "?")
+                        full_title = path + " > " + spec_title if path else spec_title
+                        for test in spec.get("tests", []):
+                            if test.get("status") != "expected":
+                                status = test.get("status", "?")
+                                entry = "- **%s**: %s" % (full_title, status)
+                                failure_entries.append(entry)
+                                for result in test.get("results", []):
+                                    err = result.get("error", {})
+                                    msg = err.get("message", "")
+                                    if msg:
+                                        failure_entries.append("  `%s`" % msg[:200])
+                    collect_failures(suite.get("suites", []), path)
+
+            collect_failures(json_data.get("suites", []))
+            if failure_entries:
+                lines.extend(failure_entries)
+            else:
+                lines.append("- _(reporter counted %d failure(s) but no matching entries found — check raw JSON)_" % failed)
 
         return "\n".join(lines), verdict
     else:


### PR DESCRIPTION
## Summary
- **P2-2**: `check_version_drift.py` referenced undefined `deployed_int` on lines 100/102/104 — fixed to `deployed_num` (defined at line 86). Caused NameError at runtime.
- **P2-3**: `parse_playwright_results.py` only traversed one level of suites and used spec title instead of full path. Rewrote to recurse nested suites. Added fail-closed fallback when `failed > 0` but no entries found.

## Skills Required
`/deploy-pipeline`, `/incident-response`

## Test plan
- [ ] `py_compile` passes on both scripts
- [ ] Version drift workflow runs without NameError
- [ ] Playwright parser emits test names under `### Failures` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #207