### PR TITLE
feat: extend Close History schema — DataEngine v95, MonitorEngine v12

### DIFF
--- a/Dataengine.js
+++ b/Dataengine.js
@@ -1,10 +1,10 @@
 // ════════════════════════════════════════════════════════════════════
-// DATA ENGINE v94 — Dynamic KPI Computation from Raw Tiller Data
+// DATA ENGINE v95 — Dynamic KPI Computation from Raw Tiller Data
 // WRITES TO: 💻🧮 Dashboard_Export, 💻🧮 Debt_Export, 💻🧮 DebtModel, 💻🧮 Cascade Proof, 💻🧮 Cascade Month-by-Month, 💻🧮 Cascade Payoff Schedule, 📋 Board_Config
 // READS FROM: 🔒 Transactions, 🔒 Balance History, 🔒 Categories, 💻🧮 Budget_Data, 💻🧮 Helpers, 💻🧮 DebtModel, 💻🧮 BankRec, 💻🧮 Budget_Rules, 💻 MealPlan
 // ════════════════════════════════════════════════════════════════════
 
-function getDataEngineVersion() { return 94; }
+function getDataEngineVersion() { return 95; }
 
 // ════════════════════════════════════════════════════════════════════
 //
@@ -2809,7 +2809,25 @@ function getSubscriptionData(startDate, endDate) {
 
 // ════════════════════════════════════════════════════════════════════
 // getCloseHistoryData() — Monthly Trends for The Vein (v7 addition)
+// TV-012: Extended to read columns J-P (close record metadata) — v95
 // ════════════════════════════════════════════════════════════════════
+// Close History column map (0-indexed):
+//   A [0] month label ("March 2026")
+//   B [1] status ("Closed")
+//   C [2] close timestamp (written by stampCloseMonth)
+//   D [3] earned income (Tiller-populated)
+//   E [4] UNKNOWN — not read; origin unconfirmed; do not write programmatically
+//   F [5] money out (Tiller-populated)
+//   G [6] net cash flow (Tiller-populated)
+//   H [7] debt current (written by stampCloseMonth)
+//   I [8] disc_actual — RESERVED for discretionary spend; written by TV-013
+//   J [9] gate snapshot — compact JSON of MER gate statuses (stampCloseMonth v11)
+//   K [10] proof status — overall proof result string (stampCloseMonth v11)
+//   L [11] proof timestamp (stampCloseMonth v11)
+//   M [12] operator close note, max 500 chars (stampCloseMonth v11)
+//   N [13] open items — JSON array of carry-forward items (stampCloseMonth v11)
+//   O [14] close mode — "standard" or "override" (stampCloseMonth v11)
+//   P [15] override rationale (stampCloseMonth v11)
 
 function getCloseHistoryData() {
   var data = de_readSheet_('Close History');
@@ -2832,6 +2850,15 @@ function getCloseHistoryData() {
     var year = parseInt(parts[1]) || 2026;
     var absMoneyOut = Math.abs(moneyOut);
 
+    // Columns J-P: close record metadata (written by stampCloseMonth v11+)
+    var gateSnapshotRaw = data[i][9] || '';
+    var proofStatus = String(data[i][10] || '');
+    var proofTimestamp = data[i][11] ? String(data[i][11]) : '';
+    var closeNote = String(data[i][12] || '');
+    var openItemsRaw = data[i][13] || '';
+    var closeMode = String(data[i][14] || '');
+    var overrideRationale = String(data[i][15] || '');
+
     months.push({
       month: monthName,
       year: year,
@@ -2840,10 +2867,16 @@ function getCloseHistoryData() {
       netCashFlow: roundTo(ncf, 2),
       operationalCashFlow: roundTo(earned - absMoneyOut, 2),
       debtCurrent: roundTo(debt, 2),
-      // v91: Read discretionary from col I (8) if stampCloseMonth writes it;
-      // falls back to 0 until Close History schema is extended.
-      // TODO: Extend stampCloseMonth() to write discretionary spend to col I.
-      disc_actual: roundTo(parseFloat(data[i][8]) || 0, 2)
+      // col I: reserved for discretionary spend; written when TV-013 ships
+      disc_actual: roundTo(parseFloat(data[i][8]) || 0, 2),
+      // col J-P: close record metadata
+      gateSnapshot: gateSnapshotRaw ? String(gateSnapshotRaw) : '',
+      proofStatus: proofStatus,
+      proofTimestamp: proofTimestamp,
+      closeNote: closeNote,
+      openItems: openItemsRaw ? String(openItemsRaw) : '',
+      closeMode: closeMode,
+      overrideRationale: overrideRationale
     });
   }
 
@@ -3822,4 +3855,4 @@ function getCloseProofSafe(monthLabel) {
   });
 }
 
-// END OF FILE — DataEngine v94
+// END OF FILE — DataEngine v95

--- a/Dataengine.js
+++ b/Dataengine.js
@@ -1,10 +1,10 @@
 // ════════════════════════════════════════════════════════════════════
-// DATA ENGINE v95 — Dynamic KPI Computation from Raw Tiller Data
+// DATA ENGINE v96 — Dynamic KPI Computation from Raw Tiller Data
 // WRITES TO: 💻🧮 Dashboard_Export, 💻🧮 Debt_Export, 💻🧮 DebtModel, 💻🧮 Cascade Proof, 💻🧮 Cascade Month-by-Month, 💻🧮 Cascade Payoff Schedule, 📋 Board_Config
 // READS FROM: 🔒 Transactions, 🔒 Balance History, 🔒 Categories, 💻🧮 Budget_Data, 💻🧮 Helpers, 💻🧮 DebtModel, 💻🧮 BankRec, 💻🧮 Budget_Rules, 💻 MealPlan
 // ════════════════════════════════════════════════════════════════════
 
-function getDataEngineVersion() { return 95; }
+function getDataEngineVersion() { return 96; }
 
 // ════════════════════════════════════════════════════════════════════
 //
@@ -2874,7 +2874,10 @@ function getCloseHistoryData() {
       proofStatus: proofStatus,
       proofTimestamp: proofTimestamp,
       closeNote: closeNote,
-      openItems: openItemsRaw ? String(openItemsRaw) : '',
+      openItems: (function(raw) {
+        if (!raw) return [];
+        try { var p = JSON.parse(raw); return Array.isArray(p) ? p : [String(raw)]; } catch(e) { return [String(raw)]; }
+      })(openItemsRaw),
       closeMode: closeMode,
       overrideRationale: overrideRationale
     });
