### PR TITLE
feat: feedback UI on 11 surfaces + Pushover Layer 1 (#226)

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,6 +1,6 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// Code.gs v81 — Apps Script Router (TBM Consolidated)
+// Code.gs v83 — Apps Script Router (TBM Consolidated)
 // WRITES TO: (routes only — delegates to DataEngine, KidsHub, etc.)
 // READS FROM: (routes only — delegates to DataEngine, KidsHub, etc.)
 // ════════════════════════════════════════════════════════════════════
@@ -19,7 +19,7 @@ function isLessonRunsEnabled_() {
   } catch (e) { return false; }
 }
 
-function getCodeVersion() { return 82; }
+function getCodeVersion() { return 83; }
 
 // v37 FIX 5: ES5-safe left-pad helper — replaces String.padStart()
 function leftPad2_(n) {
@@ -1122,22 +1122,33 @@ function seedStaarRlaSprintSafe(jsonStr) {
   });
 }
 
-// v52: Feedback Form — setup + submit
+// v83: Feedback Form — setup + submit (extended schema for pipeline #231)
 function setupFeedbackSheet() {
   var ss = SpreadsheetApp.openById(SSID);
   var tabName = (typeof TAB_MAP !== 'undefined' && TAB_MAP['Feedback']) || '💻 Feedback';
   var sheet = ss.getSheetByName(tabName);
   if (!sheet) {
     sheet = ss.insertSheet(tabName);
-    sheet.appendRow(['Timestamp', 'Surface', 'LayoutRating', 'ReadabilityRating', 'FreeText', 'UserAgent']);
+    sheet.appendRow(['Timestamp', 'Surface', 'LayoutRating', 'ReadabilityRating', 'FreeText', 'User', 'Processed', 'Classification']);
     sheet.setFrozenRows(1);
     sheet.getRange('1:1').setFontWeight('bold');
-    Logger.log('✅ Feedback sheet created: ' + tabName);
+    Logger.log('Feedback sheet created: ' + tabName);
   } else {
-    Logger.log('Feedback sheet already exists.');
+    var headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+    var headerStr = headers.join(',');
+    if (headerStr.indexOf('User') === -1) {
+      var nextCol = headers.length + 1;
+      sheet.getRange(1, nextCol).setValue('User');
+      sheet.getRange(1, nextCol + 1).setValue('Processed');
+      sheet.getRange(1, nextCol + 2).setValue('Classification');
+      Logger.log('Feedback sheet migrated: added User, Processed, Classification columns');
+    } else {
+      Logger.log('Feedback sheet already has extended schema.');
+    }
   }
 }
 
