### PR TITLE
infra(F07): CI policy — pull_request_target must not check out untrusted head code

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -84,6 +84,32 @@ jobs:
           fi
           echo "PASS: all shell scripts pass shellcheck (or none found)"
 
+      - name: Policy — pull_request_target must not check out untrusted head code (F07)
+        run: |
+          # pull_request_target runs with trusted base-context permissions (write access, secrets).
+          # Checking out PR head code via head.ref or head.sha exposes those secrets to
+          # potentially untrusted fork code — a severe trust-escalation vector.
+          # Fail if any pull_request_target workflow uses head.ref or head.sha as a checkout ref.
+          FAIL=0
+          for wf in .github/workflows/*.yml; do
+            if grep -q 'pull_request_target' "$wf"; then
+              # Detect checkout steps referencing head ref/sha (dot or underscore form)
+              if grep -qE 'ref:[[:space:]]*.*head[._](ref|sha)' "$wf"; then
+                echo "::error::POLICY VIOLATION: $wf uses pull_request_target and checks out untrusted head code."
+                echo "  Only base-branch checkout is safe in pull_request_target workflows."
+                echo "  Remove head.ref / head.sha / head_ref / head_sha from any checkout ref: field."
+                FAIL=1
+              else
+                echo "  OK (no unsafe head checkout): $(basename "$wf")"
+              fi
+            fi
+          done
+          if [ $FAIL -eq 1 ]; then
+            echo "FAIL: pull_request_target untrusted-checkout policy violated"
+            exit 1
+          fi
+          echo "PASS: no pull_request_target workflows check out untrusted head code"
+
       - name: Policy — no artifact downloads in workflow_run handlers (F08)
         run: |
           # workflow_run runs with repo-level write permissions in the trusted context.

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -89,13 +89,27 @@ jobs:
           # pull_request_target runs with trusted base-context permissions (write access, secrets).
           # Checking out PR head code via head.ref or head.sha exposes those secrets to
           # potentially untrusted fork code — a severe trust-escalation vector.
-          # Fail if any pull_request_target workflow uses head.ref or head.sha as a checkout ref.
+          #
+          # Guard scope: only workflows actually TRIGGERED BY pull_request_target (i.e., the
+          # string appears as a key under `on:` at the top of the YAML, not merely referenced
+          # in a condition or if: expression inside a different trigger's job).
+          # Detection: match `^on:` block lines until the next top-level key, then check for
+          # the trigger name. A workflow that mentions pull_request_target only in an `if:`
+          # expression (e.g. workflow_run checking event type) is correctly excluded.
           FAIL=0
           for wf in .github/workflows/*.yml; do
-            if grep -q 'pull_request_target' "$wf"; then
+            # Extract whether pull_request_target is an actual on: trigger.
+            # Strategy: check lines between `^on:` and next `^[a-z]` top-level key.
+            # Use awk to parse only the on: block (stops at next non-indented line after on:).
+            is_prt_trigger=$(awk '
+              /^on:/ { in_on=1; next }
+              in_on && /^[a-z]/ { exit }
+              in_on && /pull_request_target/ { print "yes"; exit }
+            ' "$wf")
+            if [ "$is_prt_trigger" = "yes" ]; then
               # Detect checkout steps referencing head ref/sha (dot or underscore form)
               if grep -qE 'ref:[[:space:]]*.*head[._](ref|sha)' "$wf"; then
-                echo "::error::POLICY VIOLATION: $wf uses pull_request_target and checks out untrusted head code."
+                echo "::error::POLICY VIOLATION: $wf is triggered by pull_request_target and checks out untrusted head code."
                 echo "  Only base-branch checkout is safe in pull_request_target workflows."
                 echo "  Remove head.ref / head.sha / head_ref / head_sha from any checkout ref: field."
                 FAIL=1


### PR DESCRIPTION
## Summary
- Adds a `workflow-lint` policy step that scans all `pull_request_target` workflows at PR time
- Fails CI if any checkout step references `head.ref`, `head.sha`, `head_ref`, or `head_sha`
- These are the unsafe patterns that expose base-context secrets to untrusted fork code

## Why
`pull_request_target` runs with trusted base-repo permissions (write access, secrets). Checking out PR head code in this context is a classic trust-escalation vector. The current `codex-pr-review.yml` is safe (uses `base_ref` for checkout, only fetches head for diff), but there was no CI assertion preventing future regressions.

## What changed
`.github/workflows/workflow-lint.yml` — new policy step `Policy — pull_request_target must not check out untrusted head code (F07)`

## Test plan
- [ ] CI passes on this PR (the new step will self-validate against `codex-pr-review.yml` — should PASS since it only uses `base_ref` for checkout)
- [ ] To verify the guard works: temporarily add `ref: ${{ github.event.pull_request.head.ref }}` to any `pull_request_target` workflow in a test branch — lint should fail

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)