@@ -3855,4 +3858,4 @@ function getCloseProofSafe(monthLabel) {
   });
 }
 
-// END OF FILE — DataEngine v95
+// END OF FILE — DataEngine v96

--- a/MonitorEngine.js
+++ b/MonitorEngine.js
@@ -1,10 +1,10 @@
 // ═══════════════════════════════════════════════════
-// MonitorEngine.gs v11
+// MonitorEngine.gs v12
 // WRITES TO: 💻🧮 Close History, 💻🧮 Month-End Review
 // READS FROM: 💻🧮 DebtModel, 💻🧮 Helpers, 🔒 Transactions, 🔒 Balance History
 // ═══════════════════════════════════════════════════
 
-function getMonitorEngineVersion() { return 11; }
+function getMonitorEngineVersion() { return 12; }
 
 // v8: Lazy accessors — avoid parse-time openById for trigger safety
 var _meSS = null;
@@ -151,8 +151,12 @@ function stampCloseMonth(monthLabel, closeOpts) {
     chSheet.getRange(targetRow, 3).setValue(new Date());
     Logger.log('✅ Row ' + targetRow + ': H=$' + debtCurrent.toFixed(2) + ', B=Closed');
 
-    // v11: Extended close record (columns J-P) — all optional, backwards compatible
+    // v12: Extended close record (columns I-P) — all optional, backwards compatible
     var opts = closeOpts || {};
+    // I (col 9): discretionary spend actual — wired by TV-013; omitted if not provided
+    if (opts.discActual !== undefined && opts.discActual !== null) {
+      chSheet.getRange(targetRow, 9).setValue(parseFloat(opts.discActual) || 0);
+    }
     // J (col 10): gate snapshot — compact JSON of gate statuses
     if (opts.gateSnapshot) {
       chSheet.getRange(targetRow, 10).setValue(
@@ -586,4 +590,4 @@ function hyg10MonthCloseGate_() {
   );
 }
 
-// EOF — MonitorEngine.gs v11
+// EOF — MonitorEngine.gs v12


### PR DESCRIPTION
## Summary
- **TV-012**: Extends `getCloseHistoryData()` to return columns J-P close record metadata written by `stampCloseMonth` v11
- Documents full column map A-P inline (column E marked UNKNOWN — do not write programmatically)
- Column I reserved for `disc_actual` — write path wired via `opts.discActual` in `stampCloseMonth`, callers deferred to TV-013
- Trends reader (A-H) untouched — backwards compatible

## New fields returned by `getCloseHistoryData()`
| Field | Col | Source |
|-------|-----|--------|
| `gateSnapshot` | J | JSON string of MER gate statuses |
| `proofStatus` | K | Overall proof result |
| `proofTimestamp` | L | Proof timestamp |
| `closeNote` | M | Operator close note |
| `openItems` | N | JSON array of carry-forward items |
| `closeMode` | O | "standard" or "override" |
| `overrideRationale` | P | Override rationale |

## Test plan
- [ ] `getCloseHistoryData()` returns existing months with all prior fields intact
- [ ] New J-P fields present in response (empty string for older rows without them)
- [ ] `stampCloseMonth(month, { discActual: 1234 })` writes value to column I
- [ ] Monthly Trends on `/vein` renders correctly (A-H unchanged)

Closes #327 (TV-012 scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)