+// v83: Feedback with Pushover notification + Processed column for pipeline (#231)
 function submitFeedbackSafe(payload) {
   return withMonitor_('submitFeedbackSafe', function() {
     var layout = parseInt(payload.layout, 10);
@@ -1150,6 +1161,7 @@ function submitFeedbackSafe(payload) {
     }
     var surface = String(payload.surface || 'unknown');
     var text = String(payload.text || '').substring(0, 500);
+    var user = String(payload.user || 'unknown');
 
     var lock = LockService.getScriptLock();
     try { lock.waitLock(30000); } catch(e) {
@@ -1162,7 +1174,25 @@ function submitFeedbackSafe(payload) {
       if (!sheet) {
         return JSON.parse(JSON.stringify({ error: true, message: 'Feedback sheet not found. Run setupFeedbackSheet() first.' }));
       }
-      sheet.appendRow([new Date().toISOString(), surface, layout, readability, text, 'web']);
+      sheet.appendRow([new Date().toISOString(), surface, layout, readability, text, user, '', '']);
+
+      // v83: Immediate Pushover to LT only — no feedback sits unread (#231 Layer 1)
+      try {
+        var stars = '';
+        for (var s = 0; s < layout; s++) stars += '\u2b50';
+        var preview = text ? (' \u2014 ' + text.substring(0, 80)) : '';
+        if (typeof sendPush_ === 'function') {
+          sendPush_(
+            '\ud83d\udde3 Feedback: ' + surface,
+            user + ': ' + stars + preview,
+            'LT',
+            typeof PUSHOVER_PRIORITY !== 'undefined' ? PUSHOVER_PRIORITY.CHORE_APPROVAL : 0
+          );
+        }
+      } catch(pushErr) {
+        if (typeof logError_ === 'function') logError_('submitFeedback_push', pushErr);
+      }
+
       return JSON.parse(JSON.stringify({ success: true }));
     } finally {
       lock.releaseLock();
@@ -2108,4 +2138,4 @@ function getOpsHealthSafe() {
   });
 }
 
-// END OF FILE — Code.gs v81
+// END OF FILE — Code.gs v83

--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -2109,7 +2109,7 @@ function finishComic() {
   html += `<p style="margin-top:12px;color:#64748B;font-size:12px;">Total words written: ${totalWords}</p>`;
   html += '<div style="margin-top:20px;display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">';
   html += '<button style="padding:12px 28px;background:#00F0FF;color:#0B0F1A;border:none;border-radius:12px;font-size:14px;font-weight:700;cursor:pointer;font-family:Orbitron,sans-serif" onclick="playReplay()">&#9654; REPLAY</button>';
-  html += '<button style="padding:12px 28px;background:#3B82F6;color:#fff;border:none;border-radius:12px;font-size:14px;font-weight:700;cursor:pointer;font-family:Nunito,sans-serif" onclick="window.location.href=(window.location.pathname.indexOf(\'/qa/\')===0?\'/qa\':\'\')+\'/daily-missions\'">Back to Missions</button>';
+  html += '<button style="padding:12px 28px;background:#3B82F6;color:#fff;border:none;border-radius:12px;font-size:14px;font-weight:700;cursor:pointer;font-family:Nunito,sans-serif" onclick="window.location.href=\'/daily-missions\'">Back to Missions</button>';
   html += '</div>';
   html += '</div>';
   comp.innerHTML = html;
@@ -2359,6 +2359,138 @@ function init() {
 
 init();
 </script>
+<!-- ═══ Kid Feedback Widget (ES5 IIFE) ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:260px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 12px 0;color:#e2e8f0;font-size:16px;text-align:center;}'
+    + '.tbm-fb-emojis{display:flex;justify-content:center;gap:16px;margin-bottom:12px;}'
+    + '.tbm-fb-emojis button{width:52px;height:52px;border-radius:50%;border:2px solid #1e3347;background:#0f1a2a;'
+    + 'font-size:26px;cursor:pointer;transition:border-color 0.15s,transform 0.15s;}'
+    + '.tbm-fb-emojis button.selected{border-color:#38bdf8;transform:scale(1.15);}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>How was it?</h3>'
+    + '<div class="tbm-fb-emojis">'
+    + '<button data-score="1" aria-label="Okay">&#x1F610;</button>'
+    + '<button data-score="3" aria-label="Good">&#x1F642;</button>'
+    + '<button data-score="5" aria-label="Awesome">&#x1F929;</button>'
+    + '</div>'
+    + '<textarea id="tbm-fb-text" placeholder="What happened? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var selectedScore = 0;
+
+  function getUser() {
+    var search = window.location.search || '';
+    var match = search.match(/[?&]child=([^&]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return 'unknown';
+  }
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'unknown';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    selectedScore = 0;
+    var btns = modal.querySelectorAll('.tbm-fb-emojis button');
+    for (var i = 0; i < btns.length; i++) btns[i].className = '';
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  var emojiButtons = modal.querySelectorAll('.tbm-fb-emojis button');
+  for (var e = 0; e < emojiButtons.length; e++) {
+    emojiButtons[e].onclick = (function(b) {
+      return function() {
+        selectedScore = parseInt(b.getAttribute('data-score'), 10);
+        var all = modal.querySelectorAll('.tbm-fb-emojis button');
+        for (var k = 0; k < all.length; k++) all[k].className = '';
+        b.className = 'selected';
+      };
+    })(emojiButtons[e]);
+  }
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!selectedScore) { showToast('Tap an emoji first!'); return; }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: selectedScore,
+      readability: selectedScore,
+      text: ta ? ta.value : '',
+      user: getUser()
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+})();
+</script>
 </body>
 </html>
-<!-- ComicStudio.html v10 -->
+<!-- ComicStudio.html v11 -->

--- a/DesignDashboard.html
+++ b/DesignDashboard.html
@@ -3,8 +3,9 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- TBM: DesignDashboard.html v3 — THE WOLFDOME home + wizard behind wrench -->
-<meta name="tbm-version" content="v3">
+<!-- TBM: DesignDashboard.html v4 — THE WOLFDOME home + wizard behind wrench -->
+<meta name="tbm-module" content="design-dashboard">
+<meta name="tbm-version" content="v4">
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 
@@ -1310,6 +1311,138 @@ if (TBM_CUSTOMIZE_MODE) {
 }
 
 </script>
+<!-- ═══ Kid Feedback Widget (ES5 IIFE) ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:260px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 12px 0;color:#e2e8f0;font-size:16px;text-align:center;}'
+    + '.tbm-fb-emojis{display:flex;justify-content:center;gap:16px;margin-bottom:12px;}'
+    + '.tbm-fb-emojis button{width:52px;height:52px;border-radius:50%;border:2px solid #1e3347;background:#0f1a2a;'
+    + 'font-size:26px;cursor:pointer;transition:border-color 0.15s,transform 0.15s;}'
+    + '.tbm-fb-emojis button.selected{border-color:#38bdf8;transform:scale(1.15);}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>How was it?</h3>'
+    + '<div class="tbm-fb-emojis">'
+    + '<button data-score="1" aria-label="Okay">&#x1F610;</button>'
+    + '<button data-score="3" aria-label="Good">&#x1F642;</button>'
+    + '<button data-score="5" aria-label="Awesome">&#x1F929;</button>'
+    + '</div>'
+    + '<textarea id="tbm-fb-text" placeholder="What happened? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var selectedScore = 0;
+
+  function getUser() {
+    var search = window.location.search || '';
+    var match = search.match(/[?&]child=([^&]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return 'unknown';
+  }
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'unknown';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    selectedScore = 0;
+    var btns = modal.querySelectorAll('.tbm-fb-emojis button');
+    for (var i = 0; i < btns.length; i++) btns[i].className = '';
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  var emojiButtons = modal.querySelectorAll('.tbm-fb-emojis button');
+  for (var e = 0; e < emojiButtons.length; e++) {
+    emojiButtons[e].onclick = (function(b) {
+      return function() {
+        selectedScore = parseInt(b.getAttribute('data-score'), 10);
+        var all = modal.querySelectorAll('.tbm-fb-emojis button');
+        for (var k = 0; k < all.length; k++) all[k].className = '';
+        b.className = 'selected';
+      };
+    })(emojiButtons[e]);
+  }
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!selectedScore) { showToast('Tap an emoji first!'); return; }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: selectedScore,
+      readability: selectedScore,
+      text: ta ? ta.value : '',
+      user: getUser()
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+})();
+</script>
 </body>
 </html>
-<!-- DesignDashboard.html v3 — THE WOLFDOME home + wizard behind wrench -->
+<!-- DesignDashboard.html v4 — THE WOLFDOME home + wizard behind wrench -->

--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -523,7 +523,7 @@ main {
     <div style="font-size:11px;color:#64748B;margin-bottom:16px;">Open-ended answers pending parent review</div>
     <div id="comp-feedback" style="background:rgba(59,130,246,0.08);border:1px solid rgba(59,130,246,0.3);border-radius:10px;padding:14px;font-size:13px;color:#94A3B8;line-height:1.6;margin-bottom:16px;text-align:left;"></div>
     <button style="background:#3B82F6;border:none;border-radius:10px;padding:12px 32px;color:#fff;font-family:'Orbitron',sans-serif;font-size:13px;font-weight:700;cursor:pointer;letter-spacing:1px;" onclick="closeCompletion()">VIEW RESULTS</button>
-    <button style="display:block;margin:12px auto 0;padding:10px 24px;background:transparent;border:1px solid #334155;border-radius:10px;color:#94A3B8;font-family:Nunito,sans-serif;font-size:13px;font-weight:600;cursor:pointer;" onclick="window.location.href=(window.location.pathname.indexOf('/qa/')===0?'/qa':'')+'/daily-missions'">Back to Missions</button>
+    <button style="display:block;margin:12px auto 0;padding:10px 24px;background:transparent;border:1px solid #334155;border-radius:10px;color:#94A3B8;font-family:Nunito,sans-serif;font-size:13px;font-weight:600;cursor:pointer;" onclick="window.location.href='/daily-missions'">Back to Missions</button>
   </div>
 </div>
 
@@ -2070,6 +2070,138 @@ function init() {
 
 loadCurriculumContent();
 loadAudioForPhase('nav');
+</script>
+<!-- ═══ Kid Feedback Widget (ES5 IIFE) ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:260px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 12px 0;color:#e2e8f0;font-size:16px;text-align:center;}'
+    + '.tbm-fb-emojis{display:flex;justify-content:center;gap:16px;margin-bottom:12px;}'
+    + '.tbm-fb-emojis button{width:52px;height:52px;border-radius:50%;border:2px solid #1e3347;background:#0f1a2a;'
+    + 'font-size:26px;cursor:pointer;transition:border-color 0.15s,transform 0.15s;}'
+    + '.tbm-fb-emojis button.selected{border-color:#38bdf8;transform:scale(1.15);}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>How was it?</h3>'
+    + '<div class="tbm-fb-emojis">'
+    + '<button data-score="1" aria-label="Okay">&#x1F610;</button>'
+    + '<button data-score="3" aria-label="Good">&#x1F642;</button>'
+    + '<button data-score="5" aria-label="Awesome">&#x1F929;</button>'
+    + '</div>'
+    + '<textarea id="tbm-fb-text" placeholder="What happened? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var selectedScore = 0;
+
+  function getUser() {
+    var search = window.location.search || '';
+    var match = search.match(/[?&]child=([^&]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return 'unknown';
+  }
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'unknown';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    selectedScore = 0;
+    var btns = modal.querySelectorAll('.tbm-fb-emojis button');
+    for (var i = 0; i < btns.length; i++) btns[i].className = '';
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  var emojiButtons = modal.querySelectorAll('.tbm-fb-emojis button');
+  for (var e = 0; e < emojiButtons.length; e++) {
+    emojiButtons[e].onclick = (function(b) {
+      return function() {
+        selectedScore = parseInt(b.getAttribute('data-score'), 10);
+        var all = modal.querySelectorAll('.tbm-fb-emojis button');
+        for (var k = 0; k < all.length; k++) all[k].className = '';
+        b.className = 'selected';
+      };
+    })(emojiButtons[e]);
+  }
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!selectedScore) { showToast('Tap an emoji first!'); return; }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: selectedScore,
+      readability: selectedScore,
+      text: ta ? ta.value : '',
+      user: getUser()
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+})();
 </script>
 </body>
 </html>

--- a/KidsHub.html
+++ b/KidsHub.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+<meta name="tbm-module" content="kidshub">
 <meta name="tbm-version" content="KidsHub v45">
 <title>Kids Hub v40</title>
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Barlow+Condensed:wght@400;600;700;800&family=Fredoka+One&family=Nunito:wght@700;800;900&family=Orbitron:wght@700;900&display=swap" rel="stylesheet">
@@ -1190,13 +1191,11 @@ var IS_PARENT = INIT_VIEW  === 'parent';
 var _pNavBaseUrl = '';
 if (IS_PARENT) { google.script.run.withSuccessHandler(function(u) { _pNavBaseUrl = u; }).withFailureHandler(function(e){ console.log('Nav URL fetch failed: ' + (e && e.message ? e.message : 'unknown')); }).getScriptUrlSafe(); }
 // v32: Education nav helper — builds URL for education module pages
-// v33: Include /qa prefix when served under /qa/* route
 var _eduBaseUrl = '';
 (function() {
   var loc = window.location;
   if (loc.hostname && loc.hostname !== 'script.google.com' && loc.hostname.indexOf('googleusercontent') === -1) {
-    var qaPrefix = (loc.pathname.indexOf('/qa/') === 0) ? '/qa' : '';
-    _eduBaseUrl = loc.origin + qaPrefix;
+    _eduBaseUrl = loc.origin;
   }
 })();
 function eduGo(page) {
@@ -4317,5 +4316,159 @@ function pBatchApprove(child) {
   };
 })();
 </script>
+<!-- ═══ Adult Feedback Widget (ES5 IIFE) — parent view only ═══ -->
+<script>
+if (IS_PARENT) {
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:280px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 14px 0;color:#e2e8f0;font-size:15px;text-align:center;}'
+    + '.tbm-fb-row{display:flex;align-items:center;margin-bottom:10px;}'
+    + '.tbm-fb-row-label{color:#9ca3af;font-size:12px;width:80px;flex-shrink:0;}'
+    + '.tbm-fb-stars{display:flex;gap:4px;}'
+    + '.tbm-fb-stars span{font-size:22px;cursor:pointer;opacity:0.3;transition:opacity 0.15s;}'
+    + '.tbm-fb-stars span.active{opacity:1;}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  function buildStarRow(label, id) {
+    var html = '<div class="tbm-fb-row"><span class="tbm-fb-row-label">' + label + '</span>'
+      + '<div class="tbm-fb-stars" data-rating-id="' + id + '">';
+    for (var s = 1; s <= 5; s++) {
+      html += '<span data-val="' + s + '">&#x2B50;</span>';
+    }
+    html += '</div></div>';
+    return html;
+  }
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>Quick Feedback</h3>'
+    + buildStarRow('Layout', 'layout')
+    + buildStarRow('Readability', 'readability')
+    + '<textarea id="tbm-fb-text" placeholder="Any thoughts? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var ratings = { layout: 0, readability: 0 };
+
+  function updateStars(containerId, val) {
+    var container = modal.querySelector('[data-rating-id="' + containerId + '"]');
+    if (!container) return;
+    var spans = container.querySelectorAll('span');
+    for (var i = 0; i < spans.length; i++) {
+      var v = parseInt(spans[i].getAttribute('data-val'), 10);
+      spans[i].className = v <= val ? 'active' : '';
+    }
+    ratings[containerId] = val;
+  }
+
+  function wireStars(containerId) {
+    var container = modal.querySelector('[data-rating-id="' + containerId + '"]');
+    if (!container) return;
+    var spans = container.querySelectorAll('span');
+    for (var i = 0; i < spans.length; i++) {
+      spans[i].onclick = (function(sp) {
+        return function() {
+          updateStars(containerId, parseInt(sp.getAttribute('data-val'), 10));
+        };
+      })(spans[i]);
+    }
+  }
+
+  wireStars('layout');
+  wireStars('readability');
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'kidshub-parent';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    ratings.layout = 0;
+    ratings.readability = 0;
+    updateStars('layout', 0);
+    updateStars('readability', 0);
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!ratings.layout || !ratings.readability) {
+      showToast('Please rate both categories');
+      return;
+    }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: ratings.layout,
+      readability: ratings.readability,
+      text: ta ? ta.value : '',
+      user: 'JT'
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+})();
+}
+</script>
 </body>
