### PR TITLE
feat: homework gate on Comic Studio — locked until daily homework done

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -550,6 +550,7 @@ function serveData(e) {
         'listComicDraftsSafe': listComicDraftsSafe,
         'deleteComicDraftSafe': deleteComicDraftSafe,
         'getComicStudioContextSafe': getComicStudioContextSafe,
+        'checkHomeworkGateSafe': checkHomeworkGateSafe,
         // NotionEngine.js — Notion-specific wrappers (v2: renamed to avoid overriding Code.js handlers)
         'notionLogHomeworkSafe': notionLogHomeworkSafe,
         'notionLogSparkleProgressSafe': notionLogSparkleProgressSafe,

--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="comic-studio">
-<meta name="tbm-version" content="v13">
+<meta name="tbm-version" content="v14">
 <title>Wolfkid Comic Studio</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -991,6 +991,15 @@ main {
 </head>
 <body>
 
+<!-- v14: Homework gate overlay — blocks Comic Studio until daily homework is done (weekdays only) -->
+<div id="hw-gate" style="display:none;position:fixed;top:0;left:0;right:0;bottom:0;z-index:99999;background:#0B0F1A;color:#E2E8F0;font-family:Nunito,sans-serif;text-align:center;padding-top:20vh;">
+  <div style="font-size:64px;margin-bottom:16px;">&#128218;</div>
+  <div style="font-family:Orbitron,sans-serif;font-size:22px;font-weight:900;color:#F59E0B;letter-spacing:2px;margin-bottom:12px;">HOMEWORK FIRST</div>
+  <div style="font-size:15px;color:#94A3B8;max-width:320px;margin:0 auto 24px;line-height:1.6;">Complete today's homework to unlock Comic Studio.</div>
+  <a href="/homework" style="display:inline-block;padding:14px 32px;background:#3B82F6;color:#fff;border-radius:10px;font-family:Orbitron,sans-serif;font-size:14px;font-weight:700;text-decoration:none;letter-spacing:1px;">GO TO HOMEWORK</a>
+  <div style="margin-top:16px;font-size:12px;color:#475569;">Unlocked on weekends &bull; Unlocked after any homework submission</div>
+</div>
+
 <div id="starfield"></div>
 
 <div id="app-header">
@@ -1147,7 +1156,7 @@ main {
 <script>
 // ── ComicStudio v5 — Day 2: F3 Drive Draft/Resume + F4 Mission/Free Mode
 // ES6 EXEMPT: Surface Pro 5 / Chrome — see specs/comicstudio-v4.md §3
-// tbm-version: v13
+// tbm-version: v14
 
 const COMIC_STUDIO_VERSION = 12; // v12: gallery autosave guard + sticker overlay in viewer
 
@@ -2912,7 +2921,29 @@ function init() {
     .catch(() => { _initReady(); });
 }
 
-init();
+// v14: Homework gate — check before allowing Comic Studio
+function checkHomeworkGateAndInit() {
+  // Skip gate in test mode
+  if (TBM_TEST_MODE) { init(); return; }
+  // Skip gate if google.script.run not available (local dev)
+  if (typeof google === 'undefined' || !google.script || !google.script.run) { init(); return; }
+
+  google.script.run
+    .withSuccessHandler(function(result) {
+      if (result && result.locked) {
+        document.getElementById('hw-gate').style.display = 'block';
+      } else {
+        init();
+      }
+    })
+    .withFailureHandler(function() {
+      // Gate check failed — let them through rather than block on error
+      init();
+    })
+    .checkHomeworkGateSafe(CHILD);
+}
+
+checkHomeworkGateAndInit();
 </script>
 <!-- ═══ Kid Feedback Widget (ES5 IIFE) ═══ -->
 <script>

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v67 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v68 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 🧹📅 KH_LessonRuns, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 67; }
+function getKidsHubVersion() { return 68; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -5135,5 +5135,39 @@ function loadComicDraftByDateSafe(child, dateKey) {
   });
 }
 
-// END OF FILE — KidsHub.gs v67
+// ── HOMEWORK GATE — check if daily homework is done ─────────────
+// Returns { locked: bool, reason: string }
+// Weekends always unlocked. Weekdays check KH_Education for today's submission.
+function checkHomeworkGate_(child) {
+  var today = new Date();
+  var day = today.getDay(); // 0=Sun, 6=Sat
+  if (day === 0 || day === 6) return { locked: false, reason: 'weekend' };
+
+  var childLower = String(child || 'buggsy').toLowerCase();
+  var todayStr = Utilities.formatDate(today, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+  var sheet = ensureKHEducationTab_();
+  var lastRow = sheet.getLastRow();
+  if (lastRow < 2) return { locked: true, reason: 'No homework submitted today' };
+
+  // Scan from bottom — most recent first
+  var data = sheet.getRange(2, 1, lastRow - 1, 4).getValues();
+  for (var i = data.length - 1; i >= 0; i--) {
+    var ts = data[i][0];
+    if (!(ts instanceof Date)) continue;
+    var rowDate = Utilities.formatDate(ts, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    if (rowDate < todayStr) break; // past today, stop scanning
+    if (rowDate === todayStr && String(data[i][1]).toLowerCase() === childLower) {
+      return { locked: false, reason: 'Homework submitted today' };
+    }
+  }
+  return { locked: true, reason: 'No homework submitted today' };
+}
+
+function checkHomeworkGateSafe(child) {
+  return withMonitor_('checkHomeworkGateSafe', function() {
+    return checkHomeworkGate_(child);
+  });
+}
+
+// END OF FILE — KidsHub.gs v68
 // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Comic Studio checks KH_Education for today's submission before loading
- Weekdays: locked if no homework submitted → shows lock screen with link to /homework
- Weekends: always unlocked
- Fail-open on gate check errors (don't punish the kid for a server glitch)

## Test plan
- [ ] Visit /comic-studio on a weekday without homework done → see lock screen
- [ ] Submit homework → revisit /comic-studio → loads normally
- [ ] Visit on weekend → loads normally regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)