### PR TITLE
[audit] F14 — commit uptime worker deploy workflow to tracked repo

### DIFF
--- a/.github/workflows/deploy-uptime-worker.yml
+++ b/.github/workflows/deploy-uptime-worker.yml
@@ -1,0 +1,34 @@
+name: Deploy Cloudflare Uptime Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'uptime-worker.js'
+      - 'wrangler-uptime.toml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-cloudflare-uptime-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy TBM Uptime Worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy uptime worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --config wrangler-uptime.toml


### PR DESCRIPTION
## Summary
- Tracks `deploy-uptime-worker.yml` which existed only on disk (untracked/absent from live GitHub repo)
- Workflow deploys on push to main when `uptime-worker.js` or `wrangler-uptime.toml` changes, or via `workflow_dispatch`
- Includes `production` environment gate, `deploy-cloudflare-uptime-production` concurrency group, and 10-minute timeout
- Closes the gap where one production Cloudflare service had no tracked CI/CD path

## Test plan
- [ ] Confirm `.github/workflows/deploy-uptime-worker.yml` is present in repo after merge
- [ ] Trigger `workflow_dispatch` against this PR branch and confirm deploy runs against uptime worker

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)