-</html><!-- END OF FILE: KidsHub.html v37 -->
+</html><!-- END OF FILE: KidsHub.html v45 -->

--- a/SparkleLearning.html
+++ b/SparkleLearning.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <meta name="tbm-module" content="sparkle-learn">
-  <meta name="tbm-version" content="v18">
+  <meta name="tbm-version" content="v19">
   <title>SparkleLearn v3 — JJ's Learning Games</title>
   <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
   <style>
@@ -3256,6 +3256,138 @@ function showMoreFallbackLetters() {
 window.onload = function() {
   init();
 };
+</script>
+<!-- ═══ Kid Feedback Widget (ES5 IIFE) ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:260px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 12px 0;color:#e2e8f0;font-size:16px;text-align:center;}'
+    + '.tbm-fb-emojis{display:flex;justify-content:center;gap:16px;margin-bottom:12px;}'
+    + '.tbm-fb-emojis button{width:52px;height:52px;border-radius:50%;border:2px solid #1e3347;background:#0f1a2a;'
+    + 'font-size:26px;cursor:pointer;transition:border-color 0.15s,transform 0.15s;}'
+    + '.tbm-fb-emojis button.selected{border-color:#38bdf8;transform:scale(1.15);}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>How was it?</h3>'
+    + '<div class="tbm-fb-emojis">'
+    + '<button data-score="1" aria-label="Okay">&#x1F610;</button>'
+    + '<button data-score="3" aria-label="Good">&#x1F642;</button>'
+    + '<button data-score="5" aria-label="Awesome">&#x1F929;</button>'
+    + '</div>'
+    + '<textarea id="tbm-fb-text" placeholder="What happened? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var selectedScore = 0;
+
+  function getUser() {
+    var search = window.location.search || '';
+    var match = search.match(/[?&]child=([^&]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return 'unknown';
+  }
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'unknown';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    selectedScore = 0;
+    var btns = modal.querySelectorAll('.tbm-fb-emojis button');
+    for (var i = 0; i < btns.length; i++) btns[i].className = '';
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  var emojiButtons = modal.querySelectorAll('.tbm-fb-emojis button');
+  for (var e = 0; e < emojiButtons.length; e++) {
+    emojiButtons[e].onclick = (function(b) {
+      return function() {
+        selectedScore = parseInt(b.getAttribute('data-score'), 10);
+        var all = modal.querySelectorAll('.tbm-fb-emojis button');
+        for (var k = 0; k < all.length; k++) all[k].className = '';
+        b.className = 'selected';
+      };
+    })(emojiButtons[e]);
+  }
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!selectedScore) { showToast('Tap an emoji first!'); return; }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: selectedScore,
+      readability: selectedScore,
+      text: ta ? ta.value : '',
+      user: getUser()
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+})();
 </script>
 </body>
 </html>

