### PR TITLE
fix: CI noise — serialize Codex reviews, extend Playwright GAS timeouts

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -22,13 +22,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  # Per-PR group cancels stale runs when a new push arrives (desirable — avoids
-  # reviewing an outdated commit). The primary 429 fix is exponential backoff in
-  # codex_review.py (15/30/60/120s) rather than workflow-level serialization,
-  # since a shared global group with cancel-in-progress: false still drops runs
-  # when GitHub's single pending-slot limit is hit under burst conditions.
-  group: codex-pr-review-${{ github.event.pull_request.number || inputs.pr }}
-  cancel-in-progress: true
+  # Shared group serializes reviews so only one OpenAI call runs at a time.
+  # This prevents concurrent PRs from exhausting the rate limit (429s).
+  # GitHub queues one pending run and drops the rest — those can be re-triggered
+  # with "@codex review" or a re-run. Preferable to 3 simultaneous INCONCLUSIVEs.
+  group: codex-pr-review-global
+  cancel-in-progress: false
 
 jobs:
   # Fast gate: broken YAML → fail early, skip OpenAI call.

--- a/tests/tbm/tbm-e2e-safe.spec.js
+++ b/tests/tbm/tbm-e2e-safe.spec.js
@@ -140,10 +140,12 @@ test.describe('P2-1: Education Review Flow', function() {
     await page.setViewportSize(DEVICES.s25);
     await gotoPath(page, '/parent');
 
-    await expect(page.getByText(/EDUCATION/i).first()).toBeVisible();
-    await expect(page.getByText(/TODAY'S HOMEWORK/i)).toBeVisible();
-    await expect(page.getByText(/Daily Missions/i)).toBeVisible();
-    await expect(page.getByText(/Baseline/i)).toBeVisible();
+    // Parent Dashboard sections render after google.script.run callbacks —
+    // allow extra time beyond the 6s waitForGAS for data-dependent rendering.
+    await expect(page.getByText(/EDUCATION/i).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/TODAY'S HOMEWORK/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/Daily Missions/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/Baseline/i)).toBeVisible({ timeout: 10000 });
   });
 });
 
@@ -206,7 +208,8 @@ test.describe('Story Factory', function() {
     await page.setViewportSize(DEVICES.s25);
     await gotoPath(page, '/parent');
 
-    await expect(page.getByText(/STORY FACTORY/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /Create Bedtime Story/i })).toBeVisible();
+    // Story Factory section renders after GAS data callback — needs extra timeout
+    await expect(page.getByText(/STORY FACTORY/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: /Create Bedtime Story/i })).toBeVisible({ timeout: 10000 });
   });
 });


### PR DESCRIPTION
## Summary
- Serialize Codex PR reviews with a shared concurrency group to prevent 3+ PRs from hitting OpenAI 429 rate limits simultaneously
- Extend Playwright assertion timeouts on Parent Dashboard tests from 5s default to 10-15s for GAS data-dependent sections (STORY FACTORY, EDUCATION)

These are the two checks failing across PRs #309, #311, and #314 — all infrastructure noise, not code problems.

## Test plan
- [ ] Codex review completes without 429 on next PR push
- [ ] Playwright Story Factory and Education tests pass with extended timeouts
- [ ] No regressions in other CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)