### PR TITLE
fix: pre-install wrangler to unblock CF worker deploy

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -29,6 +29,9 @@ jobs:
           sed -i "s/__BUILD_ID__/${BUILD_ID}/" cloudflare-worker.js
           echo "Stamped WORKER_BUILD=${BUILD_ID}"
 
+      - name: Install Wrangler
+        run: npm install -g wrangler
+
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
Closes #292

## Summary
- `wrangler-action@v3` uses `npx` to install wrangler on demand; newer npm versions refuse without `--yes`, silently completing the action step with exit 0 but never actually deploying
- Pre-install wrangler globally so the action finds it already available and skips the npx step
- Unblocks F03+F04 smoke verification (the `/version` route is deployed but the old worker is still live)

## Test plan
- [ ] CF worker deploy run completes without `npx canceled` error
- [ ] Post-deploy `/version` smoke returns JSON with correct `worker` build ID
- [ ] GAS alignment check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)