### PR TITLE
infra(F12): staged-write pattern + data recovery runbook

### DIFF
--- a/GASHardening.js
+++ b/GASHardening.js
@@ -5,7 +5,7 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
 
-function getGASHardeningVersion() { return 8; }
+function getGASHardeningVersion() { return 9; }
 
 // v6: openById migration — trigger-safe spreadsheet accessor
 var _ghSS = null;
@@ -1907,5 +1907,53 @@ function diagPreQA() {
 }
 
 
-// END OF FILE — GAS HARDENING v8
+// ═══════════════════════════════════════════════════════════════
+// 9. STAGED WRITES (F12)
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * writeStaged_: buffer rows in a hidden staging tab, validate, then promote to production.
+ * Must be called within an active LockService scope — the lock guards the full
+ * stage → validate → promote sequence so no concurrent writer can race it.
+ *
+ * On validation failure the staging tab is left populated for post-mortem inspection.
+ * On success the staging tab is cleared.
+ *
+ * @param {string}       key       - staging key; staging tab name = '_STAGING_' + key
+ * @param {Array<Array>} rows      - 2D array of values to stage and validate
+ * @param {Function}     validator - function(rows) → {ok:boolean, reason:string}
+ * @param {Function}     writer    - called with no args after validation passes; does real write
+ * @return {{ok:boolean, reason:string}}
+ */
+function writeStaged_(key, rows, validator, writer) {
+  var ss = gh_getSS_();
+  var stagingName = '_STAGING_' + key;
+  var staging = ss.getSheetByName(stagingName);
+  try {
+    if (!staging) {
+      staging = ss.insertSheet(stagingName);
+      staging.hideSheet();
+    } else {
+      staging.clearContents();
+    }
+    if (rows && rows.length > 0 && rows[0] && rows[0].length > 0) {
+      staging.getRange(1, 1, rows.length, rows[0].length).setValues(rows);
+    }
+    var result = validator(rows);
+    if (!result.ok) {
+      // Leave staging populated for post-mortem; do not promote
+      logError_('writeStaged_[' + key + ']', new Error('Validation failed: ' + result.reason));
+      return { ok: false, reason: result.reason };
+    }
+    writer();
+    staging.clearContents();
+    return { ok: true, reason: '' };
+  } catch (e) {
+    logError_('writeStaged_[' + key + ']', e);
+    return { ok: false, reason: 'writeStaged_ threw: ' + e.message };
+  }
+}
+
+
+// END OF FILE — GAS HARDENING v9
 // ═══════════════════════════════════════════════════════════════

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1349,19 +1349,40 @@ function khCompleteTask(rowIndex, expectedTaskID) {
     // v25: Batch write — modify row in memory, single writeback
     row[khCol_(h, 'Completed')] = true;
     row[khCol_(h, 'Completed_Date')] = getTodayISO_();
-    sheet.getRange(rowIndex, 1, 1, h.length).setValues([row]);
-    // v36: Verify write persisted (diagnostic for task-revert bug)
-    var verifyRow = sheet.getRange(rowIndex, 1, 1, h.length).getValues()[0];
-    var verifyDone = verifyRow[khCol_(h, 'Completed')] === true ||
-      String(verifyRow[khCol_(h, 'Completed')]).toUpperCase() === 'TRUE';
-    if (!verifyDone) {
-      console.log('KH_VERIFY_FAIL', JSON.stringify({
-        fn: 'khCompleteTask', taskID: taskID, rowIndex: rowIndex,
-        wrote: true, readBack: verifyRow[khCol_(h, 'Completed')],
-        timestamp: getNowISO_()
-      }));
-      sheet.getRange(rowIndex, khCol_(h, 'Completed') + 1).setValue(true);
-      sheet.getRange(rowIndex, khCol_(h, 'Completed_Date') + 1).setValue(getTodayISO_());
+    // v66(F12): staged write — validate before promotion to prevent bad rows reaching production
+    var staged = writeStaged_(
+      'KH_Chores',
+      [row],
+      (function(hh, tid) {
+        return function(rows) {
+          if (!rows || rows.length !== 1) return { ok: false, reason: 'expected 1 row' };
+          var r = rows[0];
+          if (!r[khCol_(hh, 'Task_ID')]) return { ok: false, reason: 'Task_ID empty' };
+          if (r[khCol_(hh, 'Task_ID')] !== tid) return { ok: false, reason: 'Task_ID mismatch: ' + tid };
+          if (r[khCol_(hh, 'Completed')] !== true) return { ok: false, reason: 'Completed not true' };
+          if (!r[khCol_(hh, 'Child')]) return { ok: false, reason: 'Child empty' };
+          return { ok: true, reason: '' };
+        };
+      })(h, taskID),
+      (function(sh, ri, hh, rw) {
+        return function() {
+          sh.getRange(ri, 1, 1, hh.length).setValues([rw]);
+          // v36: Verify write persisted (diagnostic for task-revert bug)
+          var verify = sh.getRange(ri, 1, 1, hh.length).getValues()[0];
+          if (verify[khCol_(hh, 'Completed')] !== true &&
+              String(verify[khCol_(hh, 'Completed')]).toUpperCase() !== 'TRUE') {
+            console.log('KH_VERIFY_FAIL', JSON.stringify({
+              fn: 'khCompleteTask', taskID: rw[khCol_(hh, 'Task_ID')], rowIndex: ri,
+              wrote: true, readBack: verify[khCol_(hh, 'Completed')], timestamp: getNowISO_()
+            }));
+            sh.getRange(ri, khCol_(hh, 'Completed') + 1).setValue(true);
+            sh.getRange(ri, khCol_(hh, 'Completed_Date') + 1).setValue(getTodayISO_());
+          }
+        };
+      })(sheet, rowIndex, h, row)
+    );
+    if (!staged.ok) {
+      return JSON.stringify({ status: 'error', message: 'Write validation failed: ' + staged.reason });
     }
     appendHistory_(uid, taskID, child, task, 0, basePoints, mult, 'completion', today, now);
     updateStreakCache_(child.toLowerCase(), taskID, today);
@@ -1426,7 +1447,30 @@ function khCompleteTaskWithBonus(rowIndex, multiplier, expectedTaskID) {
     }
     row[khCol_(h, 'Completed')] = true;
     row[khCol_(h, 'Completed_Date')] = today;
-    sheet.getRange(rowIndex, 1, 1, h.length).setValues([row]);
+    // v66(F12): staged write — validate before promotion to prevent bad rows reaching production
+    var stagedBonus = writeStaged_(
+      'KH_Chores',
+      [row],
+      (function(hh, tid, vm) {
+        return function(rows) {
+          if (!rows || rows.length !== 1) return { ok: false, reason: 'expected 1 row' };
+          var r = rows[0];
+          if (!r[khCol_(hh, 'Task_ID')]) return { ok: false, reason: 'Task_ID empty' };
+          if (r[khCol_(hh, 'Task_ID')] !== tid) return { ok: false, reason: 'Task_ID mismatch: ' + tid };
+          if (r[khCol_(hh, 'Completed')] !== true) return { ok: false, reason: 'Completed not true' };
+          if (!r[khCol_(hh, 'Child')]) return { ok: false, reason: 'Child empty' };
+          var mult = parseFloat(r[khCol_(hh, 'Bonus_Multiplier')]);
+          if (isNaN(mult) || mult < 1) return { ok: false, reason: 'Bonus_Multiplier invalid: ' + mult };
+          return { ok: true, reason: '' };
+        };
+      })(h, taskID, validMult),
+      (function(sh, ri, hh, rw) {
+        return function() { sh.getRange(ri, 1, 1, hh.length).setValues([rw]); };
+      })(sheet, rowIndex, h, row)
+    );
+    if (!stagedBonus.ok) {
+      return JSON.stringify({ status: 'error', message: 'Write validation failed: ' + stagedBonus.reason });
+    }
     appendHistory_(uid, taskID, child, task, 0, basePoints, validMult, 'completion', today, now);
     updateStreakCache_(child.toLowerCase(), taskID, today);
     if (child.toUpperCase() === 'BOTH') {

--- a/specs/data-recovery-runbook.md
+++ b/specs/data-recovery-runbook.md
@@ -1,0 +1,77 @@
+# Data Recovery Runbook — TBM Production Spreadsheet
+
+**Issue:** #266 (F12)
+**Created:** 2026-04-13
+
+---
+
+## Before Any Repair
+
+1. Export the affected tab as CSV to Drive (timestamped folder).
+2. Log the repair action to ErrorLog: tab name, rows affected, repair method, timestamp.
+3. Take a screenshot or snapshot of the affected range before touching anything.
+
+---
+
+## Per-Table Recovery
+
+### KH_Chores
+**Can rebuild:** Yes
+**Method:** Re-run `seedKHData_()` to restore the task roster. Daily task state (Completed, Completed_Date) is reset to defaults — acceptable if the bad write mutated those columns.
+
+### KH_History
+**Type:** Append-only
+**Method:** Trim bad rows by timestamp. Identify the first bad row by timestamp, delete from that row to end of bad block. Do not delete earlier rows — they are the authoritative completion record.
+
+### KH_Redemptions
+**Type:** Append-only
+**Method:** Same as KH_History. Trim bad rows by timestamp. KH_Allowance balances are derived from KH_History minus KH_Redemptions, so trimming bad redemption rows will restore correct balances.
+
+### KH_Allowance
+**Type:** Derived
+**Method:** Recompute from KH_History minus KH_Redemptions. Run `recalcAllowanceFromHistory_()` if available, or manually sum the delta for each child.
+
+### Close History
+**Type:** Partial rebuild
+**Method:** Re-run `stampCloseMonth()` for the affected month. The function is idempotent-guarded — it checks for existing entries before writing. Clear the bad row first, then re-run.
+
+### Cascade tabs (Month-by-Month, Payoff Schedule, Cascade Proof)
+**Type:** Fully recomputed
+**Method:** Run `refreshCascadeTabs()`. These tabs are 100% derived from Transactions and Debt_Export — no manual data, always safe to regenerate.
+
+### Dashboard_Export
+**Type:** Fully recomputed
+**Method:** Run `getData()` or trigger a full refresh. Derived from all source tabs.
+
+### Debt_Export
+**Type:** Fully recomputed
+**Method:** Re-run `parseDebtExport()` write path. Sourced from Tiller's debt data.
+
+### ErrorLog / PerfLog
+**Type:** Append-only, no business impact
+**Method:** Trim bad rows by timestamp. These logs are diagnostic only — trimming does not affect any computed values.
+
+### Board_Config
+**Type:** Small config table, manually maintained
+**Method:** Restore from the most recent code snapshot or CLAUDE.md reference. This table changes rarely and is small enough to restore by hand.
+
+---
+
+## Staged Write Failure
+
+If `writeStaged_()` blocked a write:
+1. The `_STAGING_<tab>` hidden tab will contain the rejected rows.
+2. Check `ErrorLog` for the validation failure reason.
+3. Inspect the staging tab to understand what was wrong with the data.
+4. Clear the staging tab manually via the GAS editor or `clearStagingTab_(key)` helper once investigation is complete.
+
+---
+
+## Controlled Bad-Write Simulation (Non-Prod)
+
+Once the F09 candidate workbook exists:
+1. Deploy to candidate project.
+2. Call a write function with intentionally malformed data (e.g., empty Task_ID).
+3. Confirm `writeStaged_()` blocks the write and populates the staging tab.
+4. Check ErrorLog in candidate workbook for the validation failure.
+5. Verify production workbook is unaffected.


### PR DESCRIPTION
## Summary
- `writeStaged_()` added to `GASHardening.js` (v8→v9): buffers rows in a hidden `_STAGING_<key>` tab, validates, promotes via writer callback on pass, leaves staging populated for post-mortem on fail
- `khCompleteTask` and `khCompleteTaskWithBonus` migrated to `writeStaged_()` — both validate `Task_ID`, `Completed=true`, and `Child` non-empty before any write reaches `KH_Chores`
- `specs/data-recovery-runbook.md` documents per-table rebuild/trim procedures for all production write targets

## Why
Code rollback ≠ data rollback. A bad deploy can write corrupt rows; rolling back code leaves the data damaged. Staged writes block bad data at write-time. The runbook handles the case where bad data gets through anyway.

## Test plan
- [ ] CI passes (ES5 compliance, version consistency, route integrity)
- [ ] Manual: complete a task in KidsHub — confirm `_STAGING_KH_Chores` is created, populated, and cleared on success
- [ ] Manual: simulate a validation failure by calling `writeStaged_('KH_Chores', [['']], ...)` directly in GAS editor — confirm staging tab stays populated and ErrorLog has an entry
- [ ] Confirm `khCompleteTaskWithBonus` still awards correct multiplier (1.5× or 2×)

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)