### PR TITLE
fix: Comic Studio panel drawing unresponsive to touch/pen strokes

### DIFF
--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -459,6 +459,12 @@ main {
   position: relative;
   cursor: pointer;
   transition: border-color 0.2s;
+  touch-action: none;
+}
+.panel-slot canvas {
+  display: block;
+  width: 100%;
+  touch-action: none;
 }
 .panel-slot.active {
   border-color: #F59E0B;
@@ -951,7 +957,7 @@ main {
 </main>
 
 <script>
-// ── ComicStudio v4 — Day 2: F3 Drive Draft/Resume + F4 Mission/Free Mode
+// ── ComicStudio v5 — Day 2: F3 Drive Draft/Resume + F4 Mission/Free Mode
 // ES6 EXEMPT: Surface Pro 5 / Chrome — see specs/comicstudio-v4.md §3
 // tbm-version: v11
 
@@ -1820,8 +1826,8 @@ function attachPointerEvents(canvas, panelIdx) {
   });
 
   canvas.addEventListener('pointermove', (e) => {
-    if (!isDrawing) return;
     e.preventDefault();
+    if (!isDrawing) return;
 
     const ctx = panelContexts[panelIdx];
     const pos = getPos(e);


### PR DESCRIPTION
## Summary
- Add `touch-action: none` to `.panel-slot` and `.panel-slot canvas` — panel canvases sit inside `.panel-slot`, not `.canvas-container`, so the existing `touch-action: none` rule never applied to them. Browser scroll/gesture handling was consuming `pointermove` events before the JS handler fired.
- Move `e.preventDefault()` before the `isDrawing` guard in the `pointermove` handler — prevents browser drag default from firing even before the first stroke is recognized.

## Root cause
`touch-action: none` was scoped to `.canvas-container canvas` but `buildPanels()` places canvases directly in `.panel-slot` divs — a different ancestor. The browser's default touch-pan behavior swallowed continuous drag events, leaving only discrete tap `pointerdown` events getting through.

## Test plan
- [ ] Surface Pro 5: pen drawing — strokes render continuously (not just tap dots)
- [ ] Surface Pro 5: finger drawing — same
- [ ] Paint bucket fill still works on tap
- [ ] No scroll regression in panel area

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)