### PR TITLE
fix: recover stories stuck in Generating status

### DIFF
--- a/StoryFactory.js
+++ b/StoryFactory.js
@@ -1559,7 +1559,8 @@ function sf_recoverStaleClaims_() {
           or: [
             { property: 'Status', select: { equals: 'Writing' } },
             { property: 'Status', select: { equals: 'Illustrating' } },
-            { property: 'Status', select: { equals: 'Assembling' } }
+            { property: 'Status', select: { equals: 'Assembling' } },
+            { property: 'Status', select: { equals: 'Generating' } }
           ]
         },
         { timestamp: 'last_edited_time', last_edited_time: { before: staleBefore } }
@@ -1568,7 +1569,7 @@ function sf_recoverStaleClaims_() {
     page_size: 10
   });
   if (!result.results || result.results.length === 0) return;
-  var REVERT_MAP = { 'Writing': 'Idea', 'Illustrating': 'Written', 'Assembling': 'Illustrated' };
+  var REVERT_MAP = { 'Writing': 'Idea', 'Illustrating': 'Written', 'Assembling': 'Illustrated', 'Generating': 'Idea' };
   for (var ri = 0; ri < result.results.length; ri++) {
     var page = result.results[ri];
     var stuck = page.properties['Status'] && page.properties['Status'].select


### PR DESCRIPTION
## Summary
Stories set to Generating status were invisible to both the poll and the stale-claim recovery. 3 stories stuck since April 11.

**Root cause:** Generating is a Notion select option but not a pipeline status. sf_recoverStaleClaims_ only handled Writing/Illustrating/Assembling.

**Fix:** Added Generating to the stale claim filter and REVERT_MAP (reverts to Idea for full retry). Reset 3 stuck rows manually in Notion.

Deployed live @575. The next poll cycle will pick up the 3 reset rows.

Closes #312

## Test plan
- [ ] 3 reset rows (Game Night, Sonic, Roller Coaster) move from Idea → Writing → Ready
- [ ] No new rows get stuck in Generating

🤖 Generated with [Claude Code](https://claude.com/claude-code)