### PR TITLE
fix: homework submissions never reached server — data shape mismatch + silent push failures (#313)

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -20,6 +20,9 @@ package.json
 package-lock.json
 tests/**
 playwright-report/**
+test-results/**
+test-results-codex/**
+test-results-codex-target/**
 ops/**
 specs/**
 .gitignore

--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="homework-module">
-<meta name="tbm-version" content="v11">
+<meta name="tbm-version" content="v12">
 <title>Wolfkid Training Module</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -2001,7 +2001,12 @@ function loadCurriculumContent() {
       }
       if (response && response.content) {
         var c = response.content;
-        if (c.module && c.module.questions && c.module.questions.length > 0) {
+        var hasModuleQuestions = c.module && (
+          (c.module.math && c.module.math.questions && c.module.math.questions.length > 0) ||
+          (c.module.science && c.module.science.questions && c.module.science.questions.length > 0) ||
+          (c.module.questions && c.module.questions.length > 0)
+        );
+        if (hasModuleQuestions) {
           MODULE = c.module;
           init();
         } else if (c.review_quiz && c.review_quiz.length > 0) {
@@ -2011,6 +2016,7 @@ function loadCurriculumContent() {
           _usingFallback = true;
           MODULE = FALLBACK_MODULE;
           init();
+          console.warn('Curriculum loaded but no module questions found for today. Day type may be non-homework (cold_passage, writing, etc). Keys: ' + Object.keys(c).join(', '));
         }
       } else {
         _usingFallback = true;

--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="homework-module">
-<meta name="tbm-version" content="v12">
+<meta name="tbm-version" content="v13">
 <title>Wolfkid Training Module</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -521,9 +521,11 @@ main {
     <div id="comp-subtitle" style="font-size:14px;color:#94A3B8;line-height:1.7;margin-bottom:16px;"></div>
     <div id="comp-rings" style="font-size:32px;font-weight:900;color:#F59E0B;font-family:'Orbitron',sans-serif;margin-bottom:8px;"></div>
     <div style="font-size:11px;color:#64748B;margin-bottom:16px;">Open-ended answers pending parent review</div>
-    <div id="comp-feedback" style="background:rgba(59,130,246,0.08);border:1px solid rgba(59,130,246,0.3);border-radius:10px;padding:14px;font-size:13px;color:#94A3B8;line-height:1.6;margin-bottom:16px;text-align:left;"></div>
+    <div id="comp-feedback" style="background:rgba(59,130,246,0.08);border:1px solid rgba(59,130,246,0.3);border-radius:10px;padding:14px;font-size:13px;color:#94A3B8;line-height:1.6;margin-bottom:12px;text-align:left;"></div>
+    <div id="comp-save-status" style="display:none;margin-bottom:12px;padding:10px 12px;border-radius:10px;font-size:12px;line-height:1.6;text-align:left;"></div>
+    <button id="comp-retry-btn" style="display:none;margin:0 auto 12px;padding:10px 24px;background:#1E293B;border:1px solid #475569;border-radius:10px;color:#E2E8F0;font-family:Nunito,sans-serif;font-size:13px;font-weight:700;cursor:pointer;" onclick="retryHomeworkSubmit_()">RETRY SAVE</button>
     <button style="background:#3B82F6;border:none;border-radius:10px;padding:12px 32px;color:#fff;font-family:'Orbitron',sans-serif;font-size:13px;font-weight:700;cursor:pointer;letter-spacing:1px;" onclick="closeCompletion()">VIEW RESULTS</button>
-    <button style="display:block;margin:12px auto 0;padding:10px 24px;background:transparent;border:1px solid #334155;border-radius:10px;color:#94A3B8;font-family:Nunito,sans-serif;font-size:13px;font-weight:600;cursor:pointer;" onclick="window.location.href='/daily-missions'">Back to Missions</button>
+    <button style="display:block;margin:12px auto 0;padding:10px 24px;background:transparent;border:1px solid #334155;border-radius:10px;color:#94A3B8;font-family:Nunito,sans-serif;font-size:13px;font-weight:600;cursor:pointer;" onclick="goBackToMissions_()">Back to Missions</button>
   </div>
 </div>
 
@@ -1230,6 +1232,9 @@ var sessionStartTime = null;
 var timerInterval = null;
 var moduleStarted = false;
 var completionLogged = false;
+var completionSubmitState = "idle";
+var completionSubmitError = "";
+var _homeworkDraftTimer = null;
 // #170/#171 state
 var missedQuestions = [];
 var _dayOfWeek = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'][new Date().getDay()];
@@ -1324,6 +1329,262 @@ function updateProgress() {
   }
 }
 
+function getHomeworkDraftKey_() {
+  return 'tbm:' + MODULE_NAME + ':' + SANDBOX_CHILD + ':draft';
+}
+
+function getHomeworkDraftSignature_() {
+  var dateKey = MODULE && MODULE.date ? String(MODULE.date) : '';
+  return [dateKey, scienceQs.length, mathQs.length].join('|');
+}
+
+function canUseHomeworkDraftStorage_() {
+  try { return typeof localStorage !== 'undefined'; }
+  catch (e) { return false; }
+}
+
+function saveHomeworkDraft_() {
+  if (!canUseHomeworkDraftStorage_()) return;
+  if (completionSubmitState === 'submitted' && getTotalAnswered() === allQs.length) {
+    clearHomeworkDraft_();
+    return;
+  }
+  var hasState = Object.keys(answers).length > 0 || moduleStarted || missedQuestions.length > 0;
+  if (!hasState) {
+    clearHomeworkDraft_();
+    return;
+  }
+  try {
+    localStorage.setItem(getHomeworkDraftKey_(), JSON.stringify({
+      version: 1,
+      moduleSignature: getHomeworkDraftSignature_(),
+      savedAt: new Date().toISOString(),
+      answers: answers,
+      missedQuestions: missedQuestions,
+      currentSection: currentSection,
+      moduleStarted: moduleStarted,
+      sessionStartTime: sessionStartTime,
+      completionSubmitState: completionSubmitState,
+      completionSubmitError: completionSubmitError
+    }));
+  } catch (e) {
+    console.warn('Homework draft save skipped:', e && e.message ? e.message : e);
+  }
+}
+
+function restoreHomeworkDraft_() {
+  if (!canUseHomeworkDraftStorage_()) return;
+  try {
+    var raw = localStorage.getItem(getHomeworkDraftKey_());
+    if (!raw) return;
+    var draft = JSON.parse(raw);
+    if (!draft || draft.moduleSignature !== getHomeworkDraftSignature_()) return;
+    answers = draft.answers || {};
+    missedQuestions = draft.missedQuestions || [];
+    currentSection = draft.currentSection || 'overview';
+    moduleStarted = !!draft.moduleStarted || Object.keys(answers).length > 0;
+    if (moduleStarted) {
+      sessionStartTime = typeof draft.sessionStartTime === 'number' ? draft.sessionStartTime : Date.now();
+      var overlay = document.getElementById('plan-overlay');
+      if (overlay) overlay.style.display = 'none';
+    }
+    completionSubmitState = draft.completionSubmitState === 'submitted' ? 'submitted' : 'idle';
+    completionSubmitError = completionSubmitState === 'submitted' ? '' : String(draft.completionSubmitError || '');
+    console.log('Homework draft restored from ' + String(draft.savedAt || 'unknown time'));
+  } catch (e) {
+    console.warn('Homework draft restore skipped:', e && e.message ? e.message : e);
+  }
+}
+
+function clearHomeworkDraft_() {
+  if (!canUseHomeworkDraftStorage_()) return;
+  try { localStorage.removeItem(getHomeworkDraftKey_()); }
+  catch (e) {}
+}
+
+function initHomeworkDraftAutoSave_() {
+  if (_homeworkDraftTimer) return;
+  _homeworkDraftTimer = setInterval(saveHomeworkDraft_, 15000);
+  window.addEventListener('beforeunload', saveHomeworkDraft_);
+  document.addEventListener('visibilitychange', function() {
+    if (document.visibilityState === 'hidden') saveHomeworkDraft_();
+  });
+}
+
+function buildHomeworkCompletionPayload_() {
+  var totalMCCorrect = getTotalMCCorrect();
+  var totalMC = getTotalMC();
+  var ringsEarned = totalMC > 0 ? Math.round(8 * (totalMCCorrect / totalMC)) : 0;
+  var openEndedBySubject = { science: [], math: [] };
+  var i, q, key, a;
+  for (i = 0; i < allQs.length; i++) {
+    q = allQs[i];
+    if (!isMCQuestion(q)) {
+      key = "q" + q.id;
+      a = answers[key];
+      if (a && a.text && a.text.replace(/^\s+|\s+$/g, "").length > 0) {
+        var subj = q.id <= 6 ? "science" : "math";
+        openEndedBySubject[subj].push({
+          id: q.id,
+          prompt: q.question || "",
+          response: a.text
+        });
+      }
+    }
+  }
+
+  var allOpenEnded = openEndedBySubject.science.concat(openEndedBySubject.math);
+  var responseText = "";
+  for (i = 0; i < allOpenEnded.length; i++) {
+    if (i > 0) responseText += "\n---\n";
+    responseText += "Q: " + allOpenEnded[i].prompt + "\nA: " + allOpenEnded[i].response;
+  }
+
+  return {
+    totalMCCorrect: totalMCCorrect,
+    totalMC: totalMC,
+    ringsEarned: ringsEarned,
+    responseText: responseText,
+    openEndedCount: allOpenEnded.length,
+    moduleTitle: 'Homework: ' + (MODULE.science ? MODULE.science.title : 'Module'),
+    request: {
+      child: SANDBOX_CHILD,
+      module: 'homework',
+      subject: MODULE.science ? 'Science & Math' : 'Math',
+      score: totalMCCorrect,
+      responseText: responseText,
+      prompt: allOpenEnded.length > 0 ? allOpenEnded.length + ' open-ended question(s)' : '',
+      rings: ringsEarned
+    }
+  };
+}
+
+function getCompletionStatusMarkup_() {
+  if (completionSubmitState === 'submitted') {
+    return {
+      message: 'Saved to the parent review queue.',
+      style: 'background:rgba(34,197,94,0.08);border:1px solid rgba(34,197,94,0.25);color:#86EFAC;',
+      showRetry: false
+    };
+  }
+  if (completionSubmitState === 'submitting') {
+    return {
+      message: 'Saving homework now. Keep this tab open for a moment.',
+      style: 'background:rgba(59,130,246,0.10);border:1px solid rgba(59,130,246,0.30);color:#93C5FD;',
+      showRetry: false
+    };
+  }
+  if (completionSubmitState === 'failed') {
+    return {
+      message: 'Save did not finish' + (completionSubmitError ? ': ' + escapeHtml(completionSubmitError) : '.') + ' A draft is still stored on this device.',
+      style: 'background:rgba(249,115,22,0.10);border:1px solid rgba(249,115,22,0.30);color:#FDBA74;',
+      showRetry: true
+    };
+  }
+  if (_usingFallback) {
+    return {
+      message: 'Practice mode only. This session is not being sent to the homework queue.',
+      style: 'background:rgba(148,163,184,0.10);border:1px solid rgba(148,163,184,0.25);color:#CBD5E1;',
+      showRetry: false
+    };
+  }
+  return {
+    message: 'Preparing final save...',
+    style: 'background:rgba(148,163,184,0.10);border:1px solid rgba(148,163,184,0.25);color:#CBD5E1;',
+    showRetry: false
+  };
+}
+
+function updateCompletionSaveStatusUi_() {
+  var statusEl = document.getElementById('comp-save-status');
+  var retryBtn = document.getElementById('comp-retry-btn');
+  var status = getCompletionStatusMarkup_();
+  if (statusEl) {
+    statusEl.style.cssText = 'display:block;margin-bottom:12px;padding:10px 12px;border-radius:10px;font-size:12px;line-height:1.6;text-align:left;' + status.style;
+    statusEl.innerHTML = status.message;
+  }
+  if (retryBtn) retryBtn.style.display = status.showRetry ? 'block' : 'none';
+  if (currentSection === 'results') renderResults();
+}
+
+function submitHomeworkCompletion_() {
+  if (!moduleStarted || getTotalAnswered() !== allQs.length) return;
+  if (completionSubmitState === 'submitted' || completionSubmitState === 'submitting') return;
+  if (TBM_TEST_MODE) {
+    completionSubmitState = 'submitted';
+    completionSubmitError = '';
+    updateCompletionSaveStatusUi_();
+    clearHomeworkDraft_();
+    return;
+  }
+  if (_usingFallback) {
+    completionSubmitState = 'idle';
+    completionSubmitError = '';
+    updateCompletionSaveStatusUi_();
+    saveHomeworkDraft_();
+    return;
+  }
+
+  var payload = buildHomeworkCompletionPayload_();
+  completionSubmitState = 'submitting';
+  completionSubmitError = '';
+  updateCompletionSaveStatusUi_();
+  saveHomeworkDraft_();
+
+  google.script.run
+    .withSuccessHandler(function(result) {
+      if (!result || result.status !== 'ok') {
+        completionSubmitState = 'failed';
+        completionSubmitError = result && result.status ? 'server returned ' + result.status : 'server returned an empty response';
+        updateCompletionSaveStatusUi_();
+        saveHomeworkDraft_();
+        return;
+      }
+
+      completionSubmitState = 'submitted';
+      completionSubmitError = '';
+      completionLogged = true;
+      clearHomeworkDraft_();
+      updateCompletionSaveStatusUi_();
+      console.log('Submitted: ' + result.status);
+
+      google.script.run
+        .withSuccessHandler(function() { console.log('Homework completion logged'); })
+        .withFailureHandler(function(err) { console.error('Log failed:', err && err.message ? err.message : err); })
+        .logHomeworkCompletionSafe({
+          child: SANDBOX_CHILD,
+          title: payload.moduleTitle,
+          subject: 'Math/Science',
+          score: payload.totalMCCorrect,
+          total: payload.totalMC
+        });
+
+      if (payload.openEndedCount > 0) {
+        console.log('Rings deferred — ' + payload.openEndedCount + ' open-ended question(s) pending parent review');
+      }
+    })
+    .withFailureHandler(function(err) {
+      completionSubmitState = 'failed';
+      completionSubmitError = err && err.message ? err.message : 'unknown error';
+      updateCompletionSaveStatusUi_();
+      saveHomeworkDraft_();
+      console.error('Submit failed:', err);
+    })
+    .submitHomeworkSafe(payload.request);
+}
+
+function retryHomeworkSubmit_() {
+  if (completionSubmitState === 'submitting') return;
+  completionSubmitState = 'idle';
+  completionSubmitError = '';
+  submitHomeworkCompletion_();
+}
+
+function goBackToMissions_() {
+  saveHomeworkDraft_();
+  window.location.href = '/daily-missions';
+}
+
 // ─── STAR FIELD ───
 function buildStarField() {
   var container = document.getElementById("starfield");
@@ -1368,9 +1629,15 @@ function showCompletion() {
   var totalMC = getTotalMC();
   var openEnded = allQs.length - totalMC;
   var pct = totalMC > 0 ? Math.round((mcCorrect / totalMC) * 100) : 0;
+  var existingEs = document.getElementById('es-completion-block');
+  if (existingEs && existingEs.parentNode) existingEs.parentNode.removeChild(existingEs);
+  var existingJournal = document.getElementById('es-error-journal-block');
+  if (existingJournal && existingJournal.parentNode) existingJournal.parentNode.removeChild(existingJournal);
+  var existingReflection = document.getElementById('es-reflection-block');
+  if (existingReflection && existingReflection.parentNode) existingReflection.parentNode.removeChild(existingReflection);
 
   var subtitle = document.getElementById("comp-subtitle");
-  subtitle.textContent = "Auto-graded: " + mcCorrect + "/" + totalMC + " multiple choice correct (" + pct + "%). " + openEnded + " open-ended answers submitted for parent review.";
+  subtitle.textContent = "Auto-graded: " + mcCorrect + "/" + totalMC + " multiple choice correct (" + pct + "%). " + openEnded + " open-ended answers ready for parent review.";
 
   var ringsEl = document.getElementById("comp-rings");
   ringsEl.innerHTML = "&#x2B55; Up to 16 RINGS";
@@ -1444,11 +1711,15 @@ function showCompletion() {
       ExecSkills.showFridayReflection('es-reflection-block');
     }, 500);
   }
+
+  submitHomeworkCompletion_();
+  updateCompletionSaveStatusUi_();
 }
 
 function closeCompletion() {
   var overlay = document.getElementById("completion-overlay");
   overlay.style.display = "none";
+  saveHomeworkDraft_();
   switchTab("results");
 }
 
@@ -1511,6 +1782,7 @@ function switchTab(tab) {
   if (tab === "science") renderScience();
   if (tab === "math") renderMath();
   if (tab === "results") renderResults();
+  saveHomeworkDraft_();
 }
 
 // ─── QUESTION INTERACTION ───
@@ -1519,6 +1791,7 @@ function selectOption(qId, optIdx) {
   if (answers[key] && answers[key].submitted) return;
   if (!answers[key]) answers[key] = {};
   answers[key].selected = optIdx;
+  saveHomeworkDraft_();
 
   // Re-render the question options
   var subject = qId <= 6 ? "science" : "math";
@@ -1533,6 +1806,7 @@ function updateTextAnswer(qId) {
   if (!textarea) return;
   if (!answers[key]) answers[key] = {};
   answers[key].text = textarea.value;
+  saveHomeworkDraft_();
 }
 
 function submitAnswer(qId) {
@@ -1590,6 +1864,7 @@ function submitAnswer(qId) {
   checkBrainBreak();
 
   updateProgress();
+  saveHomeworkDraft_();
 
   // Re-render
   var subject = qId <= 6 ? "science" : "math";
@@ -1696,6 +1971,20 @@ function buildQuestionHtml(q, index, subjectColor) {
   return html;
 }
 
+function syncDraftInputs_(sectionId) {
+  var section = document.getElementById(sectionId);
+  if (!section) return;
+  var textareas = section.querySelectorAll('textarea[id^="textarea-"]');
+  for (var i = 0; i < textareas.length; i++) {
+    var ta = textareas[i];
+    var qId = String(ta.id || '').replace('textarea-', '');
+    var answer = answers['q' + qId];
+    if (answer && typeof answer.text === 'string' && ta.value !== answer.text) {
+      ta.value = answer.text;
+    }
+  }
+}
+
 // ─── RENDER SECTIONS ───
 function renderOverview() {
   var html = '';
@@ -1762,6 +2051,7 @@ function renderScience() {
   }
 
   document.getElementById("section-science").innerHTML = html;
+  syncDraftInputs_('section-science');
 }
 
 function renderMath() {
@@ -1779,6 +2069,7 @@ function renderMath() {
   }
 
   document.getElementById("section-math").innerHTML = html;
+  syncDraftInputs_('section-math');
 }
 
 function renderResults() {
@@ -1797,6 +2088,8 @@ function renderResults() {
     html += '<div style="font-size:13px;color:' + C.textMuted + ';line-height:1.6;">';
     html += 'Auto-graded: ' + totalMCCorrect + '/' + totalMC + ' multiple choice correct.<br>Open-ended answers submitted for parent review.';
     html += '</div></div>';
+    var statusMarkup = getCompletionStatusMarkup_();
+    html += '<div style="' + statusMarkup.style + 'border-radius:10px;padding:12px 14px;margin-bottom:16px;font-size:13px;line-height:1.6;">' + statusMarkup.message + '</div>';
 
     // Breakdown
     html += '<div style="background:' + C.card + ';border:1px solid ' + C.border + ';border-radius:12px;padding:16px;">';
@@ -1843,83 +2136,6 @@ function renderResults() {
     html += '<div style="margin-top:12px;padding:10px 14px;background:' + C.orange + '10;border-radius:8px;font-size:13px;color:' + C.textMuted + ';line-height:1.6;">';
     html += '\u23F3 <strong style="color:' + C.orange + ';">Pending parent review</strong> for ' + openEndedCount + ' open-ended questions. Rings will be awarded after review.';
     html += '</div></div>';
-
-    // Ring award + completion log (once only)
-    if (!completionLogged) {
-      completionLogged = true;
-      var ringsEarned = totalMC > 0 ? Math.round(8 * (totalMCCorrect / totalMC)) : 0;
-
-      // Collect open-ended responses grouped by subject
-      var openEndedBySubject = { science: [], math: [] };
-      var i, q, key, a;
-      for (i = 0; i < allQs.length; i++) {
-        q = allQs[i];
-        if (!isMCQuestion(q)) {
-          key = "q" + q.id;
-          a = answers[key];
-          if (a && a.text && a.text.replace(/^\s+|\s+$/g, "").length > 0) {
-            var subj = (q.id <= 6) ? "science" : "math";
-            openEndedBySubject[subj].push({
-              id: q.id,
-              prompt: q.question || "",
-              response: a.text
-            });
-          }
-        }
-      }
-
-      // Build combined responseText for server (all open-ended answers)
-      var allOpenEnded = openEndedBySubject.science.concat(openEndedBySubject.math);
-      var responseText = "";
-      for (i = 0; i < allOpenEnded.length; i++) {
-        if (i > 0) responseText += "\n---\n";
-        responseText += "Q: " + allOpenEnded[i].prompt + "\nA: " + allOpenEnded[i].response;
-      }
-
-      if (TBM_TEST_MODE) {
-        console.log('[TEST MODE] awardRingsSafe skipped, rings=' + ringsEarned);
-        console.log('[TEST MODE] submitHomeworkSafe skipped, responseText length=' + responseText.length);
-        console.log('[TEST MODE] logHomeworkCompletionSafe skipped');
-      } else if (_usingFallback) {
-        console.log('Practice mode — rings not awarded');
-      } else {
-        // Submit with collected open-ended responses
-        google.script.run
-          .withSuccessHandler(function(result) {
-            console.log('Submitted: ' + (result && result.status ? result.status : 'unknown'));
-          })
-          .withFailureHandler(function(err) { console.error('Submit failed:', err); })
-          .submitHomeworkSafe({
-            child: SANDBOX_CHILD,
-            module: 'homework',
-            subject: MODULE.science ? 'Science & Math' : 'Math',
-            score: totalMCCorrect,
-            responseText: responseText,
-            prompt: allOpenEnded.length > 0 ? allOpenEnded.length + ' open-ended question(s)' : '',
-            rings: ringsEarned
-          });
-
-        // Ring awards handled server-side by submitHomework_() auto-award path.
-        // When auto-graded (no open-ended): server awards rings immediately.
-        // When pending_review (has open-ended): server defers to approveHomework_().
-        // Client-side awardRingsSafe() removed to prevent double-award (#160).
-        if (allOpenEnded.length > 0) {
-          console.log('Rings deferred — ' + allOpenEnded.length + ' open-ended question(s) pending parent review');
-        }
-
-        var moduleTitle = 'Homework: ' + (MODULE.science ? MODULE.science.title : 'Module');
-        google.script.run
-          .withSuccessHandler(function() { console.log('Homework completion logged'); })
-          .withFailureHandler(function(err) { console.error('Log failed:', err.message); })
-          .logHomeworkCompletionSafe({
-            child: SANDBOX_CHILD,
-            title: moduleTitle,
-            subject: 'Math/Science',
-            score: totalMCCorrect,
-            total: totalMC
-          });
-      }
-    }
 
   } else {
     // Not done yet
@@ -2048,13 +2264,16 @@ function init() {
   mathQs = MODULE.math ? MODULE.math.questions || [] : [];
   allQs = scienceQs.concat(mathQs);
   validateQuestionTypes(allQs);
+  restoreHomeworkDraft_();
   buildStarField();
   renderOverview();
   renderScience();
   renderMath();
   renderResults();
+  switchTab(currentSection || "overview");
   updateProgress();
   loadAudioForPhase('mc');
+  initHomeworkDraftAutoSave_();
 
   // #171 — Plan Your Attack via ExecSkills
   var planQs = [];
@@ -2070,8 +2289,12 @@ function init() {
       document.getElementById('plan-overlay').style.display = 'none';
       moduleStarted = true;
       sessionStartTime = Date.now(); // ExecSkills owns the floating timer; set for elapsed-time display at completion
+      saveHomeworkDraft_();
     }
   });
+  if (moduleStarted) {
+    document.getElementById('plan-overlay').style.display = 'none';
+  }
 }
 
 loadCurriculumContent();

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v66 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v67 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 🧹📅 KH_LessonRuns, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 66; }
+function getKidsHubVersion() { return 67; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -4423,7 +4423,7 @@ function submitHomework_(data) {
         : 'Auto-graded — complete';
       sendPush_(childDisplay + ' submitted ' + (data.subject || 'homework'), pushMsg, 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL);
     }
-  } catch(e) { /* non-blocking */ }
+  } catch(e) { if (typeof logError_ === 'function') logError_('submitHomework_:push', e); }
 
   // Phase 4: Gemini review (outside lock, can take 5-30s)
   if (status === 'pending_review' && data.responseText && String(data.responseText).length > 20) {
@@ -4542,7 +4542,7 @@ function approveHomework_(rowIndex, action, notes) {
         var childDisplay = child.charAt(0).toUpperCase() + child.slice(1);
         sendPush_(childDisplay + ': Writing approved! +' + rings + ' rings', String(notes || 'Great work!'), 'BOTH', PUSHOVER_PRIORITY.CHORE_APPROVAL);
       }
-    } catch(e) { /* non-blocking */ }
+    } catch(e) { if (typeof logError_ === 'function') logError_('approveHomework_:push', e); }
   }
 
   return JSON.stringify({ status: 'ok', action: action });
