### PR TITLE
feat: Comic Studio vocab word — Gemini first-pass + parent review

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -536,7 +536,9 @@ function serveData(e) {
         'notionLogHomeworkSafe': notionLogHomeworkSafe,
         'notionLogSparkleProgressSafe': notionLogSparkleProgressSafe,
         'notionApproveHomeworkSafe': notionApproveHomeworkSafe,
-        'getPendingReviewsSafe': getPendingReviewsSafe
+        'getPendingReviewsSafe': getPendingReviewsSafe,
+        // ContentEngine.gs v2 — Vocabulary usage grading (#225)
+        'gradeVocabUsageSafe': gradeVocabUsageSafe
       };
 
       if (!fn || !API_WHITELIST[fn]) {

--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -2091,13 +2091,14 @@ function finishComic() {
     if (wc > 0) captionedPanels++;
   }
 
+  // v5 (#225): base rings — vocab bonus handled separately via Gemini
   let rings = 15;
   if (captionedPanels === panelCount) rings += 10;
   if (totalWords >= 20) rings += 5;
-  // Spec bug fix: vocab bonus (+10) is Mission-only — not awarded in Free mode.
-  if (currentMode === 'mission' && checkVocabInCaptions()) rings += 10;
   rings = Math.min(rings, ringsCap);
   ringsEarned = rings;
+
+  const vocabUsed = currentMode === 'mission' && checkVocabInCaptions();
 
   document.getElementById('tab-preview').classList.add('hidden');
   document.getElementById('nav-bar').style.display = 'none';
@@ -2110,7 +2111,10 @@ function finishComic() {
   html += `<div class="ring-award"><span>+${rings}</span> Rings Earned!</div>`;
   html += `<p>${panelCount} panels drawn`;
   if (captionedPanels === panelCount) html += ' &bull; All panels captioned';
-  if (checkVocabInCaptions()) html += ` &bull; Vocab word "${escapeHtml(todayVocab.word)}" used!`;
+  if (vocabUsed) {
+    html += ` &bull; Vocab word "${escapeHtml(todayVocab.word)}" used!`;
+    html += '<div id="vocab-grade-status" style="margin-top:10px;font-size:12px;color:#94A3B8">Checking vocab with Wolfkid AI&#8230;</div>';
+  }
   html += '</p>';
   html += `<p style="margin-top:12px;color:#64748B;font-size:12px;">Total words written: ${totalWords}</p>`;
   html += '<div style="margin-top:20px;display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">';
@@ -2130,14 +2134,45 @@ function finishComic() {
 
   document.getElementById('ring-badge').textContent = rings + ' Rings';
 
-  // Award rings via backend
+  // Award base rings via backend
   if (TBM_TEST_MODE) {
     console.log('[TEST MODE] awardRings skipped, rings=' + rings);
+    if (vocabUsed) {
+      const el = document.getElementById('vocab-grade-status');
+      if (el) el.textContent = '[TEST] Vocab grading skipped';
+    }
   } else if (typeof google !== 'undefined' && google.script && google.script.run) {
     google.script.run
       .withSuccessHandler(function() { })
       .withFailureHandler(function(err) { })
       .awardRingsSafe(CHILD, rings, MODULE_NAME);
+
+    // v5 (#225): Vocab bonus — Gemini first-pass, parent review if flagged
+    if (vocabUsed) {
+      google.script.run
+        .withSuccessHandler(function(result) {
+          const el = document.getElementById('vocab-grade-status');
+          if (!el) return;
+          if (result && result.autoApproved) {
+            el.innerHTML = `<span style="color:#22C55E">&#10003; Vocab approved! +${result.ringsAwarded} bonus rings</span>`;
+          } else if (result && result.status === 'pending_review') {
+            el.innerHTML = '<span style="color:#F59E0B">&#9888; Vocab sent to parent for review &mdash; rings coming!</span>';
+          } else {
+            el.innerHTML = '<span style="color:#94A3B8">Vocab submitted.</span>';
+          }
+        })
+        .withFailureHandler(function() {
+          const el = document.getElementById('vocab-grade-status');
+          if (el) el.textContent = 'Vocab check unavailable — check back later.';
+        })
+        .gradeVocabUsageSafe({
+          child: CHILD,
+          word: todayVocab.word,
+          definition: todayVocab.def,
+          captions: captions.slice(0, panelCount),
+          vocabRings: 10
+        });
+    }
   }
 }
 

--- a/ContentEngine.js
+++ b/ContentEngine.js
@@ -1,11 +1,12 @@
 // ════════════════════════════════════════════════════════════════════════════
 // ContentEngine.gs — Gemini-powered grading + content generation
 // READS FROM: 💻 QuestionLog (via SSID + TAB_MAP)
+// WRITES TO: 🧹📅 KH_Education (gradeVocabUsageSafe)
 // DEPENDENCIES: SSID, TAB_MAP, logError_, withMonitor_ (GASHardening.gs)
 // DO NOT redeclare var TAB_MAP in this file.
 // ════════════════════════════════════════════════════════════════════════════
 
-function getContentEngineVersion() { return 1; }
+function getContentEngineVersion() { return 2; }
 
 // ════════════════════════════════════════════════════════════════════════════
 // SECTION 1: Gemini API Wrapper
@@ -593,5 +594,144 @@ function gradeShortAnswerSafe(studentResponse, correctAnswer, teksCode) {
   return withMonitor_('gradeShortAnswerSafe', function() {
     var questionText = 'Expected answer: ' + (correctAnswer || 'N/A');
     return gradeResponseWithGemini_(studentResponse, CER_RUBRIC_TEMPLATE, teksCode, questionText);
+  });
+}
+
+
+// ════════════════════════════════════════════════════════════════════════════
+// SECTION 5: Vocabulary Usage Grading (Comic Studio #225)
+// ════════════════════════════════════════════════════════════════════════════
+
+var VOCAB_GRADE_SYSTEM_PROMPT = [
+  'You are Wolfkid, a friendly learning coach for Buggsy, a 4th grade student.',
+  'Your job is to evaluate whether a vocabulary word is used correctly in a comic book caption.',
+  '',
+  'RULES:',
+  '- Auto-approve if the word is used with its correct meaning in a clear, sensible sentence.',
+  '- Flag for parent review if usage is forced, unclear, unrelated to definition, or clearly wrong.',
+  '- "auto_approve" should be true for borderline-but-plausible usage — give the kid credit.',
+  '- Keep feedback under 60 words. Be encouraging, never punishing.',
+  '',
+  'Return ONLY valid JSON:',
+  '{',
+  '  "auto_approve": true,',
+  '  "confidence": "high|medium|low",',
+  '  "feedback": "<one encouraging sentence>",',
+  '  "misconception": "<what went wrong, or null if correct>"',
+  '}'
+].join('\n');
+
+/**
+ * Grades whether a vocab word is used correctly in comic captions.
+ * @param {string} word - The vocabulary word
+ * @param {string} definition - The word's definition
+ * @param {string} captionText - All panel captions joined
+ * @return {Object} { auto_approve, confidence, feedback, misconception }
+ * @private
+ */
+function gradeVocabUsage_(word, definition, captionText) {
+  var prompt = [
+    'Vocabulary word: "' + word + '"',
+    'Definition: "' + definition + '"',
+    '',
+    'Student caption(s): "' + captionText + '"',
+    '',
+    'Is the vocabulary word used correctly in context?'
+  ].join('\n');
+
+  var resp = callGemini_(prompt, {
+    temperature: 0.2,
+    maxOutputTokens: 512,
+    systemInstruction: VOCAB_GRADE_SYSTEM_PROMPT
+  });
+  return extractGeminiJSON_(resp);
+}
+
+/**
+ * Safe wrapper: Grade vocab usage and write result to KH_Education.
+ * Awards rings immediately if auto-approved; queues for parent review otherwise.
+ *
+ * @param {Object} payload - { child, word, definition, captions: string[], vocabRings }
+ * @return {Object} { status, autoApproved, ringsAwarded, feedback }
+ */
+function gradeVocabUsageSafe(payload) {
+  return withMonitor_('gradeVocabUsageSafe', function() {
+    var child = String(payload.child || 'buggsy').toLowerCase();
+    var word = String(payload.word || '');
+    var definition = String(payload.definition || '');
+    var captions = payload.captions || [];
+    var captionText = captions.join(' | ');
+    var vocabRings = Number(payload.vocabRings) || 10;
+
+    if (!word || !captionText) {
+      return JSON.parse(JSON.stringify({ error: true, message: 'word and captions required' }));
+    }
+
+    var grade;
+    try {
+      grade = gradeVocabUsage_(word, definition, captionText);
+    } catch (e) {
+      if (typeof logError_ === 'function') logError_('gradeVocabUsage_:gemini', e);
+      // Gemini failure → flag for parent review, non-blocking
+      grade = { auto_approve: false, confidence: 'low', feedback: 'Could not auto-grade — needs parent review.', misconception: null };
+    }
+
+    var autoApprove = !!grade.auto_approve;
+    var status = autoApprove ? 'auto_approved' : 'pending_review';
+    var ringsAwarded = 0;
+
+    // Write KH_Education row (uses Kidshub.js shared scope)
+    try {
+      var sheet = ensureKHEducationTab_();
+      sheet.appendRow([
+        new Date(),
+        child,
+        'comic-studio',
+        'Vocabulary — ' + word,
+        autoApprove ? vocabRings : 0,
+        autoApprove,
+        captionText.substring(0, 500),
+        status,
+        '',
+        autoApprove ? vocabRings : 0,
+        '',
+        grade.feedback || ''
+      ]);
+    } catch (writeErr) {
+      if (typeof logError_ === 'function') logError_('gradeVocabUsageSafe:write', writeErr);
+    }
+
+    // Award rings if auto-approved
+    if (autoApprove && vocabRings > 0) {
+      try {
+        if (typeof kh_awardEducationPoints_ === 'function') {
+          var awardRaw = kh_awardEducationPoints_(child, vocabRings, 'comic-studio — vocab: ' + word);
+          var awardResult = typeof awardRaw === 'string' ? JSON.parse(awardRaw) : awardRaw;
+          ringsAwarded = (awardResult && awardResult.duplicate) ? 0 : vocabRings;
+        }
+      } catch (awardErr) {
+        if (typeof logError_ === 'function') logError_('gradeVocabUsageSafe:award', awardErr);
+      }
+    }
+
+    // Push notification if pending parent review
+    if (!autoApprove && typeof sendPush_ === 'function') {
+      try {
+        sendPush_(
+          child.charAt(0).toUpperCase() + child.slice(1) + ' Comic vocab needs review',
+          'Word: "' + word + '" — check Parent Dashboard',
+          'BOTH',
+          typeof PUSHOVER_PRIORITY !== 'undefined' ? PUSHOVER_PRIORITY.CHORE_APPROVAL : 0
+        );
+      } catch (pushErr) { /* non-blocking */ }
+    }
+
+    return JSON.parse(JSON.stringify({
+      status: status,
+      autoApproved: autoApprove,
+      ringsAwarded: ringsAwarded,
+      feedback: grade.feedback || '',
+      confidence: grade.confidence || 'medium'
+    }));
   });
 }


### PR DESCRIPTION
## Summary
- **ContentEngine.js v1→v2**: New `gradeVocabUsageSafe()` — sends comic captions + vocab word/def to Gemini (temp 0.2) for structured JSON grading; writes `KH_Education` row; auto-awards 10 rings on `auto_approve`; sends Pushover alert on `pending_review`
- **Code.js v83→v84**: Registers `gradeVocabUsageSafe` in `API_WHITELIST` so the client can call it via `google.script.run`
- **ComicStudio.html v4→v5**: Removes immediate `+10 ring` client-side vocab bonus; fires `gradeVocabUsageSafe` after comic save; renders `vocab-grade-status` div with live Gemini result (approved/pending message)

## Test plan
- [ ] Complete a comic in mission mode with vocab word used in captions → confirm Gemini grading fires, status div updates
- [ ] Complete a comic with vocab word NOT used → confirm no Gemini call, no `vocab-grade-status` message
- [ ] Force `pending_review` response → confirm Pushover fires, KH_Education row written with `pending_review` status
- [ ] Force `auto_approve` response → confirm 10 rings awarded, KH_Education row written with `auto_approve` status
- [ ] Complete comic in free-draw mode → no vocab grading, rings awarded normally

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)