--- a/ThePulse.html
+++ b/ThePulse.html
@@ -3,8 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-<meta name="tbm-version" content="v63">
-<title>The Pulse v63 — Thompson Household</title>
+<meta name="tbm-module" content="the-pulse">
+<meta name="tbm-version" content="v64">
+<title>The Pulse v64 — Thompson Household</title>
 <!-- Version history tracked in Notion deploy page. Do not add version comments here. -->
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;600&family=Playfair+Display:ital,wght@0,400;0,600;0,700;0,900;1,400&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
 <style>
@@ -548,7 +549,7 @@ function tbmNav(p){var suffix=_isPartnerMode?'&jt=1':'';if(_tbmBaseUrl)window.to
 <div id="confidenceRail" style="position:fixed;bottom:8px;left:12px;font-size:11px;color:#94a3b8;z-index:100;"></div>
 
 <script>
-var TBM_VERSION = 'v63';
+var TBM_VERSION = 'v64';
 function closest_(el, sel) { while (el && el !== document) { if ((el.matches || el.msMatchesSelector || el.webkitMatchesSelector || function(){return false;}).call(el, sel)) return el; el = el.parentElement; } return null; }
 var _lastFetchTime = null;
 var _lastGoodSim = null;
@@ -1423,6 +1424,158 @@ p.innerHTML='<div style="padding:10px 16px;display:flex;justify-content:space-be
 document.body.appendChild(p);
 document.body.style.border=allPass?'3px solid #4ade80':'3px solid #f87171';
 });
+})();
+</script>
+<!-- ═══ Adult Feedback Widget (ES5 IIFE) ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:280px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 14px 0;color:#e2e8f0;font-size:15px;text-align:center;}'
+    + '.tbm-fb-row{display:flex;align-items:center;margin-bottom:10px;}'
+    + '.tbm-fb-row-label{color:#9ca3af;font-size:12px;width:80px;flex-shrink:0;}'
+    + '.tbm-fb-stars{display:flex;gap:4px;}'
+    + '.tbm-fb-stars span{font-size:22px;cursor:pointer;opacity:0.3;transition:opacity 0.15s;}'
+    + '.tbm-fb-stars span.active{opacity:1;}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  function buildStarRow(label, id) {
+    var html = '<div class="tbm-fb-row"><span class="tbm-fb-row-label">' + label + '</span>'
+      + '<div class="tbm-fb-stars" data-rating-id="' + id + '">';
+    for (var s = 1; s <= 5; s++) {
+      html += '<span data-val="' + s + '">&#x2B50;</span>';
+    }
+    html += '</div></div>';
+    return html;
+  }
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>Quick Feedback</h3>'
+    + buildStarRow('Layout', 'layout')
+    + buildStarRow('Readability', 'readability')
+    + '<textarea id="tbm-fb-text" placeholder="Any thoughts? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var ratings = { layout: 0, readability: 0 };
+
+  function updateStars(containerId, val) {
+    var container = modal.querySelector('[data-rating-id="' + containerId + '"]');
+    if (!container) return;
+    var spans = container.querySelectorAll('span');
+    for (var i = 0; i < spans.length; i++) {
+      var v = parseInt(spans[i].getAttribute('data-val'), 10);
+      spans[i].className = v <= val ? 'active' : '';
+    }
+    ratings[containerId] = val;
+  }
+
+  function wireStars(containerId) {
+    var container = modal.querySelector('[data-rating-id="' + containerId + '"]');
+    if (!container) return;
+    var spans = container.querySelectorAll('span');
+    for (var i = 0; i < spans.length; i++) {
+      spans[i].onclick = (function(sp) {
+        return function() {
+          updateStars(containerId, parseInt(sp.getAttribute('data-val'), 10));
+        };
+      })(spans[i]);
+    }
+  }
+
+  wireStars('layout');
+  wireStars('readability');
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'unknown';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    ratings.layout = 0;
+    ratings.readability = 0;
+    updateStars('layout', 0);
+    updateStars('readability', 0);
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!ratings.layout || !ratings.readability) {
+      showToast('Please rate both categories');
+      return;
+    }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: ratings.layout,
+      readability: ratings.readability,
+      text: ta ? ta.value : '',
+      user: 'JT'
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
 })();
 </script>
 </body>

--- a/daily-missions.html
+++ b/daily-missions.html
@@ -1003,8 +1003,6 @@ var _serverStateLoaded = false;
 var _cachedMissionState = {};
 var dynamicSchedule = null;
 var _designUnlocked = false;
-// QA prefix — non-empty when served under /qa/* so nav stays in QA namespace
-var _qaPrefix = (window.location.pathname.indexOf('/qa/') === 0) ? '/qa' : '';
 
 function isJJ() { return currentChild === 'jj' || currentChild === 'sandbox-jj'; }
 
@@ -1605,7 +1603,7 @@ function render() {
       html += '<div class="mission-number" style="background:linear-gradient(135deg,#003311,#001a0a);border-color:#00ff88;color:#00ff88;">\uD83C\uDF89</div>';
       html += '<div class="mission-info"><div class="mission-name">' + block.name + '</div>';
       html += '<div class="mission-meta"><span class="mission-time">Take as long as you want. No timer.</span></div></div>';
-      html += '<div class="mission-actions"><button class="launch-btn" onclick="window.location.href=_qaPrefix+\'/wolfdome?customize=1\'" style="border-color:#00ff88;color:#00ff88;box-shadow:0 0 10px rgba(0,255,136,0.3);">ENTER \u2192</button></div>';
+      html += '<div class="mission-actions"><button class="launch-btn" onclick="window.location.href=\'/wolfdome?customize=1\'" style="border-color:#00ff88;color:#00ff88;box-shadow:0 0 10px rgba(0,255,136,0.3);">ENTER \u2192</button></div>';
       html += '</div>';
     } else {
       // Normal card
@@ -1716,6 +1714,11 @@ function render() {
       setTimeout(function() { showXPPop(cx, cy, '+10 RINGS'); }, 300);
     }
   }
+
+  // Auto-open feedback after all missions complete (fires once)
+  if (allDone && typeof window._tbmFbAutoOpen === 'function') {
+    window._tbmFbAutoOpen();
+  }
 }
 
 // ============================================================
@@ -1737,14 +1740,14 @@ function renderWeekend(container) {
     html += '<div class="bonus-title">\uD83C\uDF08 FREE PLAY \uD83C\uDF08</div>';
     html += '<div class="bonus-desc">Pick any game you want, JJ!</div>';
     html += '<div style="margin-top:12px;display:-webkit-flex;display:flex;gap:10px;-webkit-justify-content:center;justify-content:center;-webkit-flex-wrap:wrap;flex-wrap:wrap">';
-    html += '<button class="launch-btn" onclick="launchMission(_qaPrefix+\'/sparkle-free\',\'freeplay_jj\',\'Sparkle Free Play\')">Sparkle Kingdom \u2728</button>';
+    html += '<button class="launch-btn" onclick="launchMission(\'/sparkle-free\',\'freeplay_jj\',\'Sparkle Free Play\')">Sparkle Kingdom \u2728</button>';
     html += '</div>';
   } else {
     html += '<div class="bonus-title">\uD83C\uDFAE FREE TIME \uD83C\uDFAE</div>';
     html += '<div class="bonus-desc">No missions today. Pick what you want to do.</div>';
     html += '<div style="margin-top:12px;display:-webkit-flex;display:flex;gap:10px;-webkit-justify-content:center;justify-content:center;-webkit-flex-wrap:wrap;flex-wrap:wrap">';
-    html += '<button class="launch-btn" onclick="launchMission(_qaPrefix+\'/facts\',\'bonus_facts\',\'Fact Sprint\')">Fact Sprint \u26A1</button>';
-    html += '<button class="launch-btn" onclick="launchMission(_qaPrefix+\'/comic-studio\',\'freeplay_comic\',\'Comic Studio\')">Comic Studio \uD83C\uDFA8</button>';
+    html += '<button class="launch-btn" onclick="launchMission(\'/facts\',\'bonus_facts\',\'Fact Sprint\')">Fact Sprint \u26A1</button>';
+    html += '<button class="launch-btn" onclick="launchMission(\'/comic-studio\',\'freeplay_comic\',\'Comic Studio\')">Comic Studio \uD83C\uDFA8</button>';
     html += '</div>';
   }
   html += '</div>';
@@ -1799,6 +1802,146 @@ function showXPPop(cx, cy, label) {
 // BOOT
 // ============================================================
 init();
+</script>
+<!-- ═══ Kid Feedback Widget (ES5 IIFE) — auto-opens on day-complete ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:260px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 12px 0;color:#e2e8f0;font-size:16px;text-align:center;}'
+    + '.tbm-fb-emojis{display:flex;justify-content:center;gap:16px;margin-bottom:12px;}'
+    + '.tbm-fb-emojis button{width:52px;height:52px;border-radius:50%;border:2px solid #1e3347;background:#0f1a2a;'
+    + 'font-size:26px;cursor:pointer;transition:border-color 0.15s,transform 0.15s;}'
+    + '.tbm-fb-emojis button.selected{border-color:#38bdf8;transform:scale(1.15);}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>How was it?</h3>'
+    + '<div class="tbm-fb-emojis">'
+    + '<button data-score="1" aria-label="Okay">&#x1F610;</button>'
+    + '<button data-score="3" aria-label="Good">&#x1F642;</button>'
+    + '<button data-score="5" aria-label="Awesome">&#x1F929;</button>'
+    + '</div>'
+    + '<textarea id="tbm-fb-text" placeholder="What happened? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var selectedScore = 0;
+  var _fbShownOnce = false;
+
+  function getUser() {
+    var search = window.location.search || '';
+    var match = search.match(/[?&]child=([^&]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return 'unknown';
+  }
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'daily-missions';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    selectedScore = 0;
+    var btns = modal.querySelectorAll('.tbm-fb-emojis button');
+    for (var i = 0; i < btns.length; i++) btns[i].className = '';
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  var emojiButtons = modal.querySelectorAll('.tbm-fb-emojis button');
+  for (var e = 0; e < emojiButtons.length; e++) {
+    emojiButtons[e].onclick = (function(b) {
+      return function() {
+        selectedScore = parseInt(b.getAttribute('data-score'), 10);
+        var all = modal.querySelectorAll('.tbm-fb-emojis button');
+        for (var k = 0; k < all.length; k++) all[k].className = '';
+        b.className = 'selected';
+      };
+    })(emojiButtons[e]);
+  }
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!selectedScore) { showToast('Tap an emoji first!'); return; }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: selectedScore,
+      readability: selectedScore,
+      text: ta ? ta.value : '',
+      user: getUser()
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+
+  // Expose auto-open hook for day-complete celebration
+  window._tbmFbAutoOpen = function() {
+    if (_fbShownOnce) return;
+    _fbShownOnce = true;
+    setTimeout(openModal, 2000);
+  };
+})();
 </script>
 </body>
 </html>

--- a/fact-sprint.html
+++ b/fact-sprint.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="fact-sprint">
-<meta name="tbm-version" content="v8">
+<meta name="tbm-version" content="v9">
 <title>Wolfkid Fact Sprint</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -1725,6 +1725,138 @@ function init() {
 
 init();
 preloadBugsyAudio();
+</script>
+<!-- ═══ Kid Feedback Widget (ES5 IIFE) ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:260px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 12px 0;color:#e2e8f0;font-size:16px;text-align:center;}'
+    + '.tbm-fb-emojis{display:flex;justify-content:center;gap:16px;margin-bottom:12px;}'
+    + '.tbm-fb-emojis button{width:52px;height:52px;border-radius:50%;border:2px solid #1e3347;background:#0f1a2a;'
+    + 'font-size:26px;cursor:pointer;transition:border-color 0.15s,transform 0.15s;}'
+    + '.tbm-fb-emojis button.selected{border-color:#38bdf8;transform:scale(1.15);}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>How was it?</h3>'
+    + '<div class="tbm-fb-emojis">'
+    + '<button data-score="1" aria-label="Okay">&#x1F610;</button>'
+    + '<button data-score="3" aria-label="Good">&#x1F642;</button>'
+    + '<button data-score="5" aria-label="Awesome">&#x1F929;</button>'
+    + '</div>'
+    + '<textarea id="tbm-fb-text" placeholder="What happened? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var selectedScore = 0;
+
+  function getUser() {
+    var search = window.location.search || '';
+    var match = search.match(/[?&]child=([^&]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return 'unknown';
+  }
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'unknown';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    selectedScore = 0;
+    var btns = modal.querySelectorAll('.tbm-fb-emojis button');
+    for (var i = 0; i < btns.length; i++) btns[i].className = '';
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  var emojiButtons = modal.querySelectorAll('.tbm-fb-emojis button');
+  for (var e = 0; e < emojiButtons.length; e++) {
+    emojiButtons[e].onclick = (function(b) {
+      return function() {
+        selectedScore = parseInt(b.getAttribute('data-score'), 10);
+        var all = modal.querySelectorAll('.tbm-fb-emojis button');
+        for (var k = 0; k < all.length; k++) all[k].className = '';
+        b.className = 'selected';
+      };
+    })(emojiButtons[e]);
+  }
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!selectedScore) { showToast('Tap an emoji first!'); return; }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: selectedScore,
+      readability: selectedScore,
+      text: ta ? ta.value : '',
+      user: getUser()
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+})();
 </script>
 </body>
 </html>

--- a/investigation-module.html
+++ b/investigation-module.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="investigation-module">
-<meta name="tbm-version" content="v5">
+<meta name="tbm-version" content="v6">
 <title>Wolfkid Investigation Module</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -1825,6 +1825,138 @@ function init() {
 // ─── Start ───
 loadCurriculumContent();
 preloadBugsyAudio();
+</script>
+<!-- ═══ Kid Feedback Widget (ES5 IIFE) ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:260px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 12px 0;color:#e2e8f0;font-size:16px;text-align:center;}'
+    + '.tbm-fb-emojis{display:flex;justify-content:center;gap:16px;margin-bottom:12px;}'
+    + '.tbm-fb-emojis button{width:52px;height:52px;border-radius:50%;border:2px solid #1e3347;background:#0f1a2a;'
+    + 'font-size:26px;cursor:pointer;transition:border-color 0.15s,transform 0.15s;}'
+    + '.tbm-fb-emojis button.selected{border-color:#38bdf8;transform:scale(1.15);}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>How was it?</h3>'
+    + '<div class="tbm-fb-emojis">'
+    + '<button data-score="1" aria-label="Okay">&#x1F610;</button>'
+    + '<button data-score="3" aria-label="Good">&#x1F642;</button>'
+    + '<button data-score="5" aria-label="Awesome">&#x1F929;</button>'
+    + '</div>'
+    + '<textarea id="tbm-fb-text" placeholder="What happened? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var selectedScore = 0;
+
+  function getUser() {
+    var search = window.location.search || '';
+    var match = search.match(/[?&]child=([^&]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return 'unknown';
+  }
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'unknown';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    selectedScore = 0;
+    var btns = modal.querySelectorAll('.tbm-fb-emojis button');
+    for (var i = 0; i < btns.length; i++) btns[i].className = '';
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  var emojiButtons = modal.querySelectorAll('.tbm-fb-emojis button');
+  for (var e = 0; e < emojiButtons.length; e++) {
+    emojiButtons[e].onclick = (function(b) {
+      return function() {
+        selectedScore = parseInt(b.getAttribute('data-score'), 10);
+        var all = modal.querySelectorAll('.tbm-fb-emojis button');
+        for (var k = 0; k < all.length; k++) all[k].className = '';
+        b.className = 'selected';
+      };
+    })(emojiButtons[e]);
+  }
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!selectedScore) { showToast('Tap an emoji first!'); return; }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: selectedScore,
+      readability: selectedScore,
+      text: ta ? ta.value : '',
+      user: getUser()
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+})();
 </script>
 </body>
 </html>

--- a/reading-module.html
+++ b/reading-module.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="reading-module">
-<meta name="tbm-version" content="v6">
+<meta name="tbm-version" content="v7">
 <title>Wolfkid Reading Module</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -1958,5 +1958,137 @@ preloadBugsyAudio();
   <button style="background:rgba(245,158,11,0.1);border:1px solid #f59e0b;color:#f59e0b;font-family:'Orbitron',sans-serif;font-weight:700;border-radius:5px;font-size:8px;cursor:default;padding:6px 12px;">&#x1F4D6; Reading</button>
   <button style="background:transparent;border:none;color:#4a6080;font-size:11px;cursor:pointer;padding:6px 12px;font-family:'Nunito',sans-serif;" onclick="showNavBlock()">&#x1F4DA; Math/Sci</button>
 </div>
+<!-- ═══ Kid Feedback Widget (ES5 IIFE) ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:260px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 12px 0;color:#e2e8f0;font-size:16px;text-align:center;}'
+    + '.tbm-fb-emojis{display:flex;justify-content:center;gap:16px;margin-bottom:12px;}'
+    + '.tbm-fb-emojis button{width:52px;height:52px;border-radius:50%;border:2px solid #1e3347;background:#0f1a2a;'
+    + 'font-size:26px;cursor:pointer;transition:border-color 0.15s,transform 0.15s;}'
+    + '.tbm-fb-emojis button.selected{border-color:#38bdf8;transform:scale(1.15);}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>How was it?</h3>'
+    + '<div class="tbm-fb-emojis">'
+    + '<button data-score="1" aria-label="Okay">&#x1F610;</button>'
+    + '<button data-score="3" aria-label="Good">&#x1F642;</button>'
+    + '<button data-score="5" aria-label="Awesome">&#x1F929;</button>'
+    + '</div>'
+    + '<textarea id="tbm-fb-text" placeholder="What happened? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var selectedScore = 0;
+
+  function getUser() {
+    var search = window.location.search || '';
+    var match = search.match(/[?&]child=([^&]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return 'unknown';
+  }
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'unknown';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    selectedScore = 0;
+    var btns = modal.querySelectorAll('.tbm-fb-emojis button');
+    for (var i = 0; i < btns.length; i++) btns[i].className = '';
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  var emojiButtons = modal.querySelectorAll('.tbm-fb-emojis button');
+  for (var e = 0; e < emojiButtons.length; e++) {
+    emojiButtons[e].onclick = (function(b) {
+      return function() {
+        selectedScore = parseInt(b.getAttribute('data-score'), 10);
+        var all = modal.querySelectorAll('.tbm-fb-emojis button');
+        for (var k = 0; k < all.length; k++) all[k].className = '';
+        b.className = 'selected';
+      };
+    })(emojiButtons[e]);
+  }
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!selectedScore) { showToast('Tap an emoji first!'); return; }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: selectedScore,
+      readability: selectedScore,
+      text: ta ? ta.value : '',
+      user: getUser()
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+})();
+</script>
 </body>
 </html>

--- a/writing-module.html
+++ b/writing-module.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="tbm-module" content="writing-module">
-<meta name="tbm-version" content="v6">
+<meta name="tbm-version" content="v7">
 <title>Writing Module - Buggsy</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -1683,5 +1683,137 @@ preloadBugsyAudio();
   <button style="background:rgba(245,158,11,0.1);border:1px solid #f59e0b;color:#f59e0b;font-family:'Orbitron',sans-serif;font-weight:700;border-radius:5px;font-size:8px;cursor:default;padding:6px 12px;">&#x270D;&#xFE0F; Writing</button>
   <button style="background:transparent;border:none;color:#4a6080;font-size:11px;cursor:pointer;padding:6px 12px;font-family:'Nunito',sans-serif;" onclick="showNavBlock()">&#x1F4DA; Math/Sci</button>
 </div>
