### PR TITLE
[audit] F05 — production concurrency serialization on GAS deploy lane

### DIFF
--- a/.github/workflows/deploy-and-notify.yml
+++ b/.github/workflows/deploy-and-notify.yml
@@ -22,6 +22,12 @@ on:
 permissions:
   contents: write   # required for gh release create
 
+# Serialize all production-mutation lanes. Same group applies to deploy-worker.yml (F03/F04).
+# cancel-in-progress: false ensures a queued deploy is never silently dropped.
+concurrency:
+  group: tbm-production-release
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: GAS Deploy + Smoke + Pushover


### PR DESCRIPTION
## Summary
- Adds `tbm-production-release` concurrency group to `deploy-and-notify.yml` with `cancel-in-progress: false`
- Prevents two near-simultaneous merges from running overlapping `clasp push --force` against the same GAS project
- `deploy-worker.yml` receives the same group via F03/F04 (#273)

## Test plan
- [ ] Trigger `deploy-and-notify.yml` and `deploy-worker.yml` from the same merge event and confirm one waits behind the other (check Actions queue)

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)