### PR TITLE
feat: /qa/* route isolation — per-request QA env, no global toggle (#219)

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -19,7 +19,7 @@ function isLessonRunsEnabled_() {
   } catch (e) { return false; }
 }
 
-function getCodeVersion() { return 81; }
+function getCodeVersion() { return 82; }
 
 // v37 FIX 5: ES5-safe left-pad helper — replaces String.padStart()
 function leftPad2_(n) {
@@ -47,11 +47,12 @@ var KH_CACHE_HB_KEY = 'KH_LAST_HB'; // stores last-seen heartbeat value
  */
 function getCachedKHPayload_(key) {
   try {
-    var cacheKey = key || KH_CACHE_KEY;
+    var cacheKey = getEnvCacheKey_(key || KH_CACHE_KEY);
+    var scopedHBKey = getEnvCacheKey_(KH_CACHE_HB_KEY);
     var cache = CacheService.getScriptCache();
-    var keys = cache.getAll([cacheKey, KH_CACHE_HB_KEY]);
+    var keys = cache.getAll([cacheKey, scopedHBKey]);
     var raw = keys[cacheKey];
-    var cachedHB = keys[KH_CACHE_HB_KEY];
+    var cachedHB = keys[scopedHBKey];
     if (!raw || !cachedHB) return null;
 
     // Check heartbeat — single cell read (fast)
@@ -70,13 +71,14 @@ function getCachedKHPayload_(key) {
  */
 function setCachedKHPayload_(jsonStr, key) {
   try {
-    var cacheKey = key || KH_CACHE_KEY;
+    var cacheKey = getEnvCacheKey_(key || KH_CACHE_KEY);
+    var scopedHBKey = getEnvCacheKey_(KH_CACHE_HB_KEY);
     var cache = CacheService.getScriptCache();
     var currentHB = getKHLastModified();
     if (!currentHB) return; // no heartbeat → don't cache stale
     var payload = {};
     payload[cacheKey] = jsonStr;
-    payload[KH_CACHE_HB_KEY] = currentHB;
+    payload[scopedHBKey] = currentHB;
     cache.putAll(payload, KH_CACHE_TTL);
     var size = jsonStr.length;
     if (size > 50000) {
@@ -89,6 +91,7 @@ function setCachedKHPayload_(jsonStr, key) {
 
 function getCachedPayload_(cacheKey) {
   try {
+    cacheKey = getEnvCacheKey_(cacheKey);
     var cache = CacheService.getScriptCache();
     var raw = cache.get(cacheKey);
     if (!raw) return null;
@@ -124,6 +127,7 @@ function getCachedPayload_(cacheKey) {
 
 function setCachedPayload_(cacheKey, payload, ttl) {
   try {
+    cacheKey = getEnvCacheKey_(cacheKey);
     var json = JSON.stringify(payload);
     var size = json.length;
     var effectiveTTL = ttl || DE_CACHE_TTL;
@@ -162,29 +166,74 @@ function setCachedPayload_(cacheKey, payload, ttl) {
   }
 }
 
-/** Bust the DE payload cache. Call from dashboards via google.script.run. */
+// ════════════════════════════════════════════════════════════════════
+// v82: QA ROUTE ISOLATION — HMAC token validation + env-scoped cache keys
+// (specs/qa-route-isolation.md, issue #219)
+// ════════════════════════════════════════════════════════════════════
+
+/** Compute HMAC-SHA256 of message with secret. Returns lowercase hex string. */
+function computeHmac_(message, secret) {
+  try {
+    var bytes = Utilities.computeHmacSha256Signature(message, secret);
+    return bytes.map(function(b) {
+      var hex = (b & 0xff).toString(16);
+      return hex.length === 1 ? '0' + hex : hex;
+    }).join('');
+  } catch(e) { return ''; }
+}
+
+/**
+ * Validate a per-request QA HMAC token from the CF Worker.
+ * Token format: "<timestamp>:<hmac-hex>" — 5-minute window.
+ * Returns true if valid, false otherwise.
+ */
+function validateQAToken_(tokenParam) {
+  if (!tokenParam) return false;
+  var parts = tokenParam.split(':');
+  if (parts.length !== 2) return false;
+  var ts = parseInt(parts[0], 10);
+  if (isNaN(ts) || Math.abs(Date.now() - ts) > 300000) return false;
+  var secret = PropertiesService.getScriptProperties().getProperty('QA_HMAC_SECRET');
+  if (!secret) return false;
+  var expected = computeHmac_(ts + ':qa', secret);
+  return expected === parts[1];
+}
+
+/**
+ * Return env-scoped cache key. Prepends 'qa:' when running in QA context
+ * (SSID matches TBM_QA_SSID). Prod requests are unaffected.
+ */
+function getEnvCacheKey_(baseKey) {
+  var qaSSID = PropertiesService.getScriptProperties().getProperty('TBM_QA_SSID');
+  if (qaSSID && SSID === qaSSID) return 'qa:' + baseKey;
+  return baseKey;
+}
+
+/** Bust the DE payload cache. Call from dashboards via google.script.run.
+ * v82: env-scoped — busts only the namespace matching the active SSID (prod or qa:*). */
 function bustCache() {
   try {
     var cache = CacheService.getScriptCache();
 
-    // Remove primary keys
-    cache.remove(DE_CACHE_KEY);
+    // Remove primary keys (scoped to active env)
+    var deKey = getEnvCacheKey_(DE_CACHE_KEY);
+    cache.remove(deKey);
     var n = new Date();
     var ym = n.getFullYear() + '-' + leftPad2_(n.getMonth() + 1);
-    var monthKey = DE_CACHE_KEY + '_' + ym + '-01';
+    var monthKey = getEnvCacheKey_(DE_CACHE_KEY + '_' + ym + '-01');
     cache.remove(monthKey);
 
-    // Clean up any chunk keys (up to 10 chunks should cover any payload)
+    // Clean up chunk keys (up to 10 chunks per payload)
     var chunkKeys = [];
     for (var i = 0; i < 10; i++) {
-      chunkKeys.push(DE_CACHE_KEY + '_chunk_' + i);
+      chunkKeys.push(deKey + '_chunk_' + i);
       chunkKeys.push(monthKey + '_chunk_' + i);
     }
-    // v47/v70: Also bust KH cache (all + per-child keys)
-    chunkKeys.push(KH_CACHE_KEY);
-    chunkKeys.push(KH_CACHE_KEY + '_buggsy');
-    chunkKeys.push(KH_CACHE_KEY + '_jj');
-    chunkKeys.push(KH_CACHE_HB_KEY);
+    // Also bust KH cache (all + per-child keys)
+    chunkKeys.push(getEnvCacheKey_(KH_CACHE_KEY));
+    chunkKeys.push(getEnvCacheKey_(KH_CACHE_KEY + '_buggsy'));
+    chunkKeys.push(getEnvCacheKey_(KH_CACHE_KEY + '_jj'));
+    chunkKeys.push(getEnvCacheKey_(KH_CACHE_HB_KEY));
     cache.removeAll(chunkKeys);
   } catch(e) { if (typeof logError_ === 'function') logError_('bustCache', e); }
   return { status: 'ok', busted: new Date().toISOString() };
@@ -319,6 +368,24 @@ function doPost(e) {
 
 function serveData(e) {
   var action = e.parameter.action || 'data';
+
+  // v82: QA env override — per-request SSID swap (tokens from CF Worker, 5-min window)
+  // Safe: each GAS HTTP request runs in its own V8 isolate; SSID reassignment is local.
+  if (e.parameter.env === 'qa') {
+    if (!validateQAToken_(e.parameter.qa_token)) {
+      return ContentService.createTextOutput(
+        JSON.stringify({ error: 'Invalid QA token' })
+      ).setMimeType(ContentService.MimeType.JSON);
+    }
+    var qaSSID = PropertiesService.getScriptProperties().getProperty('TBM_QA_SSID');
+    if (!qaSSID) {
+      return ContentService.createTextOutput(
+        JSON.stringify({ error: 'QA workbook not configured' })
+      ).setMimeType(ContentService.MimeType.JSON);
+    }
+    SSID = qaSSID;
+    _tbmSS = null; // bust cached workbook reference
+  }
 
   try {
     var result;

--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="comic-studio">
-<meta name="tbm-version" content="v10">
+<meta name="tbm-version" content="v11">
 <title>Wolfkid Comic Studio</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -953,7 +953,7 @@ main {
 <script>
 // ── ComicStudio v4 — Day 2: F3 Drive Draft/Resume + F4 Mission/Free Mode
 // ES6 EXEMPT: Surface Pro 5 / Chrome — see specs/comicstudio-v4.md §3
-// tbm-version: v10
+// tbm-version: v11
 
 const COMIC_STUDIO_VERSION = 10; // v10: bubble text span fix + replay bubble composite
 
@@ -2109,7 +2109,7 @@ function finishComic() {
   html += `<p style="margin-top:12px;color:#64748B;font-size:12px;">Total words written: ${totalWords}</p>`;
   html += '<div style="margin-top:20px;display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">';
   html += '<button style="padding:12px 28px;background:#00F0FF;color:#0B0F1A;border:none;border-radius:12px;font-size:14px;font-weight:700;cursor:pointer;font-family:Orbitron,sans-serif" onclick="playReplay()">&#9654; REPLAY</button>';
-  html += '<button style="padding:12px 28px;background:#3B82F6;color:#fff;border:none;border-radius:12px;font-size:14px;font-weight:700;cursor:pointer;font-family:Nunito,sans-serif" onclick="window.location.href=\'/daily-missions\'">Back to Missions</button>';
+  html += '<button style="padding:12px 28px;background:#3B82F6;color:#fff;border:none;border-radius:12px;font-size:14px;font-weight:700;cursor:pointer;font-family:Nunito,sans-serif" onclick="window.location.href=(window.location.pathname.indexOf(\'/qa/\')===0?\'/qa\':\'\')+\'/daily-missions\'">Back to Missions</button>';
   html += '</div>';
   html += '</div>';
   comp.innerHTML = html;

--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="homework-module">
-<meta name="tbm-version" content="v10">
+<meta name="tbm-version" content="v11">
 <title>Wolfkid Training Module</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -523,7 +523,7 @@ main {
     <div style="font-size:11px;color:#64748B;margin-bottom:16px;">Open-ended answers pending parent review</div>
     <div id="comp-feedback" style="background:rgba(59,130,246,0.08);border:1px solid rgba(59,130,246,0.3);border-radius:10px;padding:14px;font-size:13px;color:#94A3B8;line-height:1.6;margin-bottom:16px;text-align:left;"></div>
     <button style="background:#3B82F6;border:none;border-radius:10px;padding:12px 32px;color:#fff;font-family:'Orbitron',sans-serif;font-size:13px;font-weight:700;cursor:pointer;letter-spacing:1px;" onclick="closeCompletion()">VIEW RESULTS</button>
-    <button style="display:block;margin:12px auto 0;padding:10px 24px;background:transparent;border:1px solid #334155;border-radius:10px;color:#94A3B8;font-family:Nunito,sans-serif;font-size:13px;font-weight:600;cursor:pointer;" onclick="window.location.href='/daily-missions'">Back to Missions</button>
+    <button style="display:block;margin:12px auto 0;padding:10px 24px;background:transparent;border:1px solid #334155;border-radius:10px;color:#94A3B8;font-family:Nunito,sans-serif;font-size:13px;font-weight:600;cursor:pointer;" onclick="window.location.href=(window.location.pathname.indexOf('/qa/')===0?'/qa':'')+'/daily-missions'">Back to Missions</button>
   </div>
 </div>
 

--- a/KidsHub.html
+++ b/KidsHub.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-<meta name="tbm-version" content="KidsHub v44">
+<meta name="tbm-version" content="KidsHub v45">
 <title>Kids Hub v40</title>
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Barlow+Condensed:wght@400;600;700;800&family=Fredoka+One&family=Nunito:wght@700;800;900&family=Orbitron:wght@700;900&display=swap" rel="stylesheet">
 <style>
@@ -1190,11 +1190,13 @@ var IS_PARENT = INIT_VIEW  === 'parent';
 var _pNavBaseUrl = '';
 if (IS_PARENT) { google.script.run.withSuccessHandler(function(u) { _pNavBaseUrl = u; }).withFailureHandler(function(e){ console.log('Nav URL fetch failed: ' + (e && e.message ? e.message : 'unknown')); }).getScriptUrlSafe(); }
 // v32: Education nav helper — builds URL for education module pages
+// v33: Include /qa prefix when served under /qa/* route
 var _eduBaseUrl = '';
 (function() {
   var loc = window.location;
   if (loc.hostname && loc.hostname !== 'script.google.com' && loc.hostname.indexOf('googleusercontent') === -1) {
-    _eduBaseUrl = loc.origin;
+    var qaPrefix = (loc.pathname.indexOf('/qa/') === 0) ? '/qa' : '';
+    _eduBaseUrl = loc.origin + qaPrefix;
   }
 })();
 function eduGo(page) {

--- a/Tbmsmoketest.js
+++ b/Tbmsmoketest.js
@@ -1,5 +1,5 @@
 // ════════════════════════════════════════════════════════════════════
-// tbmSmokeTest.gs v13 — Pre-Deploy Structural Validation
+// tbmSmokeTest.gs v14 — Pre-Deploy Structural Validation
 // WRITES TO: (none — read-only checks)
 // READS FROM: All sheets (for schema/wiring validation)
 // ════════════════════════════════════════════════════════════════════
@@ -37,7 +37,7 @@
 // A PASS here means "safe to deploy" not "system works perfectly."
 // ════════════════════════════════════════════════════════════════════
 
-function getSmokeTestVersion() { return 13; }
+function getSmokeTestVersion() { return 14; }
 
 var CANONICAL_SAFE_FUNCTIONS = [
   // KidsHub core
@@ -122,6 +122,9 @@ function tbmSmokeTest() {
 
   // ── Category 5: Triggers ────────────────────────────────────────
   results.categories['5_triggers'] = checkTriggers_();
+
+  // ── Category 10: QA Route Parity ────────────────────────────────
+  results.categories['10_qa_routes'] = checkQARouteParity_();
 
   // ── Categories 6-8: Source-level (NOT runtime verifiable) ───────
   results.categories['6_concurrency'] = {
@@ -740,4 +743,48 @@ function checkHTMLContracts_() {
 }
 
 
-// END OF FILE — tbmSmokeTest.gs v13
+// ════════════════════════════════════════════════════════════════════
+// CATEGORY 10: QA ROUTE PARITY (v14)
+// Verify QA_ROUTES in cloudflare-worker.js mirrors PATH_ROUTES minus
+// finance surfaces. Static check — confirms expected count and denied list.
+// Per specs/qa-route-isolation.md Section 2 (issue #219).
+// ════════════════════════════════════════════════════════════════════
+
+function checkQARouteParity_() {
+  var result = {
+    status: 'PASS',
+    description: 'QA_ROUTES in cloudflare-worker.js mirrors PATH_ROUTES minus finance surfaces',
+    details: '',
+    method: 'static',
+    expected_routes: 0,
+    denied_routes: [],
+    note: ''
+  };
+
+  // Per spec table (Section 2) — routes eligible for QA isolation
+  var EXPECTED_QA_ROUTES = [
+    '/qa/buggsy', '/qa/jj', '/qa/parent',
+    '/qa/homework', '/qa/sparkle', '/qa/sparkle-free',
+    '/qa/wolfkid', '/qa/wolfdome', '/qa/dashboard', '/qa/sparkle-kingdom',
+    '/qa/facts', '/qa/reading', '/qa/writing',
+    '/qa/story-library', '/qa/comic-studio', '/qa/progress',
+    '/qa/story', '/qa/investigation', '/qa/daily-missions',
+    '/qa/daily-adventures', '/qa/baseline', '/qa/power-scan',
+    '/qa/spine', '/qa/soul', '/qa/vault'
+  ];
+
+  // Finance surfaces explicitly excluded from QA (audit risk)
+  var QA_DENIED = ['/qa/pulse', '/qa/vein'];
+
+  // Phase 2 deferred: /qa/ (QA Operator dashboard — OQ-4)
+
+  result.expected_routes = EXPECTED_QA_ROUTES.length;
+  result.denied_routes = QA_DENIED;
+  result.note = 'Phase 2 deferred: /qa/ (QA Operator dashboard). Verify QA_ROUTES in cloudflare-worker.js has ' + EXPECTED_QA_ROUTES.length + ' entries.';
+  result.details = EXPECTED_QA_ROUTES.length + ' QA routes expected. Denied: ' + QA_DENIED.join(', ') + '. Runtime verification not possible (CF Worker constant). Confirm parity manually against PATH_ROUTES.';
+
+  return result;
+}
+
+
+// END OF FILE — tbmSmokeTest.gs v14

--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -1,5 +1,5 @@
 // ═══════════════════════════════════════════════════════════════════
-// TBM Smart Proxy v3.4 — thompsonfams.com — Front Door + PIN Gate
+// TBM Smart Proxy v3.5 — thompsonfams.com — Front Door + PIN Gate + QA Route Isolation
 // Clean URLs + GAS API shim + goog stub
 // ═══════════════════════════════════════════════════════════════════
 
@@ -37,6 +37,38 @@ const PATH_ROUTES = {
   '/power-scan':    { page: 'power-scan' }
 };
 
+// ─── QA Route Isolation (v3.5, issue #219) ──────────────────────────────────
+// 25-entry allowlist mirrors PATH_ROUTES minus finance surfaces.
+const QA_ROUTES = {
+  '/qa/buggsy':          { page: 'kidshub', child: 'buggsy' },
+  '/qa/jj':              { page: 'kidshub', child: 'jj' },
+  '/qa/parent':          { page: 'kidshub', view: 'parent' },
+  '/qa/homework':        { page: 'homework' },
+  '/qa/sparkle':         { page: 'sparkle' },
+  '/qa/sparkle-free':    { page: 'sparkle', mode: 'freeplay' },
+  '/qa/wolfkid':         { page: 'wolfkid' },
+  '/qa/wolfdome':        { page: 'wolfdome' },
+  '/qa/dashboard':       { page: 'wolfdome' },
+  '/qa/sparkle-kingdom': { page: 'sparkle-kingdom' },
+  '/qa/facts':           { page: 'facts' },
+  '/qa/reading':         { page: 'reading' },
+  '/qa/writing':         { page: 'writing' },
+  '/qa/story-library':   { page: 'story-library' },
+  '/qa/comic-studio':    { page: 'comic-studio' },
+  '/qa/progress':        { page: 'progress' },
+  '/qa/story':           { page: 'story' },
+  '/qa/investigation':   { page: 'investigation' },
+  '/qa/daily-missions':  { page: 'daily-missions' },
+  '/qa/daily-adventures':{ page: 'daily-missions', child: 'jj' },
+  '/qa/baseline':        { page: 'baseline' },
+  '/qa/power-scan':      { page: 'power-scan' },
+  '/qa/spine':           { page: 'spine' },
+  '/qa/soul':            { page: 'soul' },
+  '/qa/vault':           { page: 'vault' }
+};
+// Finance surfaces excluded — real Tiller data, no QA snapshot. Explicit 403.
+const QA_DENIED = { '/qa/pulse': true, '/qa/vein': true };
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -60,12 +92,42 @@ export default {
 
     // Route: /api → proxy function calls to GAS
     if (url.pathname === '/api') {
-      return handleApi(request, url);
+      return handleApi(request, url, env, null);
     }
 
     // Route: / → Front Door landing page
     if (url.pathname === '/' && !url.searchParams.has('page')) {
       return serveFrontDoor();
+    }
+
+    // Route: /qa/* → QA mode (PIN-gated, QA workbook via per-request SSID override)
+    if (url.pathname.indexOf('/qa') === 0) {
+      // Explicit deny for finance surfaces
+      if (QA_DENIED[url.pathname]) {
+        return jsonResponse({ error: 'Finance surfaces are not available in QA mode' }, 403);
+      }
+      // /qa/api/verify-pin — check before /qa/api to avoid prefix match
+      if (url.pathname === '/qa/api/verify-pin' && request.method === 'POST') {
+        return handleVerifyPin(request, env, 'qa');
+      }
+      // /qa/api — proxy function calls to GAS with env=qa token
+      if (url.pathname === '/qa/api') {
+        if (!isValidQACookie(request, env)) {
+          return jsonResponse({ error: 'QA authentication required' }, 401);
+        }
+        return handleApi(request, url, env, 'qa');
+      }
+      // Allowlisted QA pages
+      if (QA_ROUTES[url.pathname]) {
+        if (!isValidQACookie(request, env)) {
+          return Response.redirect(
+            url.origin + '/?gate=qa&returnTo=' + encodeURIComponent(url.pathname), 302
+          );
+        }
+        return serveQAPage(request, url, env);
+      }
+      // Anything else under /qa — 403, never fallthrough to prod
+      return jsonResponse({ error: 'Route not available in QA mode' }, 403);
     }
 
     // Route: /pulse, /vein → Finance guard (cookie check)
@@ -198,7 +260,7 @@ async function servePage(request, url) {
 // HANDLE API — proxy function calls to GAS
 // ═══════════════════════════════════════════════════════════════════
 
-async function handleApi(request, url) {
+async function handleApi(request, url, env, envOverride) {
   var fn = url.searchParams.get('fn');
   if (!fn) {
     return jsonResponse({ error: 'Missing fn parameter' }, 400);
@@ -218,6 +280,13 @@ async function handleApi(request, url) {
 
   var target = GAS_URL + '?action=api&fn=' + encodeURIComponent(fn)
     + '&args=' + encodeURIComponent(args);
+
+  // v3.5: QA env override — append env=qa + per-request HMAC token
+  if (envOverride === 'qa' && env && env.QA_HMAC_SECRET) {
+    var ts = Date.now();
+    var hmac = await computeQAHmac_(ts + ':qa', env.QA_HMAC_SECRET);
+    target += '&env=qa&qa_token=' + encodeURIComponent(ts + ':' + hmac);
+  }
 
   try {
     var response = await fetch(target, { redirect: 'follow' });
@@ -418,6 +487,166 @@ function getShimScript() {
 
 
 // ═══════════════════════════════════════════════════════════════════
+// QA SHIM — Same as prod shim but API="/qa/api", /qa/* nav URLs,
+// amber non-dismissable banner. Injected on all /qa/* pages. (v3.5)
+// ═══════════════════════════════════════════════════════════════════
+
+function getQAShimScript() {
+  return '<script>\n' +
+'(function() {\n' +
+'  if (!window.goog) {\n' +
+'    window.goog = {\n' +
+'      provide: function() {},\n' +
+'      require: function() {},\n' +
+'      exportSymbol: function() {},\n' +
+'      exportProperty: function() {},\n' +
+'      isDefAndNotNull: function(a) { return a != null; },\n' +
+'      isDef: function(a) { return a !== undefined; },\n' +
+'      inherits: function(child, parent) {\n' +
+'        function T() {} T.prototype = parent.prototype;\n' +
+'        child.prototype = new T(); child.prototype.constructor = child;\n' +
+'      },\n' +
+'      base: function() {},\n' +
+'      string: { trim: function(s) { return s.trim(); } },\n' +
+'      dom: { getDocument: function() { return document; } },\n' +
+'      events: { listen: function() {} }\n' +
+'    };\n' +
+'  }\n' +
+'\n' +
+'  var API = "/qa/api";\n' +
+'\n' +
+'  function R() {\n' +
+'    this._ok = function() {};\n' +
+'    this._err = function(e) { console.error("[TBM-QA]", e); };\n' +
+'  }\n' +
+'\n' +
+'  R.prototype.withSuccessHandler = function(fn) {\n' +
+'    this._ok = fn || function() {};\n' +
+'    return this;\n' +
+'  };\n' +
+'\n' +
+'  R.prototype.withFailureHandler = function(fn) {\n' +
+'    this._err = fn || function() {};\n' +
+'    return this;\n' +
+'  };\n' +
+'\n' +
+'  var FNS = [\n' +
+'    "getDataSafe","getMonthsSafe","getCashFlowForecastSafe",\n' +
+'    "getSimulatorDataSafe","getWeeklyTrackerDataSafe",\n' +
+'    "getSubscriptionDataSafe","getCategoryTransactionsSafe",\n' +
+'    "getReconcileStatusSafe","reconcileVeinPulseSafe","getBoardDataSafe",\n' +
+'    "getSystemHealthSafe","getMERGateStatusSafe",\n' +
+'    "getCloseHistoryDataSafe",\n' +
+'    "getKidsHubDataSafe","getKidsHubWidgetDataSafe",\n' +
+'    "getKHLastModified","getSpineHeartbeatSafe",\n' +
+'    "khCompleteTaskSafe","khCompleteTaskWithBonusSafe","khUncompleteTaskSafe",\n' +
+'    "khApproveTaskSafe","khRejectTaskSafe",\n' +
+'    "khOverrideTaskSafe","khApproveWithBonusSafe",\n' +
+'    "khResetTasksSafe","khRedeemRewardSafe",\n' +
+'    "khSubmitRequestSafe","khApproveRequestSafe","khDenyRequestSafe",\n' +
+'    "khAddBonusTaskSafe","khDebitScreenTimeSafe",\n' +
+'    "khSetBankOpeningSafe","khVerifyPinSafe",\n' +
+'    "khAddDeductionSafe","khHealthCheckSafe",\n' +
+'    "khSubmitGradeSafe","khGetGradeHistorySafe",\n' +
+'    "updateFamilyNoteSafe","reconcileVeinPulse",\n' +
+'    "getVaultDataSafe","runStoryFactorySafe",\n' +
+'    "getDeployedVersionsSafe",\n' +
+'    "runMERGatesSafe","stampCloseMonthSafe",\n' +
+'    "addKidsEventSafe",\n' +
+'    "getKHLastModifiedSafe","getStoryApiStatsSafe",\n' +
+'    "khBatchApproveSafe","updateMealPlanSafe",\n' +
+'    "getTodayContentSafe","getAudioBatchSafe",\n' +
+'    "logHomeworkCompletionSafe","logSparkleProgressSafe",\n' +
+'    "awardRingsSafe","seedWeek1CurriculumSafe","seedStaarRlaSprintSafe","submitFeedbackSafe",\n' +
+'    "logQuestionResultSafe","savePowerScanResultsSafe","getWeeklyProgressSafe",\n' +
+'    "saveProgressSafe","loadProgressSafe","logScaffoldEventSafe","getWeekProgressSafe",\n' +
+'    "listStoredStoriesSafe","getStoryForReaderSafe","getStoryImagesSafe",\n' +
+'    "saveMissionStateSafe","getMissionStateSafe",\n' +
+'    "submitHomeworkSafe","getEducationQueueSafe","approveHomeworkSafe",\n' +
+'    "getDailyScheduleSafe",\n' +
+'    "checkDay1Safe",\n' +
+'    "saveDesignChoicesSafe",\n' +
+'    "getDesignChoicesSafe",\n' +
+'    "getDesignUnlockedSafe",\n' +
+'    "resetSandboxSafe",\n' +
+'    "getRecentTransactionsSafe",\n' +
+'    "getDailyMissionsInitSafe",\n' +
+'    "getAssetRegistrySafe"\n' +
+'  ];\n' +
+'\n' +
+'  for (var i = 0; i < FNS.length; i++) {\n' +
+'    (function(name) {\n' +
+'      R.prototype[name] = function() {\n' +
+'        var args = [];\n' +
+'        for (var j = 0; j < arguments.length; j++) args.push(arguments[j]);\n' +
+'        var self = this;\n' +
+'        fetch(API + "?fn=" + encodeURIComponent(name), {\n' +
+'          method: "POST",\n' +
+'          headers: { "Content-Type": "application/json" },\n' +
+'          body: JSON.stringify({ args: args })\n' +
+'        })\n' +
+'        .then(function(r) { return r.text(); })\n' +
+'        .then(function(t) {\n' +
+'          var parsed;\n' +
+'          try { parsed = JSON.parse(t); } catch(e) { parsed = t; }\n' +
+'          try { self._ok(parsed); } catch(e2) { console.error("[TBM-QA] Handler error in " + name + ":", e2); }\n' +
+'        })\n' +
+'        .catch(function(err) {\n' +
+'          try { self._err({ message: err.message || "Network error" }); } catch(e) {}\n' +
+'        });\n' +
+'      };\n' +
+'    })(FNS[i]);\n' +
+'  }\n' +
+'\n' +
+'  // OVERRIDE: return /qa base URL for QA nav\n' +
+'  R.prototype.getScriptUrlSafe = function() {\n' +
+'    var self = this;\n' +
+'    setTimeout(function() { self._ok(window.location.origin + "/qa"); }, 0);\n' +
+'  };\n' +
+'\n' +
+'  // OVERRIDE: return /qa/* app URLs for kid tablets\n' +
+'  R.prototype.getKHAppUrlsSafe = function() {\n' +
+'    var self = this;\n' +
+'    var b = window.location.origin;\n' +
+'    setTimeout(function() {\n' +
+'      self._ok({\n' +
+'        buggsy: b + "/qa/buggsy",\n' +
+'        jj: b + "/qa/jj",\n' +
+'        parent: b + "/qa/parent"\n' +
+'      });\n' +
+'    }, 0);\n' +
+'  };\n' +
+'\n' +
+'  var g = {};\n' +
+'  g.script = {};\n' +
+'  Object.defineProperty(g.script, "run", {\n' +
+'    get: function() { return new R(); }\n' +
+'  });\n' +
+'  window.google = g;\n' +
+'\n' +
+'  // QA amber banner — non-dismissable, injected once\n' +
+'  if (!window.__tbmQABanner) {\n' +
+'    window.__tbmQABanner = true;\n' +
+'    function injectQABanner() {\n' +
+'      var s = document.createElement("style");\n' +
+'      s.textContent = "body{padding-top:32px!important}";\n' +
+'      document.head.appendChild(s);\n' +
+'      var b = document.createElement("div");\n' +
+'      b.style.cssText = "position:fixed;top:0;left:0;right:0;z-index:99999;background:#f59e0b;color:#1a1a1a;font-weight:800;font-family:monospace;font-size:12px;text-align:center;padding:8px;letter-spacing:2px;pointer-events:none";\n' +
+'      b.textContent = "QA MODE \u2014 DATA IS NOT REAL";\n' +
+'      document.body.appendChild(b);\n' +
+'    }\n' +
+'    if (document.body) { injectQABanner(); }\n' +
+'    else { document.addEventListener("DOMContentLoaded", injectQABanner); }\n' +
+'  }\n' +
+'\n' +
+'  console.log("[TBM-QA] Smart Proxy v3.5 QA mode — " + FNS.length + " functions via /qa/api");\n' +
+'})();\n' +
+'</script>';
+}
+
+
+// ═══════════════════════════════════════════════════════════════════
 // FRONT DOOR — Landing page at thompsonfams.com/
 // ═══════════════════════════════════════════════════════════════════
 
@@ -436,16 +665,18 @@ function serveFrontDoor() {
 // PIN GATE — verify PIN + set auth cookie
 // ═══════════════════════════════════════════════════════════════════
 
-async function handleVerifyPin(request, env) {
+async function handleVerifyPin(request, env, gateType) {
   try {
     var body = await request.json();
     var pin = String(body.pin || '').replace(/\D/g, '').slice(0, 4);
-    var target = body.target === 'vein' ? 'vein' : 'pulse';
+    var isQA = gateType === 'qa';
+    var financeTarget = body.target === 'vein' ? 'vein' : 'pulse';
+    var rateLimitKey = isQA ? 'verify-pin:qa' : ('verify-pin:' + financeTarget);
 
     var clientIP = request.headers.get('CF-Connecting-IP') || 'unknown';
     if (env.PIN_RATE_LIMITER && typeof env.PIN_RATE_LIMITER.limit === 'function') {
       var rateLimitResult = await env.PIN_RATE_LIMITER.limit({
-        key: 'verify-pin:' + target + ':' + clientIP
+        key: rateLimitKey + ':' + clientIP
       });
       if (!rateLimitResult.success) {
         return new Response(
@@ -476,7 +707,20 @@ async function handleVerifyPin(request, env) {
     var hashHex = hashArr.map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
     var cookieVal = ts + ':' + hashHex;
 
-    return new Response(JSON.stringify({ ok: true, redirectTo: '/' + target }), {
+    if (isQA) {
+      // v3.5: QA gate — validate returnTo (must start with /qa/), set tbm_qa cookie
+      var returnTo = String(body.returnTo || '');
+      if (!returnTo || returnTo.indexOf('/qa/') !== 0) returnTo = '/qa/';
+      return new Response(JSON.stringify({ ok: true, redirectTo: returnTo }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Set-Cookie': 'tbm_qa=' + cookieVal + '; Path=/qa; HttpOnly; Secure; SameSite=Lax; Max-Age=14400'
+        }
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true, redirectTo: '/' + financeTarget }), {
       status: 200,
       headers: {
         'Content-Type': 'application/json',
@@ -487,6 +731,115 @@ async function handleVerifyPin(request, env) {
     return jsonResponse({ ok: false, error: 'Server error' }, 500);
   }
 }
+
+// ═══════════════════════════════════════════════════════════════════
+// QA COOKIE — tbm_qa, Path=/qa, 4h lifetime (v3.5)
+// ═══════════════════════════════════════════════════════════════════
+
+function isValidQACookie(request, env) {
+  if (!env.FINANCE_PIN) return false;
+  var cookies = request.headers.get('Cookie') || '';
+  var match = cookies.match(/tbm_qa=([^;]+)/);
+  if (!match) return false;
+  var parts = match[1].split(':');
+  if (parts.length !== 2) return false;
+  var ts = parts[0];
+  var hash = parts[1];
+  // Check expiry (4h = 14400000ms)
+  var age = Date.now() - parseInt(ts, 10);
+  if (isNaN(age) || age > 14400000 || age < 0) return false;
+  // SECURITY NOTE (R9-F07): Same structural check as finance cookie.
+  // crypto.subtle.digest is async-only. Accepted: validate structure
+  // (timestamp:64-char-hex) + expiry + HttpOnly/Secure/SameSite.
+  return hash.length === 64;
+}
+
+
+// ═══════════════════════════════════════════════════════════════════
+// SERVE QA PAGE — like servePage but env=qa + QA shim + HMAC token
+// ═══════════════════════════════════════════════════════════════════
+
+async function serveQAPage(request, url, env) {
+  var params = new URLSearchParams();
+  params.set('action', 'htmlSource');
+  params.set('env', 'qa');
+
+  // Generate per-request HMAC token so GAS can validate the env=qa override
+  if (env.QA_HMAC_SECRET) {
+    var ts = Date.now();
+    var hmac = await computeQAHmac_(ts + ':qa', env.QA_HMAC_SECRET);
+    params.set('qa_token', ts + ':' + hmac);
+  }
+
+  var qaRoute = QA_ROUTES[url.pathname];
+  if (qaRoute) {
+    for (var key in qaRoute) {
+      params.set(key, qaRoute[key]);
+    }
+  }
+
+  // Pass through extra query params (e.g. ?jt=1) but protect reserved keys
+  for (const [k, v] of url.searchParams) {
+    if (k !== 'action' && k !== 'env' && k !== 'qa_token' && !params.has(k)) {
+      params.set(k, v);
+    }
+  }
+
+  var target = GAS_URL + '?' + params.toString();
+
+  try {
+    var response = await fetch(target, { redirect: 'follow' });
+    if (!response.ok) {
+      return errorPage('GAS returned ' + response.status);
+    }
+    var html = await response.text();
+
+    if (html.charAt(0) === '{') {
+      try {
+        var err = JSON.parse(html);
+        if (err.error) return errorPage('GAS error: ' + err.error);
+      } catch(e) {}
+    }
+
+    // Inject QA-aware shim (different API endpoint + amber banner)
+    var qaShim = getQAShimScript();
+    if (html.indexOf('<head>') !== -1) {
+      html = html.replace('<head>', '<head>\n' + qaShim);
+    } else {
+      html = qaShim + '\n' + html;
+    }
+    if (html.indexOf('</body>') !== -1) {
+      html = html.replace('</body>', qaShim + '\n</body>');
+    }
+
+    return new Response(html, {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-cache'
+      }
+    });
+  } catch(err) {
+    return errorPage('Fetch failed: ' + err.message);
+  }
+}
+
+
+// ═══════════════════════════════════════════════════════════════════
+// QA HMAC HELPER — HMAC-SHA256 via Web Crypto API (async)
+// ═══════════════════════════════════════════════════════════════════
+
+async function computeQAHmac_(message, secret) {
+  var enc = new TextEncoder();
+  var keyMaterial = await crypto.subtle.importKey(
+    'raw', enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false, ['sign']
+  );
+  var sig = await crypto.subtle.sign('HMAC', keyMaterial, enc.encode(message));
+  var hashArr = Array.from(new Uint8Array(sig));
+  return hashArr.map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
+}
+
 
 function isValidFinanceCookie(request, env) {
   if (!env.FINANCE_PIN) return false;
@@ -512,4 +865,4 @@ function isValidFinanceCookie(request, env) {
 // FRONT DOOR HTML
 // ═══════════════════════════════════════════════════════════════════
 
-var FRONT_DOOR_HTML = '<!doctype html>\n<html lang="en">\n<head>\n  <meta charset="utf-8">\n  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">\n  <title>The Thompsons \u00b7 Family Management System</title>\n  <meta name="theme-color" content="#0d0d14">\n  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&family=Cormorant+Garamond:wght@300;400;600&family=Barlow+Condensed:wght@400;600;700;800&display=swap" rel="stylesheet">\n  <style>\n    :root{\n      --bg-base:#0d0d14;\n      --bg-gradient:linear-gradient(160deg,#0d0d14 0%,#111118 30%,#141420 60%,#0f0f1a 100%);\n      --glass-bg:rgba(255,255,255,0.05);\n      --glass-border:rgba(255,255,255,0.09);\n      --glass-hover:rgba(255,255,255,0.09);\n      --gold:#C9A84C;\n      --gold-soft:#e8d5a3;\n      --gold-dim:rgba(201,168,76,0.35);\n      --text-primary:#f0ede8;\n      --text-muted:rgba(240,237,232,0.6);\n      --text-dim:rgba(240,237,232,0.3);\n      --shadow-deep:0 24px 80px rgba(0,0,0,0.6);\n      --shadow-card:0 16px 40px rgba(0,0,0,0.35);\n      --radius:4px;\n      --ease:cubic-bezier(.22,.61,.36,1);\n      --mx:50%;\n      --my:50%;\n    }\n    *{box-sizing:border-box}html,body{margin:0;min-height:100%}\n    body{font-family:\'Barlow Condensed\',sans-serif;color:var(--text-primary);background:radial-gradient(ellipse 60% 50% at 50% 0%,rgba(201,168,76,0.08) 0%,transparent 60%),radial-gradient(ellipse 40% 35% at 15% 50%,rgba(92,40,51,0.12) 0%,transparent 55%),radial-gradient(ellipse 40% 35% at 85% 50%,rgba(30,58,138,0.10) 0%,transparent 55%),radial-gradient(ellipse 80% 60% at 50% 100%,rgba(30,20,10,0.4) 0%,transparent 70%),var(--bg-gradient);overflow-x:hidden}\n    .scene{position:relative;min-height:100vh;isolation:isolate;overflow:hidden}\n    .orb{position:absolute;border-radius:50%;filter:blur(18px);opacity:.65;pointer-events:none;mix-blend-mode:screen;animation:drift linear infinite}\n    .orb.one{width:42vw;height:42vw;left:-8vw;top:-6vw;background:radial-gradient(circle at 30% 30%,rgba(180,205,255,.52),rgba(180,205,255,0) 68%);animation-duration:28s}\n    .orb.two{width:30vw;height:30vw;right:-4vw;top:22vh;background:radial-gradient(circle at 35% 35%,rgba(246,212,152,.24),rgba(246,212,152,0) 70%);animation-duration:24s;animation-direction:reverse}\n    .orb.three{width:34vw;height:34vw;left:40vw;bottom:-10vw;background:radial-gradient(circle at 50% 50%,rgba(175,196,236,.22),rgba(175,196,236,0) 70%);animation-duration:30s}\n    .particles{position:absolute;inset:0;pointer-events:none;overflow:hidden;z-index:0}\n    .particle{position:absolute;bottom:-20px;width:4px;height:4px;border-radius:50%;background:radial-gradient(circle,rgba(253,230,138,.95) 0%,rgba(212,168,67,.75) 45%,rgba(212,168,67,0) 100%);box-shadow:0 0 10px rgba(253,230,138,.45);opacity:.75;animation:rise linear infinite}\n    .wrap{position:relative;z-index:2;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:32px 18px 48px}\n    .shell{width:min(100%,760px);display:flex;flex-direction:column;align-items:center}\n    .crest-wrap{position:relative;padding-top:clamp(20px,5vh,56px);margin-bottom:56px;transform-style:preserve-3d;will-change:transform;transition:transform .22s var(--ease);opacity:0;animation:introUp 0.9s var(--ease) 0.1s forwards}\n    .crest-glow{position:absolute;inset:auto 50% -20px auto;transform:translateX(50%);width:min(70vw,480px);height:min(30vw,200px);border-radius:50%;background:radial-gradient(ellipse at center,rgba(201,168,76,0.22) 0%,rgba(201,168,76,0.08) 40%,rgba(201,168,76,0) 70%);filter:blur(24px);z-index:-1;animation:pulseGlow 7s ease-in-out infinite}\n    .crest-ring{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:calc(min(240px,30vw) + 60px);height:calc(min(240px,30vw) + 60px);border-radius:50%;border:1px solid rgba(201,168,76,0.12);animation:pulseGlow 7s ease-in-out 1s infinite;pointer-events:none;z-index:-1}\n    .crest{width:clamp(240px,30vw,320px);max-width:80vw;display:block;filter:drop-shadow(0 0 40px rgba(201,168,76,0.20)) drop-shadow(0 20px 60px rgba(0,0,0,0.5));animation:crestFloat 6s ease-in-out infinite,crestTilt 14s ease-in-out infinite;user-select:none;-webkit-user-drag:none}\n    .brand{margin-top:18px;text-align:center;opacity:0;animation:introUp 0.7s var(--ease) 0.25s forwards}\n    .brand h1{margin:0;font-family:\'Cormorant Garamond\',serif;font-size:clamp(22px,3.2vw,34px);font-weight:300;letter-spacing:10px;color:var(--gold-soft);text-shadow:0 1px 0 rgba(0,0,0,0.08)}\n    .brand p{margin:10px 0 0;font-family:\'Barlow Condensed\',sans-serif;font-size:10px;letter-spacing:5px;text-transform:uppercase;color:var(--text-dim)}\n    .panel{width:min(100%,680px);transform-style:preserve-3d;transition:transform .22s var(--ease)}\n    .section{margin-bottom:26px}\n    .section:nth-child(1){opacity:0;animation:introUp 0.6s var(--ease) 0.4s forwards}\n    .section:nth-child(2){opacity:0;animation:introUp 0.6s var(--ease) 0.52s forwards}\n    .section:nth-child(3){opacity:0;animation:introUp 0.6s var(--ease) 0.64s forwards}\n    .section-head{display:flex;align-items:center;gap:10px;margin-bottom:12px;padding:0 6px}\n    .section-label{font-family:\'Barlow Condensed\',sans-serif;font-size:10px;letter-spacing:3px;text-transform:uppercase;color:rgba(201,168,76,0.70);font-weight:700}\n    .pill{font-size:10px;letter-spacing:1.4px;text-transform:uppercase;color:var(--gold-soft);border:1px solid rgba(253,230,138,.28);background:rgba(212,168,67,.10);padding:4px 8px;border-radius:999px}\n    .grid{display:grid;gap:14px}\n    .grid.family,.grid.education{grid-template-columns:repeat(3,minmax(0,1fr))}\n    .grid.finance{max-width:460px;margin:0 auto;grid-template-columns:repeat(2,minmax(0,1fr))}\n    .door{position:relative;display:block;text-decoration:none;color:inherit;min-height:102px;padding:18px 16px 16px;border-radius:4px;background:radial-gradient(circle at var(--mx) var(--my),rgba(255,255,255,.16) 0%,rgba(255,255,255,.06) 22%,rgba(255,255,255,.03) 38%,rgba(255,255,255,0) 60%),var(--glass-bg);border:1px solid var(--glass-border);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);box-shadow:var(--shadow-card);overflow:hidden;transform:translateY(0) scale(1);transition:transform .25s ease,border-color .25s ease,background .25s ease,box-shadow .25s ease}\n    .door::before{content:"";position:absolute;inset:-1px;background:linear-gradient(115deg,rgba(255,255,255,.18),rgba(255,255,255,0) 32%,rgba(253,230,138,.13) 52%,rgba(255,255,255,0) 74%);opacity:.35;pointer-events:none}\n    .door::after{content:"";position:absolute;inset:0;transform:translateX(-140%);background:linear-gradient(100deg,rgba(255,255,255,0) 0%,rgba(255,255,255,.12) 45%,rgba(255,255,255,0) 100%);transition:transform .7s var(--ease);pointer-events:none}\n    .door:hover,.door:focus-visible{border-color:rgba(253,230,138,.44);background:radial-gradient(circle at var(--mx) var(--my),rgba(255,255,255,.22) 0%,rgba(255,255,255,.10) 24%,rgba(255,255,255,.04) 42%,rgba(255,255,255,0) 62%),var(--glass-hover);transform:translateY(-2px) scale(1.02);box-shadow:0 20px 40px rgba(16,24,40,.18),0 0 0 1px rgba(253,230,138,.06) inset;outline:none}\n    .door:hover::after,.door:focus-visible::after{transform:translateX(140%)}\n    .door.locked{cursor:pointer}\n    .door.locked:active{transform:translateY(1px) scale(0.98)}\n    .icon{font-size:30px;line-height:1;margin-bottom:12px;filter:drop-shadow(0 4px 12px rgba(0,0,0,.15));transition:transform 0.25s ease}\n    .door:hover .icon,.door:focus-visible .icon{transform:translateY(-3px)}\n    .lock{position:absolute;top:10px;right:12px;font-size:15px;opacity:.5;transition:transform 0.3s ease}\n    .door.locked:hover .lock{transform:rotate(-8deg)}\n    .name{font-family:\'Barlow Condensed\',sans-serif;font-size:15px;font-weight:700;letter-spacing:0.5px;color:var(--text-primary);margin-bottom:5px}\n    .sub{font-size:11px;color:var(--text-muted);line-height:1.45;opacity:0.6;transition:opacity 0.25s ease}\n    .door:hover .sub,.door:focus-visible .sub{opacity:1}\n    footer{margin-top:8px;font-size:11px;letter-spacing:2px;text-transform:uppercase;color:rgba(240,242,248,.20);text-align:center;opacity:0;animation:introUp 0.5s var(--ease) 0.76s forwards}\n    .gate{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;z-index:50;background:rgba(13,19,33,.60);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px)}\n    .gate.show{display:flex}\n    .gate-card{width:min(100%,300px);border-radius:4px;padding:24px 22px 20px;background:rgba(13,13,20,0.92);border:1px solid rgba(201,168,76,0.25);box-shadow:0 0 0 1px rgba(201,168,76,0.08),0 24px 70px rgba(0,0,0,0.7),0 0 60px rgba(201,168,76,0.04);text-align:center;backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);transform:translateY(8px) scale(.985);animation:gateIn .25s var(--ease) forwards}\n    .gate-crest{width:80px;display:block;margin:0 auto 12px;filter:drop-shadow(0 12px 28px rgba(0,0,0,.22))}\n    .gate-title{margin:0 0 14px;color:var(--gold-soft);font-family:\'Cormorant Garamond\',serif;font-size:30px;font-weight:400;letter-spacing:.5px}\n    .gate-target{margin:-4px 0 14px;font-size:11px;letter-spacing:2px;text-transform:uppercase;color:var(--text-dim)}\n    .pin{width:100%;background:transparent;border:none;border-bottom:2px solid rgba(201,168,76,0.35);border-radius:0;color:var(--text-primary);font-size:34px;line-height:1.2;text-align:center;letter-spacing:16px;padding:8px 10px 12px 22px;outline:none;font-family:\'Cormorant Garamond\',serif;transition:border-color .2s ease,box-shadow .2s ease}\n    .pin:focus{border-bottom-color:rgba(201,168,76,0.9);box-shadow:0 12px 28px rgba(201,168,76,0.08)}\n    .pin.error{border-bottom-color:#ff8383;animation:shake .4s linear}\n    .gate-actions{margin-top:18px}\n    .enter-btn{width:100%;border:none;border-radius:999px;padding:12px 16px;color:#1f1b10;font-size:14px;font-weight:800;cursor:pointer;background:linear-gradient(135deg,#f3d17a 0%,#d4a843 55%,#b8882f 100%);box-shadow:0 10px 24px rgba(212,168,67,.28);transition:transform .2s ease,box-shadow .2s ease,filter .2s ease}\n    .enter-btn:hover{transform:translateY(-1px);box-shadow:0 14px 28px rgba(212,168,67,.32);filter:brightness(1.02)}\n    .cancel-btn{appearance:none;border:none;background:transparent;color:var(--text-dim);font-size:13px;margin-top:12px;cursor:pointer}\n    .error-msg{min-height:18px;margin-top:10px;font-size:12px;color:#ffb1b1}\n    .door[href*=\"buggsy\"]:hover,.door[href*=\"buggsy\"]:focus-visible{border-color:rgba(245,158,11,0.4);box-shadow:0 20px 40px rgba(0,0,0,0.25),0 0 20px rgba(245,158,11,0.06) inset}\n    .door[href*=\"jj\"]:hover,.door[href*=\"jj\"]:focus-visible{border-color:rgba(236,72,153,0.4);box-shadow:0 20px 40px rgba(0,0,0,0.25),0 0 20px rgba(236,72,153,0.06) inset}\n    .door[href*=\"parent\"]:hover,.door[href*=\"parent\"]:focus-visible{border-color:rgba(201,168,76,0.35)}\n    .door[href*=\"homework\"]:hover,.door[href*=\"homework\"]:focus-visible{border-color:rgba(245,158,11,0.35)}\n    .door[href*=\"sparkle\"]:hover,.door[href*=\"sparkle\"]:focus-visible{border-color:rgba(168,85,247,0.35)}\n    .door.locked[data-locked=\"pulse\"]:hover{border-color:rgba(184,131,106,0.5);box-shadow:0 20px 40px rgba(0,0,0,0.25),0 0 20px rgba(92,40,51,0.12) inset}\n    .door.locked[data-locked=\"vein\"]:hover{border-color:rgba(37,99,235,0.4);box-shadow:0 20px 40px rgba(0,0,0,0.25),0 0 20px rgba(30,58,138,0.12) inset}\n    @keyframes introUp{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:translateY(0)}}\n    @keyframes crestFloat{0%,100%{transform:translateY(0px) rotate(0deg)}50%{transform:translateY(-4px) rotate(0deg)}}\n    @keyframes crestTilt{0%,100%{transform:rotate(0deg)}50%{transform:rotate(0.8deg)}}\n    @keyframes drift{0%{transform:translate3d(0,0,0) scale(1)}50%{transform:translate3d(2vw,1.4vw,0) scale(1.04)}100%{transform:translate3d(0,0,0) scale(1)}}\n    @keyframes rise{0%{transform:translateY(0) scale(.7);opacity:0}12%{opacity:.78}100%{transform:translateY(-110vh) scale(1.08);opacity:0}}\n    @keyframes pulseGlow{0%,100%{opacity:.42;transform:translateX(50%) scale(1)}50%{opacity:.64;transform:translateX(50%) scale(1.08)}}\n    @keyframes gateIn{to{transform:translateY(0) scale(1)}}\n    @keyframes shake{0%,100%{transform:translateX(0)}16%{transform:translateX(-8px)}32%{transform:translateX(8px)}48%{transform:translateX(-8px)}64%{transform:translateX(8px)}80%{transform:translateX(-5px)}}\n    @media(max-width:700px){.grid.family,.grid.education{grid-template-columns:repeat(2,minmax(0,1fr))}}\n    @media(max-width:480px){.wrap{padding-top:22px}.crest-wrap{margin-bottom:44px}.grid.family,.grid.education{grid-template-columns:repeat(2,minmax(0,1fr))}.grid.finance{grid-template-columns:repeat(2,minmax(0,1fr))}.door{min-height:96px}.brand h1{letter-spacing:4px}.brand p{letter-spacing:3px}}\n    @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important;scroll-behavior:auto!important}}\n  </style>\n</head>\n<body>\n  <div class="scene" id="scene">\n    <div class="orb one"></div><div class="orb two"></div><div class="orb three"></div>\n    <div class="particles" id="particles"></div>\n    <div class="wrap"><div class="shell">\n      <div class="crest-wrap" id="crestWrap">\n        <div class="crest-glow"></div>\n        <img class="crest" src="https://i.ibb.co/FLDTT6QH/1774020751171.png" alt="Thompson family crest"/>\n        <div class="brand"><h1>THE THOMPSONS</h1><p>Every Thompson \u00b7 Every Day</p></div>\n      </div>\n      <div class="panel" id="panel">\n        <section class="section"><div class="section-head"><div class="section-label">Family</div></div>\n          <div class="grid family">\n            <a class="door" href="/buggsy" data-card><div class="icon">\uD83D\uDC3A</div><div class="name">Buggsy</div><div class="sub">Chore board</div></a>\n            <a class="door" href="/jj" data-card><div class="icon">\u2728</div><div class="name">JJ</div><div class="sub">Chore board</div></a>\n            <a class="door" href="/parent" data-card><div class="icon">\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC66</div><div class="name">Parent Hub</div><div class="sub">Approvals</div></a>\n          </div>\n        </section>\n        <section class="section"><div class="section-head"><div class="section-label">Education</div></div>\n          <div class="grid education">\n            <a class="door" href="/homework" data-card><div class="icon">\uD83D\uDCDA</div><div class="name">Homework</div><div class="sub">Buggsy</div></a>\n            <a class="door" href="/sparkle" data-card><div class="icon">\uD83C\uDF1F</div><div class="name">SparkleLearn</div><div class="sub">JJ</div></a>\n            <a class="door" href="/daily-missions" data-card><div class="icon">\uD83C\uDFAF</div><div class="name">Daily Missions</div><div class="sub">Progress and goals</div></a>\n          </div>\n        </section>\n        <section class="section"><div class="section-head"><div class="section-label">Finance</div><div class="pill">PIN Required</div></div>\n          <div class="grid finance">\n            <a class="door locked" href="/pulse" data-card data-locked="pulse"><div class="lock">\uD83D\uDD12</div><div class="icon">\uD83E\uDEC0</div><div class="name">ThePulse</div><div class="sub">Daily finance</div></a>\n            <a class="door locked" href="/vein" data-card data-locked="vein"><div class="lock">\uD83D\uDD12</div><div class="icon">\uD83E\uDDE0</div><div class="name">TheVein</div><div class="sub">Command center</div></a>\n          </div>\n        </section>\n        <footer>TBM \u00b7 thompsonfams.com</footer>\n      </div>\n    </div></div>\n  </div>\n  <div class="gate" id="gate"><div class="gate-card">\n    <img class="gate-crest" src="https://i.ibb.co/FLDTT6QH/1774020751171.png" alt="Thompson family crest"/>\n    <h2 class="gate-title">Enter PIN</h2>\n    <div class="gate-target" id="gateTarget">Finance Access</div>\n    <input class="pin" id="pinInput" type="password" inputmode="numeric" pattern="[0-9]*" maxlength="4" autocomplete="one-time-code" aria-label="4 digit PIN"/>\n    <div class="gate-actions"><button class="enter-btn" id="enterBtn">Enter</button><button class="cancel-btn" id="cancelBtn" type="button">Cancel</button><div class="error-msg" id="errorMsg"></div></div>\n  </div></div>\n  <script>\n(function(){\n  var scene=document.getElementById("scene"),panel=document.getElementById("panel"),crestWrap=document.getElementById("crestWrap"),particles=document.getElementById("particles"),gate=document.getElementById("gate"),pinInput=document.getElementById("pinInput"),enterBtn=document.getElementById("enterBtn"),cancelBtn=document.getElementById("cancelBtn"),errorMsg=document.getElementById("errorMsg"),gateTarget=document.getElementById("gateTarget"),currentTarget="pulse",reduceMotion=window.matchMedia&&window.matchMedia("(prefers-reduced-motion: reduce)").matches;\n  function createParticles(){if(!particles||reduceMotion)return;for(var i=0;i<10;i++){var d=document.createElement("span");d.className="particle";d.style.left=(6+Math.random()*88)+"%";d.style.width=(3+Math.random()*2.6)+"px";d.style.height=d.style.width;d.style.animationDuration=(20+Math.random()*12)+"s";d.style.animationDelay=(Math.random()*10)+"s";d.style.opacity=(0.32+Math.random()*0.5).toFixed(2);particles.appendChild(d)}}\n  function onMove(e){if(reduceMotion)return;var x=e.clientX/window.innerWidth,y=e.clientY/window.innerHeight;var rx=(y-0.5)*-7,ry=(x-0.5)*10;crestWrap.style.transform="perspective(1000px) rotateX("+(rx*0.7)+"deg) rotateY("+(ry*0.9)+"deg)";panel.style.transform="perspective(1200px) rotateX("+(rx*0.35)+"deg) rotateY("+(ry*0.45)+"deg)";document.documentElement.style.setProperty("--mx",(x*100).toFixed(2)+"%");document.documentElement.style.setProperty("--my",(y*100).toFixed(2)+"%")}\n  var cards=document.querySelectorAll("[data-card]");for(var ci=0;ci<cards.length;ci++){(function(card){card.addEventListener("mousemove",function(ev){var r=card.getBoundingClientRect();var x=((ev.clientX-r.left)/r.width)*100;var y=((ev.clientY-r.top)/r.height)*100;card.style.setProperty("--mx",x.toFixed(2)+"%");card.style.setProperty("--my",y.toFixed(2)+"%")})})(cards[ci])}\n  function openGate(target){currentTarget=target==="vein"?"vein":"pulse";gate.classList.add("show");gateTarget.textContent=currentTarget==="vein"?"TheVein":"ThePulse";errorMsg.textContent="";pinInput.value="";pinInput.classList.remove("error");setTimeout(function(){pinInput.focus()},10)}\n  function closeGate(){gate.classList.remove("show");errorMsg.textContent="";pinInput.value="";pinInput.classList.remove("error")}\n  function showPinError(msg){errorMsg.textContent=msg||"Incorrect PIN";pinInput.value="";pinInput.classList.remove("error");void pinInput.offsetWidth;pinInput.classList.add("error");pinInput.focus()}\n  function submitPin(){var pin=(pinInput.value||"").replace(/\\D/g,"").slice(0,4);pinInput.value=pin;if(pin.length!==4){showPinError("Enter all 4 digits");return}enterBtn.disabled=true;errorMsg.textContent="";var xhr=new XMLHttpRequest();xhr.open("POST","/api/verify-pin",true);xhr.setRequestHeader("Content-Type","application/json");xhr.onreadystatechange=function(){if(xhr.readyState!==4)return;enterBtn.disabled=false;try{var data=JSON.parse(xhr.responseText);if(xhr.status===200&&data.ok){window.location.href=data.redirectTo||("/"+currentTarget)}else{showPinError(data.error||"Incorrect PIN")}}catch(e){showPinError("Connection issue")}};xhr.onerror=function(){enterBtn.disabled=false;showPinError("Connection issue")};xhr.send(JSON.stringify({pin:pin,target:currentTarget}))}\n  var locked=document.querySelectorAll("[data-locked]");for(var li=0;li<locked.length;li++){(function(el){el.addEventListener("click",function(ev){ev.preventDefault();openGate(el.getAttribute("data-locked"))})})(locked[li])}\n  enterBtn.addEventListener("click",submitPin);cancelBtn.addEventListener("click",closeGate);\n  pinInput.addEventListener("input",function(){pinInput.value=pinInput.value.replace(/\\D/g,"").slice(0,4);pinInput.classList.remove("error");errorMsg.textContent=""});\n  pinInput.addEventListener("keydown",function(e){if(e.key==="Enter")submitPin();if(e.key==="Escape")closeGate()});\n  gate.addEventListener("click",function(e){if(e.target===gate)closeGate()});\n  window.addEventListener("mousemove",onMove,{passive:true});\n  window.addEventListener("mouseleave",function(){crestWrap.style.transform="";panel.style.transform=""});\n  createParticles();\n  var qs=window.location.search;var gateMatch=qs.match(/[?&]gate=([^&]*)/);var gateParam=gateMatch?gateMatch[1].toLowerCase():"";\n  if(gateParam==="pulse"||gateParam==="vein"){openGate(gateParam)}\n})();\n  </script>\n</body>\n</html>';
+var FRONT_DOOR_HTML = '<!doctype html>\n<html lang="en">\n<head>\n  <meta charset="utf-8">\n  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">\n  <title>The Thompsons \u00b7 Family Management System</title>\n  <meta name="theme-color" content="#0d0d14">\n  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&family=Cormorant+Garamond:wght@300;400;600&family=Barlow+Condensed:wght@400;600;700;800&display=swap" rel="stylesheet">\n  <style>\n    :root{\n      --bg-base:#0d0d14;\n      --bg-gradient:linear-gradient(160deg,#0d0d14 0%,#111118 30%,#141420 60%,#0f0f1a 100%);\n      --glass-bg:rgba(255,255,255,0.05);\n      --glass-border:rgba(255,255,255,0.09);\n      --glass-hover:rgba(255,255,255,0.09);\n      --gold:#C9A84C;\n      --gold-soft:#e8d5a3;\n      --gold-dim:rgba(201,168,76,0.35);\n      --text-primary:#f0ede8;\n      --text-muted:rgba(240,237,232,0.6);\n      --text-dim:rgba(240,237,232,0.3);\n      --shadow-deep:0 24px 80px rgba(0,0,0,0.6);\n      --shadow-card:0 16px 40px rgba(0,0,0,0.35);\n      --radius:4px;\n      --ease:cubic-bezier(.22,.61,.36,1);\n      --mx:50%;\n      --my:50%;\n    }\n    *{box-sizing:border-box}html,body{margin:0;min-height:100%}\n    body{font-family:\'Barlow Condensed\',sans-serif;color:var(--text-primary);background:radial-gradient(ellipse 60% 50% at 50% 0%,rgba(201,168,76,0.08) 0%,transparent 60%),radial-gradient(ellipse 40% 35% at 15% 50%,rgba(92,40,51,0.12) 0%,transparent 55%),radial-gradient(ellipse 40% 35% at 85% 50%,rgba(30,58,138,0.10) 0%,transparent 55%),radial-gradient(ellipse 80% 60% at 50% 100%,rgba(30,20,10,0.4) 0%,transparent 70%),var(--bg-gradient);overflow-x:hidden}\n    .scene{position:relative;min-height:100vh;isolation:isolate;overflow:hidden}\n    .orb{position:absolute;border-radius:50%;filter:blur(18px);opacity:.65;pointer-events:none;mix-blend-mode:screen;animation:drift linear infinite}\n    .orb.one{width:42vw;height:42vw;left:-8vw;top:-6vw;background:radial-gradient(circle at 30% 30%,rgba(180,205,255,.52),rgba(180,205,255,0) 68%);animation-duration:28s}\n    .orb.two{width:30vw;height:30vw;right:-4vw;top:22vh;background:radial-gradient(circle at 35% 35%,rgba(246,212,152,.24),rgba(246,212,152,0) 70%);animation-duration:24s;animation-direction:reverse}\n    .orb.three{width:34vw;height:34vw;left:40vw;bottom:-10vw;background:radial-gradient(circle at 50% 50%,rgba(175,196,236,.22),rgba(175,196,236,0) 70%);animation-duration:30s}\n    .particles{position:absolute;inset:0;pointer-events:none;overflow:hidden;z-index:0}\n    .particle{position:absolute;bottom:-20px;width:4px;height:4px;border-radius:50%;background:radial-gradient(circle,rgba(253,230,138,.95) 0%,rgba(212,168,67,.75) 45%,rgba(212,168,67,0) 100%);box-shadow:0 0 10px rgba(253,230,138,.45);opacity:.75;animation:rise linear infinite}\n    .wrap{position:relative;z-index:2;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:32px 18px 48px}\n    .shell{width:min(100%,760px);display:flex;flex-direction:column;align-items:center}\n    .crest-wrap{position:relative;padding-top:clamp(20px,5vh,56px);margin-bottom:56px;transform-style:preserve-3d;will-change:transform;transition:transform .22s var(--ease);opacity:0;animation:introUp 0.9s var(--ease) 0.1s forwards}\n    .crest-glow{position:absolute;inset:auto 50% -20px auto;transform:translateX(50%);width:min(70vw,480px);height:min(30vw,200px);border-radius:50%;background:radial-gradient(ellipse at center,rgba(201,168,76,0.22) 0%,rgba(201,168,76,0.08) 40%,rgba(201,168,76,0) 70%);filter:blur(24px);z-index:-1;animation:pulseGlow 7s ease-in-out infinite}\n    .crest-ring{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:calc(min(240px,30vw) + 60px);height:calc(min(240px,30vw) + 60px);border-radius:50%;border:1px solid rgba(201,168,76,0.12);animation:pulseGlow 7s ease-in-out 1s infinite;pointer-events:none;z-index:-1}\n    .crest{width:clamp(240px,30vw,320px);max-width:80vw;display:block;filter:drop-shadow(0 0 40px rgba(201,168,76,0.20)) drop-shadow(0 20px 60px rgba(0,0,0,0.5));animation:crestFloat 6s ease-in-out infinite,crestTilt 14s ease-in-out infinite;user-select:none;-webkit-user-drag:none}\n    .brand{margin-top:18px;text-align:center;opacity:0;animation:introUp 0.7s var(--ease) 0.25s forwards}\n    .brand h1{margin:0;font-family:\'Cormorant Garamond\',serif;font-size:clamp(22px,3.2vw,34px);font-weight:300;letter-spacing:10px;color:var(--gold-soft);text-shadow:0 1px 0 rgba(0,0,0,0.08)}\n    .brand p{margin:10px 0 0;font-family:\'Barlow Condensed\',sans-serif;font-size:10px;letter-spacing:5px;text-transform:uppercase;color:var(--text-dim)}\n    .panel{width:min(100%,680px);transform-style:preserve-3d;transition:transform .22s var(--ease)}\n    .section{margin-bottom:26px}\n    .section:nth-child(1){opacity:0;animation:introUp 0.6s var(--ease) 0.4s forwards}\n    .section:nth-child(2){opacity:0;animation:introUp 0.6s var(--ease) 0.52s forwards}\n    .section:nth-child(3){opacity:0;animation:introUp 0.6s var(--ease) 0.64s forwards}\n    .section-head{display:flex;align-items:center;gap:10px;margin-bottom:12px;padding:0 6px}\n    .section-label{font-family:\'Barlow Condensed\',sans-serif;font-size:10px;letter-spacing:3px;text-transform:uppercase;color:rgba(201,168,76,0.70);font-weight:700}\n    .pill{font-size:10px;letter-spacing:1.4px;text-transform:uppercase;color:var(--gold-soft);border:1px solid rgba(253,230,138,.28);background:rgba(212,168,67,.10);padding:4px 8px;border-radius:999px}\n    .grid{display:grid;gap:14px}\n    .grid.family,.grid.education{grid-template-columns:repeat(3,minmax(0,1fr))}\n    .grid.finance{max-width:460px;margin:0 auto;grid-template-columns:repeat(2,minmax(0,1fr))}\n    .door{position:relative;display:block;text-decoration:none;color:inherit;min-height:102px;padding:18px 16px 16px;border-radius:4px;background:radial-gradient(circle at var(--mx) var(--my),rgba(255,255,255,.16) 0%,rgba(255,255,255,.06) 22%,rgba(255,255,255,.03) 38%,rgba(255,255,255,0) 60%),var(--glass-bg);border:1px solid var(--glass-border);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);box-shadow:var(--shadow-card);overflow:hidden;transform:translateY(0) scale(1);transition:transform .25s ease,border-color .25s ease,background .25s ease,box-shadow .25s ease}\n    .door::before{content:"";position:absolute;inset:-1px;background:linear-gradient(115deg,rgba(255,255,255,.18),rgba(255,255,255,0) 32%,rgba(253,230,138,.13) 52%,rgba(255,255,255,0) 74%);opacity:.35;pointer-events:none}\n    .door::after{content:"";position:absolute;inset:0;transform:translateX(-140%);background:linear-gradient(100deg,rgba(255,255,255,0) 0%,rgba(255,255,255,.12) 45%,rgba(255,255,255,0) 100%);transition:transform .7s var(--ease);pointer-events:none}\n    .door:hover,.door:focus-visible{border-color:rgba(253,230,138,.44);background:radial-gradient(circle at var(--mx) var(--my),rgba(255,255,255,.22) 0%,rgba(255,255,255,.10) 24%,rgba(255,255,255,.04) 42%,rgba(255,255,255,0) 62%),var(--glass-hover);transform:translateY(-2px) scale(1.02);box-shadow:0 20px 40px rgba(16,24,40,.18),0 0 0 1px rgba(253,230,138,.06) inset;outline:none}\n    .door:hover::after,.door:focus-visible::after{transform:translateX(140%)}\n    .door.locked{cursor:pointer}\n    .door.locked:active{transform:translateY(1px) scale(0.98)}\n    .icon{font-size:30px;line-height:1;margin-bottom:12px;filter:drop-shadow(0 4px 12px rgba(0,0,0,.15));transition:transform 0.25s ease}\n    .door:hover .icon,.door:focus-visible .icon{transform:translateY(-3px)}\n    .lock{position:absolute;top:10px;right:12px;font-size:15px;opacity:.5;transition:transform 0.3s ease}\n    .door.locked:hover .lock{transform:rotate(-8deg)}\n    .name{font-family:\'Barlow Condensed\',sans-serif;font-size:15px;font-weight:700;letter-spacing:0.5px;color:var(--text-primary);margin-bottom:5px}\n    .sub{font-size:11px;color:var(--text-muted);line-height:1.45;opacity:0.6;transition:opacity 0.25s ease}\n    .door:hover .sub,.door:focus-visible .sub{opacity:1}\n    footer{margin-top:8px;font-size:11px;letter-spacing:2px;text-transform:uppercase;color:rgba(240,242,248,.20);text-align:center;opacity:0;animation:introUp 0.5s var(--ease) 0.76s forwards}\n    .gate{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;z-index:50;background:rgba(13,19,33,.60);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px)}\n    .gate.show{display:flex}\n    .gate-card{width:min(100%,300px);border-radius:4px;padding:24px 22px 20px;background:rgba(13,13,20,0.92);border:1px solid rgba(201,168,76,0.25);box-shadow:0 0 0 1px rgba(201,168,76,0.08),0 24px 70px rgba(0,0,0,0.7),0 0 60px rgba(201,168,76,0.04);text-align:center;backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);transform:translateY(8px) scale(.985);animation:gateIn .25s var(--ease) forwards}\n    .gate-crest{width:80px;display:block;margin:0 auto 12px;filter:drop-shadow(0 12px 28px rgba(0,0,0,.22))}\n    .gate-title{margin:0 0 14px;color:var(--gold-soft);font-family:\'Cormorant Garamond\',serif;font-size:30px;font-weight:400;letter-spacing:.5px}\n    .gate-target{margin:-4px 0 14px;font-size:11px;letter-spacing:2px;text-transform:uppercase;color:var(--text-dim)}\n    .pin{width:100%;background:transparent;border:none;border-bottom:2px solid rgba(201,168,76,0.35);border-radius:0;color:var(--text-primary);font-size:34px;line-height:1.2;text-align:center;letter-spacing:16px;padding:8px 10px 12px 22px;outline:none;font-family:\'Cormorant Garamond\',serif;transition:border-color .2s ease,box-shadow .2s ease}\n    .pin:focus{border-bottom-color:rgba(201,168,76,0.9);box-shadow:0 12px 28px rgba(201,168,76,0.08)}\n    .pin.error{border-bottom-color:#ff8383;animation:shake .4s linear}\n    .gate-actions{margin-top:18px}\n    .enter-btn{width:100%;border:none;border-radius:999px;padding:12px 16px;color:#1f1b10;font-size:14px;font-weight:800;cursor:pointer;background:linear-gradient(135deg,#f3d17a 0%,#d4a843 55%,#b8882f 100%);box-shadow:0 10px 24px rgba(212,168,67,.28);transition:transform .2s ease,box-shadow .2s ease,filter .2s ease}\n    .enter-btn:hover{transform:translateY(-1px);box-shadow:0 14px 28px rgba(212,168,67,.32);filter:brightness(1.02)}\n    .cancel-btn{appearance:none;border:none;background:transparent;color:var(--text-dim);font-size:13px;margin-top:12px;cursor:pointer}\n    .error-msg{min-height:18px;margin-top:10px;font-size:12px;color:#ffb1b1}\n    .door[href*=\"buggsy\"]:hover,.door[href*=\"buggsy\"]:focus-visible{border-color:rgba(245,158,11,0.4);box-shadow:0 20px 40px rgba(0,0,0,0.25),0 0 20px rgba(245,158,11,0.06) inset}\n    .door[href*=\"jj\"]:hover,.door[href*=\"jj\"]:focus-visible{border-color:rgba(236,72,153,0.4);box-shadow:0 20px 40px rgba(0,0,0,0.25),0 0 20px rgba(236,72,153,0.06) inset}\n    .door[href*=\"parent\"]:hover,.door[href*=\"parent\"]:focus-visible{border-color:rgba(201,168,76,0.35)}\n    .door[href*=\"homework\"]:hover,.door[href*=\"homework\"]:focus-visible{border-color:rgba(245,158,11,0.35)}\n    .door[href*=\"sparkle\"]:hover,.door[href*=\"sparkle\"]:focus-visible{border-color:rgba(168,85,247,0.35)}\n    .door.locked[data-locked=\"pulse\"]:hover{border-color:rgba(184,131,106,0.5);box-shadow:0 20px 40px rgba(0,0,0,0.25),0 0 20px rgba(92,40,51,0.12) inset}\n    .door.locked[data-locked=\"vein\"]:hover{border-color:rgba(37,99,235,0.4);box-shadow:0 20px 40px rgba(0,0,0,0.25),0 0 20px rgba(30,58,138,0.12) inset}\n    @keyframes introUp{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:translateY(0)}}\n    @keyframes crestFloat{0%,100%{transform:translateY(0px) rotate(0deg)}50%{transform:translateY(-4px) rotate(0deg)}}\n    @keyframes crestTilt{0%,100%{transform:rotate(0deg)}50%{transform:rotate(0.8deg)}}\n    @keyframes drift{0%{transform:translate3d(0,0,0) scale(1)}50%{transform:translate3d(2vw,1.4vw,0) scale(1.04)}100%{transform:translate3d(0,0,0) scale(1)}}\n    @keyframes rise{0%{transform:translateY(0) scale(.7);opacity:0}12%{opacity:.78}100%{transform:translateY(-110vh) scale(1.08);opacity:0}}\n    @keyframes pulseGlow{0%,100%{opacity:.42;transform:translateX(50%) scale(1)}50%{opacity:.64;transform:translateX(50%) scale(1.08)}}\n    @keyframes gateIn{to{transform:translateY(0) scale(1)}}\n    @keyframes shake{0%,100%{transform:translateX(0)}16%{transform:translateX(-8px)}32%{transform:translateX(8px)}48%{transform:translateX(-8px)}64%{transform:translateX(8px)}80%{transform:translateX(-5px)}}\n    @media(max-width:700px){.grid.family,.grid.education{grid-template-columns:repeat(2,minmax(0,1fr))}}\n    @media(max-width:480px){.wrap{padding-top:22px}.crest-wrap{margin-bottom:44px}.grid.family,.grid.education{grid-template-columns:repeat(2,minmax(0,1fr))}.grid.finance{grid-template-columns:repeat(2,minmax(0,1fr))}.door{min-height:96px}.brand h1{letter-spacing:4px}.brand p{letter-spacing:3px}}\n    @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important;scroll-behavior:auto!important}}\n  </style>\n</head>\n<body>\n  <div class="scene" id="scene">\n    <div class="orb one"></div><div class="orb two"></div><div class="orb three"></div>\n    <div class="particles" id="particles"></div>\n    <div class="wrap"><div class="shell">\n      <div class="crest-wrap" id="crestWrap">\n        <div class="crest-glow"></div>\n        <img class="crest" src="https://i.ibb.co/FLDTT6QH/1774020751171.png" alt="Thompson family crest"/>\n        <div class="brand"><h1>THE THOMPSONS</h1><p>Every Thompson \u00b7 Every Day</p></div>\n      </div>\n      <div class="panel" id="panel">\n        <section class="section"><div class="section-head"><div class="section-label">Family</div></div>\n          <div class="grid family">\n            <a class="door" href="/buggsy" data-card><div class="icon">\uD83D\uDC3A</div><div class="name">Buggsy</div><div class="sub">Chore board</div></a>\n            <a class="door" href="/jj" data-card><div class="icon">\u2728</div><div class="name">JJ</div><div class="sub">Chore board</div></a>\n            <a class="door" href="/parent" data-card><div class="icon">\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC66</div><div class="name">Parent Hub</div><div class="sub">Approvals</div></a>\n          </div>\n        </section>\n        <section class="section"><div class="section-head"><div class="section-label">Education</div></div>\n          <div class="grid education">\n            <a class="door" href="/homework" data-card><div class="icon">\uD83D\uDCDA</div><div class="name">Homework</div><div class="sub">Buggsy</div></a>\n            <a class="door" href="/sparkle" data-card><div class="icon">\uD83C\uDF1F</div><div class="name">SparkleLearn</div><div class="sub">JJ</div></a>\n            <a class="door" href="/daily-missions" data-card><div class="icon">\uD83C\uDFAF</div><div class="name">Daily Missions</div><div class="sub">Progress and goals</div></a>\n          </div>\n        </section>\n        <section class="section"><div class="section-head"><div class="section-label">Finance</div><div class="pill">PIN Required</div></div>\n          <div class="grid finance">\n            <a class="door locked" href="/pulse" data-card data-locked="pulse"><div class="lock">\uD83D\uDD12</div><div class="icon">\uD83E\uDEC0</div><div class="name">ThePulse</div><div class="sub">Daily finance</div></a>\n            <a class="door locked" href="/vein" data-card data-locked="vein"><div class="lock">\uD83D\uDD12</div><div class="icon">\uD83E\uDDE0</div><div class="name">TheVein</div><div class="sub">Command center</div></a>\n          </div>\n        </section>\n        <footer>TBM \u00b7 thompsonfams.com</footer>\n      </div>\n    </div></div>\n  </div>\n  <div class="gate" id="gate"><div class="gate-card">\n    <img class="gate-crest" src="https://i.ibb.co/FLDTT6QH/1774020751171.png" alt="Thompson family crest"/>\n    <h2 class="gate-title">Enter PIN</h2>\n    <div class="gate-target" id="gateTarget">Finance Access</div>\n    <input class="pin" id="pinInput" type="password" inputmode="numeric" pattern="[0-9]*" maxlength="4" autocomplete="one-time-code" aria-label="4 digit PIN"/>\n    <div class="gate-actions"><button class="enter-btn" id="enterBtn">Enter</button><button class="cancel-btn" id="cancelBtn" type="button">Cancel</button><div class="error-msg" id="errorMsg"></div></div>\n  </div></div>\n  <script>\n(function(){\n  var scene=document.getElementById("scene"),panel=document.getElementById("panel"),crestWrap=document.getElementById("crestWrap"),particles=document.getElementById("particles"),gate=document.getElementById("gate"),pinInput=document.getElementById("pinInput"),enterBtn=document.getElementById("enterBtn"),cancelBtn=document.getElementById("cancelBtn"),errorMsg=document.getElementById("errorMsg"),gateTarget=document.getElementById("gateTarget"),currentTarget="pulse",currentReturnTo="",reduceMotion=window.matchMedia&&window.matchMedia("(prefers-reduced-motion: reduce)").matches;\n  function createParticles(){if(!particles||reduceMotion)return;for(var i=0;i<10;i++){var d=document.createElement("span");d.className="particle";d.style.left=(6+Math.random()*88)+"%";d.style.width=(3+Math.random()*2.6)+"px";d.style.height=d.style.width;d.style.animationDuration=(20+Math.random()*12)+"s";d.style.animationDelay=(Math.random()*10)+"s";d.style.opacity=(0.32+Math.random()*0.5).toFixed(2);particles.appendChild(d)}}\n  function onMove(e){if(reduceMotion)return;var x=e.clientX/window.innerWidth,y=e.clientY/window.innerHeight;var rx=(y-0.5)*-7,ry=(x-0.5)*10;crestWrap.style.transform="perspective(1000px) rotateX("+(rx*0.7)+"deg) rotateY("+(ry*0.9)+"deg)";panel.style.transform="perspective(1200px) rotateX("+(rx*0.35)+"deg) rotateY("+(ry*0.45)+"deg)";document.documentElement.style.setProperty("--mx",(x*100).toFixed(2)+"%");document.documentElement.style.setProperty("--my",(y*100).toFixed(2)+"%")}\n  var cards=document.querySelectorAll("[data-card]");for(var ci=0;ci<cards.length;ci++){(function(card){card.addEventListener("mousemove",function(ev){var r=card.getBoundingClientRect();var x=((ev.clientX-r.left)/r.width)*100;var y=((ev.clientY-r.top)/r.height)*100;card.style.setProperty("--mx",x.toFixed(2)+"%");card.style.setProperty("--my",y.toFixed(2)+"%")})})(cards[ci])}\n  function openGate(target,returnTo){currentTarget=target==="vein"?"vein":(target==="qa"?"qa":"pulse");currentReturnTo=returnTo||"";gate.classList.add("show");gateTarget.textContent=currentTarget==="vein"?"TheVein":(currentTarget==="qa"?"QA Access":"ThePulse");errorMsg.textContent="";pinInput.value="";pinInput.classList.remove("error");setTimeout(function(){pinInput.focus()},10)}\n  function closeGate(){gate.classList.remove("show");errorMsg.textContent="";pinInput.value="";pinInput.classList.remove("error")}\n  function showPinError(msg){errorMsg.textContent=msg||"Incorrect PIN";pinInput.value="";pinInput.classList.remove("error");void pinInput.offsetWidth;pinInput.classList.add("error");pinInput.focus()}\n  function submitPin(){var pin=(pinInput.value||"").replace(/\\D/g,"").slice(0,4);pinInput.value=pin;if(pin.length!==4){showPinError("Enter all 4 digits");return}enterBtn.disabled=true;errorMsg.textContent="";var xhr=new XMLHttpRequest();xhr.open("POST",currentTarget==="qa"?"/qa/api/verify-pin":"/api/verify-pin",true);xhr.setRequestHeader("Content-Type","application/json");xhr.onreadystatechange=function(){if(xhr.readyState!==4)return;enterBtn.disabled=false;try{var data=JSON.parse(xhr.responseText);if(xhr.status===200&&data.ok){window.location.href=data.redirectTo||("/"+currentTarget)}else{showPinError(data.error||"Incorrect PIN")}}catch(e){showPinError("Connection issue")}};xhr.onerror=function(){enterBtn.disabled=false;showPinError("Connection issue")};xhr.send(JSON.stringify(currentTarget==="qa"?{pin:pin,returnTo:currentReturnTo}:{pin:pin,target:currentTarget}))}\n  var locked=document.querySelectorAll("[data-locked]");for(var li=0;li<locked.length;li++){(function(el){el.addEventListener("click",function(ev){ev.preventDefault();openGate(el.getAttribute("data-locked"))})})(locked[li])}\n  enterBtn.addEventListener("click",submitPin);cancelBtn.addEventListener("click",closeGate);\n  pinInput.addEventListener("input",function(){pinInput.value=pinInput.value.replace(/\\D/g,"").slice(0,4);pinInput.classList.remove("error");errorMsg.textContent=""});\n  pinInput.addEventListener("keydown",function(e){if(e.key==="Enter")submitPin();if(e.key==="Escape")closeGate()});\n  gate.addEventListener("click",function(e){if(e.target===gate)closeGate()});\n  window.addEventListener("mousemove",onMove,{passive:true});\n  window.addEventListener("mouseleave",function(){crestWrap.style.transform="";panel.style.transform=""});\n  createParticles();\n  var qs=window.location.search;var gateMatch=qs.match(/[?&]gate=([^&]*)/);var gateParam=gateMatch?gateMatch[1].toLowerCase():"";\n  var returnToMatch=qs.match(/[?&]returnTo=([^&]*)/);var returnToParam=returnToMatch?decodeURIComponent(returnToMatch[1]):"";if(gateParam==="pulse"||gateParam==="vein"){openGate(gateParam)}else if(gateParam==="qa"){openGate("qa",returnToParam.indexOf("/qa/")===0?returnToParam:"/qa/")}\n})();\n  </script>\n</body>\n</html>';

--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -491,7 +491,7 @@ function getShimScript() {
 
 // ═══════════════════════════════════════════════════════════════════
 // QA SHIM — Same as prod shim but API="/qa/api", /qa/* nav URLs,
-// amber non-dismissable banner. Injected on all /qa/* pages. (v3.5)
+// amber non-dismissable banner. Finance functions stripped. (v3.6)
 // ═══════════════════════════════════════════════════════════════════
 
 function getQAShimScript() {
@@ -533,13 +533,10 @@ function getQAShimScript() {
 '    return this;\n' +
 '  };\n' +
 '\n' +
+'  // Finance functions (ThePulse/TheVein) stripped — those surfaces are QA-denied.\n' +
 '  var FNS = [\n' +
-'    "getDataSafe","getMonthsSafe","getCashFlowForecastSafe",\n' +
-'    "getSimulatorDataSafe","getWeeklyTrackerDataSafe",\n' +
-'    "getSubscriptionDataSafe","getCategoryTransactionsSafe",\n' +
-'    "getReconcileStatusSafe","reconcileVeinPulseSafe","getBoardDataSafe",\n' +
-'    "getSystemHealthSafe","getMERGateStatusSafe",\n' +
-'    "getCloseHistoryDataSafe",\n' +
+'    "getBoardDataSafe",\n' +
+'    "getSystemHealthSafe",\n' +
 '    "getKidsHubDataSafe","getKidsHubWidgetDataSafe",\n' +
 '    "getKHLastModified","getSpineHeartbeatSafe",\n' +
 '    "khCompleteTaskSafe","khCompleteTaskWithBonusSafe","khUncompleteTaskSafe",\n' +
@@ -551,10 +548,9 @@ function getQAShimScript() {
 '    "khSetBankOpeningSafe","khVerifyPinSafe",\n' +
 '    "khAddDeductionSafe","khHealthCheckSafe",\n' +
 '    "khSubmitGradeSafe","khGetGradeHistorySafe",\n' +
-'    "updateFamilyNoteSafe","reconcileVeinPulse",\n' +
+'    "updateFamilyNoteSafe",\n' +
 '    "getVaultDataSafe","runStoryFactorySafe",\n' +
 '    "getDeployedVersionsSafe",\n' +
-'    "runMERGatesSafe","stampCloseMonthSafe",\n' +
 '    "addKidsEventSafe",\n' +
 '    "getKHLastModifiedSafe","getStoryApiStatsSafe",\n' +
 '    "khBatchApproveSafe","updateMealPlanSafe",\n' +
@@ -572,7 +568,6 @@ function getQAShimScript() {
 '    "getDesignChoicesSafe",\n' +
 '    "getDesignUnlockedSafe",\n' +
 '    "resetSandboxSafe",\n' +
-'    "getRecentTransactionsSafe",\n' +
 '    "getDailyMissionsInitSafe",\n' +
 '    "getAssetRegistrySafe"\n' +
 '  ];\n' +

--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -1,5 +1,5 @@
 // ═══════════════════════════════════════════════════════════════════
-// TBM Smart Proxy v3.5 — thompsonfams.com — Front Door + PIN Gate + QA Route Isolation
+// TBM Smart Proxy v3.6 — thompsonfams.com — Front Door + PIN Gate + QA Route Isolation
 // Clean URLs + GAS API shim + goog stub
 // ═══════════════════════════════════════════════════════════════════
 
@@ -121,7 +121,7 @@ export default {
       if (QA_ROUTES[url.pathname]) {
         if (!isValidQACookie(request, env)) {
           return Response.redirect(
-            url.origin + '/?gate=qa&returnTo=' + encodeURIComponent(url.pathname), 302
+            url.origin + '/?gate=qa&returnTo=' + encodeURIComponent(url.pathname + url.search), 302
           );
         }
         return serveQAPage(request, url, env);
@@ -281,8 +281,11 @@ async function handleApi(request, url, env, envOverride) {
   var target = GAS_URL + '?action=api&fn=' + encodeURIComponent(fn)
     + '&args=' + encodeURIComponent(args);
 
-  // v3.5: QA env override — append env=qa + per-request HMAC token
-  if (envOverride === 'qa' && env && env.QA_HMAC_SECRET) {
+  // v3.6: QA env override — append env=qa + per-request HMAC token; fail closed if secret missing
+  if (envOverride === 'qa') {
+    if (!env || !env.QA_HMAC_SECRET) {
+      return jsonResponse({ error: 'QA_HMAC_SECRET not configured' }, 503);
+    }
     var ts = Date.now();
     var hmac = await computeQAHmac_(ts + ':qa', env.QA_HMAC_SECRET);
     target += '&env=qa&qa_token=' + encodeURIComponent(ts + ':' + hmac);
@@ -710,7 +713,7 @@ async function handleVerifyPin(request, env, gateType) {
     if (isQA) {
       // v3.5: QA gate — validate returnTo (must start with /qa/), set tbm_qa cookie
       var returnTo = String(body.returnTo || '');
-      if (!returnTo || returnTo.indexOf('/qa/') !== 0) returnTo = '/qa/';
+      if (!returnTo || returnTo.indexOf('/qa/') !== 0) returnTo = '/qa/homework';
       return new Response(JSON.stringify({ ok: true, redirectTo: returnTo }), {
         status: 200,
         headers: {
@@ -764,12 +767,13 @@ async function serveQAPage(request, url, env) {
   params.set('action', 'htmlSource');
   params.set('env', 'qa');
 
-  // Generate per-request HMAC token so GAS can validate the env=qa override
-  if (env.QA_HMAC_SECRET) {
-    var ts = Date.now();
-    var hmac = await computeQAHmac_(ts + ':qa', env.QA_HMAC_SECRET);
-    params.set('qa_token', ts + ':' + hmac);
+  // Generate per-request HMAC token so GAS can validate the env=qa override; fail closed if secret missing
+  if (!env || !env.QA_HMAC_SECRET) {
+    return jsonResponse({ error: 'QA_HMAC_SECRET not configured' }, 503);
   }
+  var ts = Date.now();
+  var hmac = await computeQAHmac_(ts + ':qa', env.QA_HMAC_SECRET);
+  params.set('qa_token', ts + ':' + hmac);
 
   var qaRoute = QA_ROUTES[url.pathname];
   if (qaRoute) {

--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -68,6 +68,18 @@ const QA_ROUTES = {
 };
 // Finance surfaces excluded — real Tiller data, no QA snapshot. Explicit 403.
 const QA_DENIED = { '/qa/pulse': true, '/qa/vein': true };
+// Finance API denylist — blocks direct /qa/api calls to finance-only functions.
+// Mirrors QA_DENIED: if the page is denied, its backing API calls are denied too.
+const QA_FINANCE_DENIED = {
+  'getDataSafe': true, 'getMonthsSafe': true,
+  'getCashFlowForecastSafe': true, 'getSimulatorDataSafe': true,
+  'getWeeklyTrackerDataSafe': true, 'getSubscriptionDataSafe': true,
+  'getCategoryTransactionsSafe': true, 'getReconcileStatusSafe': true,
+  'reconcileVeinPulseSafe': true, 'reconcileVeinPulse': true,
+  'getMERGateStatusSafe': true, 'getCloseHistoryDataSafe': true,
+  'runMERGatesSafe': true, 'stampCloseMonthSafe': true,
+  'getRecentTransactionsSafe': true
+};
 
 export default {
   async fetch(request, env) {
@@ -280,6 +292,12 @@ async function handleApi(request, url, env, envOverride) {
 
   var target = GAS_URL + '?action=api&fn=' + encodeURIComponent(fn)
     + '&args=' + encodeURIComponent(args);
+
+  // v3.6: QA finance denylist — block finance-only functions at the proxy layer.
+  // Matches QA_DENIED route policy: pulse/vein pages denied → their backing API calls denied too.
+  if (envOverride === 'qa' && QA_FINANCE_DENIED[fn]) {
+    return jsonResponse({ error: 'Finance function not available in QA mode: ' + fn }, 403);
+  }
 
   // v3.6: QA env override — append env=qa + per-request HMAC token; fail closed if secret missing
   if (envOverride === 'qa') {

--- a/daily-missions.html
+++ b/daily-missions.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="daily-missions">
-<meta name="tbm-version" content="v16">
+<meta name="tbm-version" content="v17">
 <title>Daily Missions</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&family=Fredoka+One&display=swap" rel="stylesheet">
 <style>
@@ -1003,6 +1003,8 @@ var _serverStateLoaded = false;
 var _cachedMissionState = {};
 var dynamicSchedule = null;
 var _designUnlocked = false;
+// QA prefix — non-empty when served under /qa/* so nav stays in QA namespace
+var _qaPrefix = (window.location.pathname.indexOf('/qa/') === 0) ? '/qa' : '';
 
 function isJJ() { return currentChild === 'jj' || currentChild === 'sandbox-jj'; }
 
@@ -1603,7 +1605,7 @@ function render() {
       html += '<div class="mission-number" style="background:linear-gradient(135deg,#003311,#001a0a);border-color:#00ff88;color:#00ff88;">\uD83C\uDF89</div>';
       html += '<div class="mission-info"><div class="mission-name">' + block.name + '</div>';
       html += '<div class="mission-meta"><span class="mission-time">Take as long as you want. No timer.</span></div></div>';
-      html += '<div class="mission-actions"><button class="launch-btn" onclick="window.location.href=\'/wolfdome?customize=1\'" style="border-color:#00ff88;color:#00ff88;box-shadow:0 0 10px rgba(0,255,136,0.3);">ENTER \u2192</button></div>';
+      html += '<div class="mission-actions"><button class="launch-btn" onclick="window.location.href=_qaPrefix+\'/wolfdome?customize=1\'" style="border-color:#00ff88;color:#00ff88;box-shadow:0 0 10px rgba(0,255,136,0.3);">ENTER \u2192</button></div>';
       html += '</div>';
     } else {
       // Normal card
@@ -1735,14 +1737,14 @@ function renderWeekend(container) {
     html += '<div class="bonus-title">\uD83C\uDF08 FREE PLAY \uD83C\uDF08</div>';
     html += '<div class="bonus-desc">Pick any game you want, JJ!</div>';
     html += '<div style="margin-top:12px;display:-webkit-flex;display:flex;gap:10px;-webkit-justify-content:center;justify-content:center;-webkit-flex-wrap:wrap;flex-wrap:wrap">';
-    html += '<button class="launch-btn" onclick="launchMission(\'/sparkle-free\',\'freeplay_jj\',\'Sparkle Free Play\')">Sparkle Kingdom \u2728</button>';
+    html += '<button class="launch-btn" onclick="launchMission(_qaPrefix+\'/sparkle-free\',\'freeplay_jj\',\'Sparkle Free Play\')">Sparkle Kingdom \u2728</button>';
     html += '</div>';
   } else {
     html += '<div class="bonus-title">\uD83C\uDFAE FREE TIME \uD83C\uDFAE</div>';
     html += '<div class="bonus-desc">No missions today. Pick what you want to do.</div>';
     html += '<div style="margin-top:12px;display:-webkit-flex;display:flex;gap:10px;-webkit-justify-content:center;justify-content:center;-webkit-flex-wrap:wrap;flex-wrap:wrap">';
-    html += '<button class="launch-btn" onclick="launchMission(\'/facts\',\'bonus_facts\',\'Fact Sprint\')">Fact Sprint \u26A1</button>';
-    html += '<button class="launch-btn" onclick="launchMission(\'/comic-studio\',\'freeplay_comic\',\'Comic Studio\')">Comic Studio \uD83C\uDFA8</button>';
+    html += '<button class="launch-btn" onclick="launchMission(_qaPrefix+\'/facts\',\'bonus_facts\',\'Fact Sprint\')">Fact Sprint \u26A1</button>';
+    html += '<button class="launch-btn" onclick="launchMission(_qaPrefix+\'/comic-studio\',\'freeplay_comic\',\'Comic Studio\')">Comic Studio \uD83C\uDFA8</button>';
     html += '</div>';
   }
   html += '</div>';

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,3 +18,8 @@ namespace_id = "1001"
 [ratelimits.simple]
 limit = 2
 period = 10
+
+# QA Route Isolation secrets (issue #219)
+# Set via: wrangler secret put QA_HMAC_SECRET
+# Must match GAS Script Property QA_HMAC_SECRET (same value, both sides)
+# Prerequisite: TBM_QA_SSID Script Property set in GAS to QA workbook ID


### PR DESCRIPTION
## Summary

- **CF Worker v3.5**: `QA_ROUTES` (25 routes), `QA_DENIED` (pulse/vein), `/qa/*` routing block with PIN gate, `serveQAPage` (env=qa + HMAC token + QA shim), `isValidQACookie` (tbm_qa, Path=/qa, 4h), `handleVerifyPin` QA gate (returnTo + tbm_qa cookie), `handleApi` envOverride=qa, Front Door `gate=qa` + returnTo flow, `computeQAHmac_` (HMAC-SHA256 via Web Crypto)
- **Code.js v82**: `validateQAToken_` (5-min HMAC window), `computeHmac_`, `getEnvCacheKey_` (qa: prefix), `serveData` env=qa dispatch (SSID override + _tbmSS flush), all cache functions scoped (getCachedPayload_, setCachedPayload_, KH variants, bustCache)
- **Tbmsmoketest.js v14**: Category 10 QA route parity (25 routes expected, pulse/vein denied)
- **wrangler.toml**: QA_HMAC_SECRET secret documented

## How it works

`thompsonfams.com/qa/homework` → CF Worker checks `tbm_qa` cookie → if missing, redirects to `/?gate=qa&returnTo=/qa/homework` → PIN entry → `tbm_qa` cookie set (Path=/qa, 4h) → `serveQAPage` fetches HTML from GAS with `env=qa&qa_token=<ts>:<hmac>` → GAS validates token (5-min window), sets `SSID = TBM_QA_SSID` for that request → QA data. Prod routes unaffected.

## Prerequisites before going live

```
wrangler secret put QA_HMAC_SECRET          # same value in GAS Script Property
```
GAS Script Property `TBM_QA_SSID` must be set to QA workbook ID.
Run `seedQAWorkbook()` to populate QA data.

## Test plan

- [ ] R1: `/qa/homework` with valid cookie → 200 HTML with amber QA banner
- [ ] R2: `/qa/pulse` → 403 finance denied message
- [ ] R3: `/qa/nonexistent` → 403 route not available
- [ ] R4: `/qa/homework` no cookie → 302 to `/?gate=qa&returnTo=/qa/homework`
- [ ] A1: Correct PIN → `tbm_qa` cookie set with `Path=/qa; Max-Age=14400`
- [ ] A2: Wrong PIN → 401, no cookie
- [ ] A3: `tbm_qa` cookie not sent on `/homework` (prod) — browser scoping
- [ ] A5: returnTo preserved after PIN success
- [ ] A6: `returnTo=/evil.com` → defaults to `/qa/`
- [ ] D1: `/qa/api` reads QA workbook data
- [ ] D2: `/api` reads prod workbook simultaneously
- [ ] B1: `/qa/homework` shows amber fixed banner
- [ ] B2: `/homework` (prod) has no banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #219