### PR TITLE
[audit] F03+F04 — worker build identity, GAS alignment check, front-door smoke

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -55,7 +55,6 @@ jobs:
           echo "Front-door smoke PASS — worker=${DEPLOYED_BUILD}"
 
           # Alignment check (F03): confirm GAS target suffix matches cloudflare-worker.js constant
-          GAS_SUFFIX="${CF_WORKER_URL}" # unused — alignment via /version gas_target field
           REMOTE_GAS_TAIL=$(echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('gas_target',''))" 2>/dev/null || echo "")
           LOCAL_GAS_TAIL=$(grep "^const GAS_URL" cloudflare-worker.js | grep -oP "(?<=')[^']+" | tail -c 13 | head -c 12)
           if [ "$REMOTE_GAS_TAIL" != "$LOCAL_GAS_TAIL" ]; then

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -8,15 +8,58 @@ on:
       - 'wrangler.toml'
   workflow_dispatch:
 
+# Serialize all production-mutation lanes. Same group as deploy-and-notify.yml (F05).
+concurrency:
+  group: tbm-production-release
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    name: Deploy + Smoke (Cloudflare Worker)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Stamp build identity (F04)
+        run: |
+          BUILD_ID="${GITHUB_SHA:0:12}"
+          sed -i "s/__BUILD_ID__/${BUILD_ID}/" cloudflare-worker.js
+          echo "Stamped WORKER_BUILD=${BUILD_ID}"
 
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Post-deploy smoke — front-door /version (F03/F04)
+        env:
+          CF_WORKER_URL: ${{ secrets.CF_WORKER_URL }}
+        run: |
+          if [ -z "$CF_WORKER_URL" ]; then
+            echo "::warning::CF_WORKER_URL not set — skipping front-door smoke. Set this secret to enable post-deploy verification."
+            exit 0
+          fi
+          BUILD_ID="${GITHUB_SHA:0:12}"
+          echo "Probing ${CF_WORKER_URL}/version for build ${BUILD_ID}..."
+          RESPONSE=$(curl -sS --max-time 30 "${CF_WORKER_URL}/version")
+          echo "Response: $RESPONSE"
+          DEPLOYED_BUILD=$(echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('worker',''))" 2>/dev/null || echo "")
+          if [ "$DEPLOYED_BUILD" != "$BUILD_ID" ]; then
+            echo "::error::Front-door smoke FAILED — expected worker=${BUILD_ID}, got worker=${DEPLOYED_BUILD}"
+            exit 1
+          fi
+          echo "Front-door smoke PASS — worker=${DEPLOYED_BUILD}"
+
+          # Alignment check (F03): confirm GAS target suffix matches cloudflare-worker.js constant
+          GAS_SUFFIX="${CF_WORKER_URL}" # unused — alignment via /version gas_target field
+          REMOTE_GAS_TAIL=$(echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('gas_target',''))" 2>/dev/null || echo "")
+          LOCAL_GAS_TAIL=$(grep "^const GAS_URL" cloudflare-worker.js | grep -oP "(?<=')[^']+" | tail -c 13 | head -c 12)
+          if [ "$REMOTE_GAS_TAIL" != "$LOCAL_GAS_TAIL" ]; then
+            echo "::error::GAS alignment check FAILED — live worker gas_target=${REMOTE_GAS_TAIL}, repo GAS_URL tail=${LOCAL_GAS_TAIL}"
+            exit 1
+          fi
+          echo "GAS alignment PASS — gas_target tail matches: ${REMOTE_GAS_TAIL}"

--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -5,6 +5,10 @@
 
 const GAS_URL = 'https://script.google.com/macros/s/AKfycbweFe1QLmIAlr2x0umcJ-uc2EIm-ADdcjJ9QjihBr6tmnt4Axz6xO73lmwBl4Jk6_KVOw/exec';
 
+// Build identity — replaced at deploy time by deploy-worker.yml
+// Exposes /version route so post-deploy smoke and alignment checks have a stable assertion target.
+const WORKER_BUILD = '__BUILD_ID__';
+
 // Clean URL → GAS query param mapping
 const PATH_ROUTES = {
   '/buggsy': { page: 'kidshub', child: 'buggsy' },
@@ -94,6 +98,13 @@ export default {
           'Access-Control-Allow-Headers': 'Content-Type',
           'Access-Control-Max-Age': '86400'
         }
+      });
+    }
+
+    // Route: /version → build identity for post-deploy smoke + alignment checks (F03/F04)
+    if (url.pathname === '/version') {
+      return new Response(JSON.stringify({ worker: WORKER_BUILD, gas_target: GAS_URL.slice(-12) }), {
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
       });
     }
 


### PR DESCRIPTION
## Summary
- Adds `WORKER_BUILD` constant to `cloudflare-worker.js` (replaced with commit SHA at deploy time via `sed`)
- Adds `/version` route returning `{worker, gas_target}` — stable assertion target for smoke and alignment checks
- Rewrites `deploy-worker.yml`: stamps build ID pre-deploy, runs post-deploy `curl /version` asserting deployed SHA matches commit SHA, adds GAS alignment check (CF worker GAS_URL tail == live `gas_target`), adds `tbm-production-release` concurrency group (F05)

## Test plan
- [ ] Verify worker serves `GET /version` returning JSON with `worker` and `gas_target` fields
- [ ] Trigger `deploy-worker.yml` — confirm post-deploy smoke step passes and logs build SHA match
- [ ] Edit `cloudflare-worker.js` GAS_URL to wrong value in a test branch — confirm alignment step fails
- [ ] Set `CF_WORKER_URL` secret if not already present (e.g. `https://thompsonfams.com`)

Closes #257, #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)