### PR TITLE
fix: repair .es-plan-attack fixture contract (#329)

### DIFF
--- a/tests/tbm/education-workflows.spec.js
+++ b/tests/tbm/education-workflows.spec.js
@@ -75,10 +75,10 @@ test.describe('Homework: Plan Your Attack → answer flow → completion', funct
     await shimGAS(page, FIXTURES);
 
     await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
-    await page.waitForTimeout(6000);
 
-    // Plan Your Attack screen should be visible
-    await expect(page.locator('.es-plan-attack')).toBeVisible({ timeout: 15000 });
+    // Plan Your Attack screen should be visible — wait for dynamic render (ExecSkills.showPlanYourAttack
+    // injects .es-plan-attack into #plan-overlay after getTodayContentSafe returns).
+    await page.locator('.es-plan-attack').waitFor({ state: 'visible', timeout: 20000 });
 
     // Click ready button to start session
     await page.locator('.es-ready-btn').click();
@@ -119,8 +119,9 @@ test.describe('Homework: wrong answer shows purple not red', function() {
     await shimGAS(page, FIXTURES);
 
     await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
-    await page.waitForTimeout(6000);
 
+    // Wait for Plan Your Attack to render before clicking the ready button.
+    await page.locator('.es-plan-attack').waitFor({ state: 'visible', timeout: 20000 });
     // Start the session
     await page.locator('.es-ready-btn').click();
     await page.waitForTimeout(2000);

--- a/tests/tbm/fixtures/gas-shim.js
+++ b/tests/tbm/fixtures/gas-shim.js
@@ -20,6 +20,13 @@ var EDUCATION_FIXTURES = {
           strand: 'Force and Motion',
           teks: '4.7A',
           title: 'Forces Briefing',
+          quickFact: 'Gravity pulls objects toward Earth and acts at a distance — no contact needed.',
+          passage: [
+            'Forces are pushes or pulls that act on objects. Some forces require direct contact, like friction. Others act at a distance, like gravity and magnetism.',
+            'Gravity is the force that pulls everything toward Earth. It causes dropped objects to fall and keeps us on the ground.',
+            'Friction is a contact force that resists motion between two surfaces. Rough surfaces create more friction than smooth ones.',
+            'Magnetism is a non-contact force. Magnets can attract or repel certain materials without touching them.'
+          ],
           questions: [
             {
               id: 1,


### PR DESCRIPTION
## Summary

- **Root cause:** `HomeworkModule` v13 updated `hasModuleQuestions` to accept `c.module.science.questions`, so the fixture data now flows into `MODULE` instead of FALLBACK_MODULE. `renderScience()` then throws `TypeError: Cannot read property 'length' of undefined` at `MODULE.science.passage.length` because the fixture's science object lacked `quickFact` and `passage`. The throw stops `init()` before `ExecSkills.showPlanYourAttack()` runs — `.es-plan-attack` never renders — all 5 homework tests fail.
- **Fix 1 — `gas-shim.js`:** add `quickFact` (string) and `passage` (array of 4 paragraphs) to the science fixture so `renderScience()` completes without throwing.
- **Fix 2 — `education-workflows.spec.js`:** replace fragile `waitForTimeout(6000)` in tests 1 + 2 with `waitFor({ state: 'visible', timeout: 20000 })` — consistent with the pattern used in all other homework tests.

## Test plan
- [ ] Education workflow CI runs green (5 previously-failing homework tests now pass)
- [ ] All other education tests (brain break, error journal, reflection, Sparkle, Fact Sprint, Daily Missions) continue to pass
- [ ] No ES5 violations — audit passes

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)