### PR TITLE
fix: dinner save and family note save broken on Fold 7

### DIFF
--- a/KidsHub.html
+++ b/KidsHub.html
@@ -3813,7 +3813,7 @@ function pBatchApprove(child) {
       '<label style="display:flex;align-items:center;gap:8px;font-size:12px;color:#94a3b8;cursor:pointer">' +
       '<input type="checkbox" id="dinnerKidsSplit" onchange="window._toggleKidMeal()" style="cursor:pointer"> Kids eating something different?</label>' +
       '<input type="text" id="dinnerKidMeal" placeholder="Kids\' meal?" style="display:none;padding:10px 12px;border:1px solid rgba(255,255,255,0.15);border-radius:8px;font-size:14px;font-family:inherit;background:rgba(20,20,40,0.4);color:#e2e8f0;outline:none">' +
-      '<button id="dinnerBtn" onclick="window._v2LogDinner()" style="padding:12px;background:#22c55e;color:#fff;border:none;border-radius:8px;font-size:14px;font-weight:700;cursor:pointer">🍽 Log Dinner</button>' +
+      '<button id="dinnerBtn" onclick="window._v2LogDinner()" style="padding:12px;min-height:44px;background:#22c55e;color:#fff;border:none;border-radius:8px;font-size:14px;font-weight:700;cursor:pointer">🍽 Log Dinner</button>' +
       '<div id="dinnerStatus" style="display:none;font-size:12px;padding:6px 10px;border-radius:6px;text-align:center"></div>' +
       '</div></div>';
   }

--- a/TheVein.html
+++ b/TheVein.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="tbm-version" content="v65">
 <title>The Vein v65 — Household Command Center</title>
-<!-- TheVein v65 — Version history tracked in Notion deploy page. No changelogs in this file. -->
+<!-- TheVein v66 — Version history tracked in Notion deploy page. No changelogs in this file. -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400;1,600&family=JetBrains+Mono:wght@300;400;500;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <style>
@@ -209,7 +209,7 @@ background:linear-gradient(90deg,transparent,var(--blue),transparent);}
 .fnote-row{display:flex;gap:8px;align-items:flex-start}
 .fnote-input{flex:1;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;padding:8px 12px;font-family:'DM Sans',sans-serif;font-size:13px;color:var(--text);resize:none;min-height:36px;max-height:80px;line-height:1.4;outline:none}
 .fnote-input:focus{border-color:var(--blue)}
-.fnote-save{background:var(--blue);color:#fff;border:none;border-radius:8px;padding:8px 14px;font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:600;letter-spacing:.08em;cursor:pointer;white-space:nowrap;opacity:.5;pointer-events:none;transition:opacity .2s}
+.fnote-save{background:var(--blue);color:#fff;border:none;border-radius:8px;padding:8px 14px;min-height:44px;font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:600;letter-spacing:.08em;cursor:pointer;white-space:nowrap;opacity:.5;pointer-events:none;transition:opacity .2s}
 .fnote-save.active{opacity:1;pointer-events:auto}
 .fnote-save:active{transform:scale(.97)}
 .fnote-preview{margin-top:8px;font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-dim);line-height:1.5}
@@ -706,7 +706,7 @@ function tbmNav(p){var s=_isPartnerMode?'&jt=1':'';if(_tbmBaseUrl){window.top.lo
       <div style="font-size:10px;color:var(--text-muted);margin-bottom:2px;">Notes</div>
       <input type="text" id="dinnerNotes" class="fnote-input" placeholder="Optional" maxlength="300" style="width:100%;resize:none;height:36px;padding:6px 10px;">
     </div>
-    <button class="fnote-save" id="dinnerSave" onclick="saveDinner()" style="height:36px;">Save</button>
+    <button class="fnote-save active" id="dinnerSave" onclick="saveDinner()" style="height:44px;min-width:54px;">Save</button>
   </div>
   <div style="margin-top:8px;">
     <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:12px;color:var(--text-muted);">


### PR DESCRIPTION
## Summary

### TheVein.html — dinner save (root cause: pointer-events: none forever)
- `dinnerSave` button used `class="fnote-save"` which CSS sets to `pointer-events:none`. Nothing in JS ever added `.active` to this button, so it was permanently untappable. Changed initial class to `fnote-save active`.
- Boosted to `height:44px min-width:54px` (Fold 7 touch minimum)

### TheVein.html — family note save (root cause: undersized touch target)
- Added `min-height:44px` to `.fnote-save` CSS — button was ~30px tall, below the 44px touch target floor

### KidsHub.html — dinner log button
- Added `min-height:44px` inline to `dinnerBtn`

## Test plan
- [ ] Fold 7: `/vein` → type dinner → tap Save → row written to MealPlan
- [ ] Fold 7: `/vein` → type family note → tap Save → note saves
- [ ] Fold 7: `/parent` → dinner section → fill meal → tap Log Dinner → saves OK
- [ ] Desktop: no visual regression on any of the three buttons

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)