### PR TITLE
feat(#295): education alert orchestrator + daily trigger installer

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,6 +1,6 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// Code.gs v86 — Apps Script Router (TBM Consolidated)
+// Code.gs v87 — Apps Script Router (TBM Consolidated)
 // WRITES TO: (routes only — delegates to DataEngine, KidsHub, etc.)
 // READS FROM: (routes only — delegates to DataEngine, KidsHub, etc.)
 // ════════════════════════════════════════════════════════════════════
@@ -1929,4 +1929,4 @@ function getOpsHealthSafe() {
   });
 }
 
-// END OF FILE — Code.gs v86
+// END OF FILE — Code.gs v87

--- a/Code.js
+++ b/Code.js
@@ -19,7 +19,7 @@ function isLessonRunsEnabled_() {
   } catch (e) { return false; }
 }
 
-function getCodeVersion() { return 86; }
+function getCodeVersion() { return 87; }
 
 // v37 FIX 5: ES5-safe left-pad helper — replaces String.padStart()
 function leftPad2_(n) {


### PR DESCRIPTION
## Summary
- `runDailyEducationAlerts()` — orchestrator that runs all three checks: streak-break (both kids), pending review age, accuracy drop (both kids). Each in isolated try/catch so one failure doesn't block the rest.
- `installDailyEducationAlertTrigger_()` — installs a daily 7pm GAS time trigger. Run once from the GAS editor to activate.
- Code.js allowlist updated so all three new entry points are callable.

## Note
The three alert functions (`checkStreakBroken_`, `checkPendingReviewAge_`, `checkAccuracyDrop_`) were already implemented in EducationAlerts.js v1 but had no entry point or trigger. This PR wires them up.

## Activation
After deploy, run `installDailyEducationAlertTrigger_()` once in the GAS editor to start the daily 7pm trigger.

## Test plan
- [ ] Run `runDailyEducationAlerts()` manually in GAS editor — no errors, relevant Pushover alerts fire if conditions are met
- [ ] Run `installDailyEducationAlertTrigger_()` — trigger appears in GAS trigger list at 7pm daily

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)