+<!-- ═══ Kid Feedback Widget (ES5 IIFE) ═══ -->
+<script>
+(function() {
+  var FB_STYLES = '#tbm-fb-btn{position:fixed;bottom:12px;left:12px;width:48px;height:48px;border-radius:50%;'
+    + 'background:rgba(11,19,29,0.7);border:1px solid #1e3347;color:#e2e8f0;font-size:22px;cursor:pointer;'
+    + 'z-index:9000;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,0.3);'
+    + 'transition:opacity 0.2s;opacity:0.6;}'
+    + '#tbm-fb-btn:hover{opacity:1;}'
+    + '#tbm-fb-overlay{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:9001;}'
+    + '#tbm-fb-modal{position:fixed;bottom:70px;left:12px;width:260px;background:#0b131d;border:1px solid #1e3347;'
+    + 'border-radius:12px;padding:16px;z-index:9002;box-shadow:0 4px 24px rgba(0,0,0,0.5);display:none;}'
+    + '#tbm-fb-modal h3{margin:0 0 12px 0;color:#e2e8f0;font-size:16px;text-align:center;}'
+    + '.tbm-fb-emojis{display:flex;justify-content:center;gap:16px;margin-bottom:12px;}'
+    + '.tbm-fb-emojis button{width:52px;height:52px;border-radius:50%;border:2px solid #1e3347;background:#0f1a2a;'
+    + 'font-size:26px;cursor:pointer;transition:border-color 0.15s,transform 0.15s;}'
+    + '.tbm-fb-emojis button.selected{border-color:#38bdf8;transform:scale(1.15);}'
+    + '#tbm-fb-text{width:100%;box-sizing:border-box;background:#0f1a2a;border:1px solid #1e3347;border-radius:8px;'
+    + 'color:#e2e8f0;padding:8px;font-size:14px;font-family:inherit;resize:none;height:52px;margin-bottom:10px;}'
+    + '#tbm-fb-text::placeholder{color:#4a6080;}'
+    + '.tbm-fb-actions{display:flex;justify-content:flex-end;gap:8px;}'
+    + '.tbm-fb-actions button{padding:6px 14px;border-radius:6px;font-size:13px;cursor:pointer;border:none;}'
+    + '#tbm-fb-skip{background:transparent;color:#4a6080;}#tbm-fb-skip:hover{color:#e2e8f0;}'
+    + '#tbm-fb-send{background:#1e3a5f;color:#38bdf8;font-weight:700;}#tbm-fb-send:hover{background:#254a73;}'
+    + '.tbm-fb-toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#0b131d;'
+    + 'border:1px solid #1e3347;color:#e2e8f0;padding:8px 20px;border-radius:8px;font-size:14px;z-index:9010;'
+    + 'opacity:0;transition:opacity 0.3s;}';
+
+  var style = document.createElement('style');
+  style.textContent = FB_STYLES;
+  document.head.appendChild(style);
+
+  var btn = document.createElement('button');
+  btn.id = 'tbm-fb-btn';
+  btn.innerHTML = '&#x1F4AC;';
+  btn.setAttribute('aria-label', 'Give feedback');
+  document.body.appendChild(btn);
+
+  var overlay = document.createElement('div');
+  overlay.id = 'tbm-fb-overlay';
+  document.body.appendChild(overlay);
+
+  var modal = document.createElement('div');
+  modal.id = 'tbm-fb-modal';
+  modal.innerHTML = '<h3>How was it?</h3>'
+    + '<div class="tbm-fb-emojis">'
+    + '<button data-score="1" aria-label="Okay">&#x1F610;</button>'
+    + '<button data-score="3" aria-label="Good">&#x1F642;</button>'
+    + '<button data-score="5" aria-label="Awesome">&#x1F929;</button>'
+    + '</div>'
+    + '<textarea id="tbm-fb-text" placeholder="What happened? (optional)" maxlength="200"></textarea>'
+    + '<div class="tbm-fb-actions">'
+    + '<button id="tbm-fb-skip">Skip</button>'
+    + '<button id="tbm-fb-send">Send</button>'
+    + '</div>';
+  document.body.appendChild(modal);
+
+  var selectedScore = 0;
+
+  function getUser() {
+    var search = window.location.search || '';
+    var match = search.match(/[?&]child=([^&]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return 'unknown';
+  }
+
+  function getSurface() {
+    var meta = document.querySelector('meta[name="tbm-module"]');
+    return meta ? meta.getAttribute('content') : 'unknown';
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div');
+    t.className = 'tbm-fb-toast';
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() { t.style.opacity = '1'; }, 10);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 300);
+    }, 1500);
+  }
+
+  function openModal() {
+    selectedScore = 0;
+    var btns = modal.querySelectorAll('.tbm-fb-emojis button');
+    for (var i = 0; i < btns.length; i++) btns[i].className = '';
+    var ta = document.getElementById('tbm-fb-text');
+    if (ta) ta.value = '';
+    overlay.style.display = 'block';
+    modal.style.display = 'block';
+  }
+
+  function closeModal() {
+    overlay.style.display = 'none';
+    modal.style.display = 'none';
+  }
+
+  btn.onclick = openModal;
+  overlay.onclick = closeModal;
+
+  var emojiButtons = modal.querySelectorAll('.tbm-fb-emojis button');
+  for (var e = 0; e < emojiButtons.length; e++) {
+    emojiButtons[e].onclick = (function(b) {
+      return function() {
+        selectedScore = parseInt(b.getAttribute('data-score'), 10);
+        var all = modal.querySelectorAll('.tbm-fb-emojis button');
+        for (var k = 0; k < all.length; k++) all[k].className = '';
+        b.className = 'selected';
+      };
+    })(emojiButtons[e]);
+  }
+
+  document.getElementById('tbm-fb-skip').onclick = closeModal;
+
+  document.getElementById('tbm-fb-send').onclick = function() {
+    if (!selectedScore) { showToast('Tap an emoji first!'); return; }
+    var ta = document.getElementById('tbm-fb-text');
+    var payload = {
+      surface: getSurface(),
+      layout: selectedScore,
+      readability: selectedScore,
+      text: ta ? ta.value : '',
+      user: getUser()
+    };
+    closeModal();
+    google.script.run
+      .withSuccessHandler(function() { showToast('\u2713 Thanks!'); })
+      .withFailureHandler(function() { showToast('Oops, try later'); })
+      .submitFeedbackSafe(payload);
+  };
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **Kid feedback widget** (8 surfaces): fixed 💬 button → emoji modal (😐🙂🤩) → submitFeedbackSafe
- **Adult feedback widget** (2 surfaces): fixed 💬 button → 5-star layout + readability → submitFeedbackSafe
- **daily-missions**: persistent button + auto-open after all missions complete
- **Code.js v83**: submitFeedbackSafe fires Pushover to LT only, extended schema (User, Processed, Classification)

## Surfaces

ComicStudio, HomeworkModule, SparkleLearning, fact-sprint, reading-module, writing-module, investigation-module, DesignDashboard, ThePulse, KidsHub (parent guard), daily-missions

## Test plan

- [ ] Tap 💬 on any kid surface → emoji modal → send → Pushover to LT
- [ ] Tap 💬 on ThePulse → star modal → send → Pushover to LT
- [ ] KidsHub parent view: 💬 visible. Kid view: 💬 hidden
- [ ] daily-missions: complete all missions → feedback auto-opens after 2s
- [ ] Feedback sheet row has: Timestamp, Surface, Layout, Readability, FreeText, User, empty Processed, empty Classification
- [ ] JT does NOT receive Pushover (LT only)

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)