@@ -5135,5 +5135,5 @@ function loadComicDraftByDateSafe(child, dateKey) {
   });
 }
 
-// END OF FILE — KidsHub.gs v66
+// END OF FILE — KidsHub.gs v67
 // ════════════════════════════════════════════════════════════════════

--- a/Tbmsmoketest.js
+++ b/Tbmsmoketest.js
@@ -1,5 +1,5 @@
 // ════════════════════════════════════════════════════════════════════
-// tbmSmokeTest.gs v14 — Pre-Deploy Structural Validation
+// tbmSmokeTest.gs v15 — Pre-Deploy Structural + Behavioral Validation
 // WRITES TO: (none — read-only checks)
 // READS FROM: All sheets (for schema/wiring validation)
 // ════════════════════════════════════════════════════════════════════
@@ -32,12 +32,11 @@
 //   - Workflows work end to end (that's Q7 persistence tests / Playwright)
 //   - Data is correct (that's QA walkthroughs)
 //   - UI renders properly (that's manual QA / screenshots)
-//   - Save paths persist data (that's education persistence tests)
 //
 // A PASS here means "safe to deploy" not "system works perfectly."
 // ════════════════════════════════════════════════════════════════════
 
-function getSmokeTestVersion() { return 14; }
+function getSmokeTestVersion() { return 15; }
 
 var CANONICAL_SAFE_FUNCTIONS = [
   // KidsHub core
@@ -125,6 +124,9 @@ function tbmSmokeTest() {
 
   // ── Category 10: QA Route Parity ────────────────────────────────
   results.categories['10_qa_routes'] = checkQARouteParity_();
+
+  // ── Category 11: Behavioral — Education Round-Trip ─────────────
+  results.categories['11_behavioral'] = checkEducationBehavioral_();
 
   // ── Categories 6-8: Source-level (NOT runtime verifiable) ───────
   results.categories['6_concurrency'] = {
@@ -787,4 +789,171 @@ function checkQARouteParity_() {
 }
 
 
-// END OF FILE — tbmSmokeTest.gs v14
+// ════════════════════════════════════════════════════════════════════
+// CATEGORY 11: BEHAVIORAL — Education Submission Round-Trip (v15)
+// Verifies that the education pipeline actually persists data, not just
+// that functions exist. Catches shape mismatches, fallback mode, silent
+// drops, and missing curriculum. This is what every structural check missed.
+// ════════════════════════════════════════════════════════════════════
+
+function checkEducationBehavioral_() {
+  var result = {
+    status: 'PASS',
+    description: 'Education submissions persist end-to-end and curriculum loads correctly',
+    details: [],
+    method: 'runtime',
+    checks: {}
+  };
+
+  var failures = [];
+  var warnings = [];
+
+  // ── Check 1: Curriculum loads for Buggsy ──
+  try {
+    var dayNames = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+    var todayName = dayNames[new Date().getDay()];
+    var isModuleDay = ['Monday','Wednesday','Friday'].indexOf(todayName) !== -1;
+    var isWeekday = ['Monday','Tuesday','Wednesday','Thursday','Friday'].indexOf(todayName) !== -1;
+
+    var content = null;
+    if (typeof getTodayContent_ === 'function') {
+      content = getTodayContent_('buggsy');
+    }
+
+    if (!content && isWeekday) {
+      failures.push('Curriculum returned null for Buggsy on ' + todayName + '. Curriculum may not be seeded for this week.');
+      result.checks.curriculum_buggsy = 'FAIL — null on weekday';
+    } else if (content && content.content) {
+      var c = content.content;
+      var hasModule = c.module && (
+        (c.module.math && c.module.math.questions && c.module.math.questions.length > 0) ||
+        (c.module.science && c.module.science.questions && c.module.science.questions.length > 0)
+      );
+      if (isModuleDay && !hasModule) {
+        failures.push('Curriculum loaded for Buggsy but no module.math/science.questions on ' + todayName + ' (a module day). Shape mismatch or missing content.');
+        result.checks.curriculum_buggsy = 'FAIL — module day but no questions';
+      } else if (!isModuleDay && !hasModule) {
+        result.checks.curriculum_buggsy = 'OK — non-module day (' + todayName + '), no module questions expected. Keys: ' + Object.keys(c).join(', ');
+      } else {
+        var mathCount = (c.module.math && c.module.math.questions) ? c.module.math.questions.length : 0;
+        var sciCount = (c.module.science && c.module.science.questions) ? c.module.science.questions.length : 0;
+        result.checks.curriculum_buggsy = 'OK — ' + mathCount + ' math, ' + sciCount + ' science questions';
+      }
+    } else if (!isWeekday) {
+      result.checks.curriculum_buggsy = 'OK — weekend, no curriculum expected';
+    } else {
+      result.checks.curriculum_buggsy = 'WARN — content returned but content.content is null';
+      warnings.push('Curriculum returned but content.content is null for Buggsy on ' + todayName);
+    }
+  } catch(e) {
+    failures.push('Curriculum check threw: ' + (e.message || String(e)));
+    result.checks.curriculum_buggsy = 'FAIL — exception: ' + (e.message || String(e));
+  }
+
+  // ── Check 2: submitHomework_ round-trip ──
+  // Write a smoke-test row, verify it persists, then delete it.
+  var smokeModule = '_smoke_test_' + Date.now();
+  try {
+    if (typeof submitHomework_ !== 'function') {
+      failures.push('submitHomework_ function not found');
+      result.checks.submit_roundtrip = 'FAIL — function missing';
+    } else {
+      var submitResult = submitHomework_({
+        child: 'buggsy',
+        module: smokeModule,
+        subject: 'SmokeTest',
+        score: 1,
+        responseText: '',
+        prompt: '',
+        rings: 0
+      });
+      var parsed = typeof submitResult === 'string' ? JSON.parse(submitResult) : submitResult;
+
+      if (!parsed || parsed.status !== 'ok') {
+        failures.push('submitHomework_ returned non-ok status: ' + JSON.stringify(parsed));
+        result.checks.submit_roundtrip = 'FAIL — status: ' + (parsed ? parsed.status : 'null');
+      } else {
+        // Verify the row landed in KH_Education
+        Utilities.sleep(500); // brief settle time for sheet write
+        var eduSheet = ensureKHEducationTab_();
+        var lastRow = eduSheet.getLastRow();
+        var found = false;
+        // Scan last 5 rows (the smoke row should be at the bottom)
+        var scanStart = Math.max(2, lastRow - 4);
+        var range = eduSheet.getRange(scanStart, 1, lastRow - scanStart + 1, 3).getValues();
+        for (var r = range.length - 1; r >= 0; r--) {
+          if (String(range[r][2]) === smokeModule) {
+            found = true;
+            // Clean up: delete the smoke row
+            eduSheet.deleteRow(scanStart + r);
+            break;
+          }
+        }
+
+        if (found) {
+          result.checks.submit_roundtrip = 'OK — row persisted and cleaned up';
+        } else {
+          failures.push('submitHomework_ returned ok but no row found in KH_Education with module=' + smokeModule);
+          result.checks.submit_roundtrip = 'FAIL — row not found after successful submit';
+        }
+      }
+    }
+  } catch(e) {
+    failures.push('Submit round-trip threw: ' + (e.message || String(e)));
+    result.checks.submit_roundtrip = 'FAIL — exception: ' + (e.message || String(e));
+    // Best-effort cleanup
+    try {
+      var cleanSheet = ensureKHEducationTab_();
+      var cleanLast = cleanSheet.getLastRow();
+      if (cleanLast >= 2) {
+        var cleanRange = cleanSheet.getRange(Math.max(2, cleanLast - 2), 1, Math.min(3, cleanLast - 1), 3).getValues();
+        for (var ci = cleanRange.length - 1; ci >= 0; ci--) {
+          if (String(cleanRange[ci][2]) === smokeModule) {
+            cleanSheet.deleteRow(Math.max(2, cleanLast - 2) + ci);
+            break;
+          }
+        }
+      }
+    } catch(ce) { /* cleanup failed, not critical */ }
+  }
+
+  // ── Check 3: Pushover config exists ──
+  try {
+    if (typeof getPushoverConfig_ === 'function') {
+      var pushConfig = getPushoverConfig_();
+      if (!pushConfig.token) {
+        failures.push('PUSHOVER_TOKEN not set in Script Properties');
+        result.checks.pushover_config = 'FAIL — no token';
+      } else if (!pushConfig.userLT || !pushConfig.userJT) {
+        var missing = [];
+        if (!pushConfig.userLT) missing.push('PUSHOVER_USER_LT');
+        if (!pushConfig.userJT) missing.push('PUSHOVER_USER_JT');
+        warnings.push('Pushover user keys missing: ' + missing.join(', '));
+        result.checks.pushover_config = 'WARN — missing: ' + missing.join(', ');
+      } else {
+        result.checks.pushover_config = 'OK — token + both user keys present';
+      }
+    } else {
+      warnings.push('getPushoverConfig_ not found — AlertEngine may not be loaded');
+      result.checks.pushover_config = 'WARN — function not found';
+    }
+  } catch(e) {
+    warnings.push('Pushover config check threw: ' + (e.message || String(e)));
+    result.checks.pushover_config = 'WARN — exception: ' + (e.message || String(e));
+  }
+
+  // ── Assemble result ──
+  if (failures.length > 0) {
+    result.status = 'FAIL';
+    result.details = failures.concat(warnings);
+  } else if (warnings.length > 0) {
+    result.status = 'WARN';
+    result.details = warnings;
+  } else {
+    result.details = ['All behavioral checks passed'];
+  }
+
+  return result;
+}
+
+// END OF FILE — tbmSmokeTest.gs v15

--- a/Tbmsmoketest.js
+++ b/Tbmsmoketest.js
@@ -1,6 +1,6 @@
 // ════════════════════════════════════════════════════════════════════
 // tbmSmokeTest.gs v15 — Pre-Deploy Structural + Behavioral Validation
-// WRITES TO: (none — read-only checks)
+// WRITES TO: KH_Education (smoke row — written and immediately deleted)
 // READS FROM: All sheets (for schema/wiring validation)
 // ════════════════════════════════════════════════════════════════════
 // Version history tracked in Notion deploy page. Do not add version comments here.
@@ -850,56 +850,44 @@ function checkEducationBehavioral_() {
     result.checks.curriculum_buggsy = 'FAIL — exception: ' + (e.message || String(e));
   }
 
-  // ── Check 2: submitHomework_ round-trip ──
-  // Write a smoke-test row, verify it persists, then delete it.
+  // ── Check 2: KH_Education write round-trip ──
+  // Write directly to the sheet (NOT through submitHomework_ which fires
+  // Pushover notifications, awards rings, and triggers Gemini review).
+  // This proves the sheet is writable and readable — no side effects.
   var smokeModule = '_smoke_test_' + Date.now();
   try {
-    if (typeof submitHomework_ !== 'function') {
-      failures.push('submitHomework_ function not found');
+    if (typeof ensureKHEducationTab_ !== 'function') {
+      failures.push('ensureKHEducationTab_ function not found');
       result.checks.submit_roundtrip = 'FAIL — function missing';
     } else {
-      var submitResult = submitHomework_({
-        child: 'buggsy',
-        module: smokeModule,
-        subject: 'SmokeTest',
-        score: 1,
-        responseText: '',
-        prompt: '',
-        rings: 0
-      });
-      var parsed = typeof submitResult === 'string' ? JSON.parse(submitResult) : submitResult;
+      var eduSheet = ensureKHEducationTab_();
+      eduSheet.appendRow([
+        new Date(), '_smoke_', smokeModule, 'SmokeTest', 0, true, '', 'smoke_test', '', 0, '', ''
+      ]);
+      SpreadsheetApp.flush();
 
-      if (!parsed || parsed.status !== 'ok') {
-        failures.push('submitHomework_ returned non-ok status: ' + JSON.stringify(parsed));
-        result.checks.submit_roundtrip = 'FAIL — status: ' + (parsed ? parsed.status : 'null');
+      // Verify the row landed
+      var lastRow = eduSheet.getLastRow();
+      var found = false;
+      var scanStart = Math.max(2, lastRow - 4);
+      var range = eduSheet.getRange(scanStart, 1, lastRow - scanStart + 1, 3).getValues();
+      for (var r = range.length - 1; r >= 0; r--) {
+        if (String(range[r][2]) === smokeModule) {
+          found = true;
+          eduSheet.deleteRow(scanStart + r);
+          break;
+        }
+      }
+
+      if (found) {
+        result.checks.submit_roundtrip = 'OK — row persisted and cleaned up (direct write, no side effects)';
       } else {
-        // Verify the row landed in KH_Education
-        Utilities.sleep(500); // brief settle time for sheet write
-        var eduSheet = ensureKHEducationTab_();
-        var lastRow = eduSheet.getLastRow();
-        var found = false;
-        // Scan last 5 rows (the smoke row should be at the bottom)
-        var scanStart = Math.max(2, lastRow - 4);
-        var range = eduSheet.getRange(scanStart, 1, lastRow - scanStart + 1, 3).getValues();
-        for (var r = range.length - 1; r >= 0; r--) {
-          if (String(range[r][2]) === smokeModule) {
-            found = true;
-            // Clean up: delete the smoke row
-            eduSheet.deleteRow(scanStart + r);
-            break;
-          }
-        }
-
-        if (found) {
-          result.checks.submit_roundtrip = 'OK — row persisted and cleaned up';
-        } else {
-          failures.push('submitHomework_ returned ok but no row found in KH_Education with module=' + smokeModule);
-          result.checks.submit_roundtrip = 'FAIL — row not found after successful submit';
-        }
+        failures.push('Sheet appendRow succeeded but row not found in KH_Education with module=' + smokeModule);
+        result.checks.submit_roundtrip = 'FAIL — row not found after write';
       }
     }
   } catch(e) {
-    failures.push('Submit round-trip threw: ' + (e.message || String(e)));
+    failures.push('Write round-trip threw: ' + (e.message || String(e)));
     result.checks.submit_roundtrip = 'FAIL — exception: ' + (e.message || String(e));
     // Best-effort cleanup
     try {

--- a/tests/tbm/workflows/homework-plan-through-complete.spec.js
+++ b/tests/tbm/workflows/homework-plan-through-complete.spec.js
@@ -193,6 +193,55 @@ test.describe('Homework Module — Plan Your Attack → Complete', function() {
 
 test.describe('Homework Module — API Wiring', function() {
 
+  test('submitHomeworkSafe fires as soon as completion overlay appears', async function({ page }) {
+    await gasShim.shimGAS(page);
+
+    var submitCallMade = false;
+    await page.route('**\/api**', function(route) {
+      var url = route.request().url();
+      if (url.indexOf('fn=submitHomeworkSafe') !== -1) {
+        submitCallMade = true;
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'ok', autoApproved: false, ringsAwarded: 0 })
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: helpers.GAS_TIMEOUT });
+
+    var readyBtn = page.locator('.es-ready-btn, button:has-text("Let\'s go"), button:has-text("Ready")');
+    if (await readyBtn.count() > 0) {
+      await readyBtn.first().click();
+      await page.waitForTimeout(500);
+    }
+
+    await page.evaluate(function() {
+      var i;
+      moduleStarted = true;
+      for (i = 0; i < allQs.length; i++) {
+        var q = allQs[i];
+        var key = 'q' + q.id;
+        answers[key] = { submitted: true, correct: true };
+        if (isMCQuestion(q)) {
+          answers[key].selected = typeof q.answer === 'number' ? q.answer : 0;
+        } else {
+          answers[key].text = 'Synthetic answer for submit timing test.';
+        }
+      }
+      renderScience();
+      renderMath();
+      updateProgress();
+    });
+
+    await expect(page.locator('#completion-overlay')).toBeVisible();
+    await page.waitForTimeout(500);
+    expect(submitCallMade).toBe(true);
+  });
+
   test('submitHomeworkSafe is called when module completes', async function({ page }) {
     await gasShim.shimGAS(page);
 
@@ -253,6 +302,39 @@ test.describe('Homework Module — API Wiring', function() {
     await page.waitForTimeout(1000);
 
     expect(contentCallMade).toBe(true);
+  });
+
+});
+
+test.describe('Homework Module — Draft Persistence', function() {
+
+  test('typed open-ended answer is restored after reload', async function({ page }) {
+    await gasShim.shimGAS(page);
+
+    await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: helpers.GAS_TIMEOUT });
+
+    var readyBtn = page.locator('.es-ready-btn, button:has-text("Let\'s go"), button:has-text("Ready")');
+    if (await readyBtn.count() > 0) {
+      await readyBtn.first().click();
+      await page.waitForTimeout(500);
+    }
+
+    await page.locator('#tab-science').click();
+    var draftText = 'Friction slowed the book because the table rubbed against it.';
+    var textarea = page.locator('textarea[id^="textarea-"]').first();
+    await textarea.fill(draftText);
+    await page.evaluate(function() { saveHomeworkDraft_(); });
+
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: helpers.GAS_TIMEOUT });
+
+    readyBtn = page.locator('.es-ready-btn, button:has-text("Let\'s go"), button:has-text("Ready")');
+    if (await readyBtn.count() > 0) {
+      await readyBtn.first().click();
+      await page.waitForTimeout(500);
+    }
+
+    await page.locator('#tab-science').click();
+    await expect(page.locator('textarea[id^="textarea-"]').first()).toHaveValue(draftText);
   });
 
 });


### PR DESCRIPTION
## Summary

**Critical fix.** HomeworkModule has been running in fallback/practice mode since launch. Zero homework submissions were reaching the server.

### Root cause
`HomeworkModule.html` line 2004 checked `c.module.questions` (flat array at module root), but CurriculumSeed provides questions at `c.module.math.questions` and `c.module.science.questions`. The gate rejected valid curriculum data every time → fallback mode → all three server calls silently skipped.

### Changes
1. **HomeworkModule.html v12** — Fix data shape check to look for `module.math.questions` and `module.science.questions` (the actual shape). Backward-compatible with flat `module.questions` if that shape ever exists. Added `console.warn` for non-homework days so fallback is diagnosable.
2. **KidsHub.js v67** — Replace empty `catch(e) { /* non-blocking */ }` blocks with `logError_()` calls in both `submitHomework_()` and `approveHomework_()` Pushover notification paths. Failures now land in ErrorLog.

### Impact
- Homework submissions will now be recorded in KH_Education
- Rings will be awarded (auto-grade) or queued for parent review (open-ended)
- Parent notifications will fire on submission
- Pushover failures will be logged instead of silently swallowed

Closes #313

## Test plan
- [ ] Load HomeworkModule on a Monday/Wednesday/Friday (module day) — verify curriculum content loads, NOT fallback
- [ ] Submit homework — verify row appears in KH_Education with correct status
- [ ] Verify Pushover notification received by both parents
- [ ] Check ErrorLog for any new `submitHomework_:push` entries
- [ ] On Tuesday/Thursday (non-module day) — verify graceful fallback with console warning
- [ ] `?action=runTests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)