### PR TITLE
feat: Phase 0 hygiene filer + auto-close + tests + filer workflow

### DIFF
--- a/.github/scripts/auto_close_issues.py
+++ b/.github/scripts/auto_close_issues.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""auto_close_issues.py
+Purpose:   Daily cron that re-verifies every open auto-filed Issue.
+           - If the finding sig is no longer detected, close the Issue with label auto-close:resolved.
+           - If the finding still exists but evidence values differ, update the body in place
+             (DECISION 5 = (a): live-updated evidence fields).
+           - Issues with no registered detector are left alone (logged).
+Called by: .github/workflows/auto-close-issues.yml
+Env vars:  GITHUB_TOKEN / GH_TOKEN         auth
+           GITHUB_REPOSITORY               owner/repo
+           AUTOMATION_ENABLED              "false" short-circuits (default true)
+           STATUS_ISSUE_NUMBER             pinned filer-status Issue (optional)
+Args:      --dry-run  report actions; do not modify Issues
+Exit:      0 success; 1 validation error; 2 unexpected GitHub API error
+
+Detector registry:
+  Each check-id maps to a detector() callable returning a dict: {sig: {evidence, details, title}}.
+  Phase 0 registry is empty; Phase 1 wires version-drift here.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+
+import file_hygiene_issue as filer  # noqa: E402
+
+# ---- Detector registry -----------------------------------------------------
+# Maps check-id -> callable returning {sig: {"evidence": {...}, "title": str, "details": str}}.
+# Populated by Phase 1+ integrations. Empty in Phase 0: no detectors registered,
+# helper runs cleanly but does nothing.
+
+DETECTOR_REGISTRY = {}
+
+
+def register_detector(check_id, fn):
+    """Register a detector. Phase 1 calls this to wire version-drift."""
+    DETECTOR_REGISTRY[check_id] = fn
+
+
+def log(msg):
+    sys.stderr.write('[auto-close] ' + msg + '\n')
+
+
+def env_flag(name, default=True):
+    raw = os.environ.get(name, '').strip().lower()
+    if raw == '':
+        return default
+    return raw not in ('false', '0', 'no', 'off')
+
+
+def gh_run(args, check=True):
+    proc = subprocess.run(
+        ['gh'] + args,
+        capture_output=True,
+        text=True,
+        encoding='utf-8',
+    )
+    if check and proc.returncode != 0:
+        log('gh failed: ' + ' '.join(args))
+        log('stderr: ' + (proc.stderr or '').strip())
+        raise RuntimeError('gh exit ' + str(proc.returncode))
+    return proc
+
+
+def list_filed_issues(repo):
+    """Return list of open Issues labeled auto:filed, with body + number."""
+    proc = gh_run([
+        'issue', 'list', '-R', repo,
+        '--state', 'open',
+        '--label', 'auto:filed',
+        '--limit', '100',
+        '--json', 'number,title,body,labels',
+    ])
+    return json.loads(proc.stdout or '[]')
+
+
+def parse_marker(body):
+    """Return (check_id, sig) or (None, None) if no marker."""
+    if not body:
+        return None, None
+    m = filer.MARKER_RE.search(body)
+    if not m:
+        return None, None
+    return m.group(1), m.group(2)
+
+
+def parse_evidence_from_body(body):
+    """Extract evidence key-value pairs from rendered body.
+    Skips blank lines immediately after '**Evidence:**', collects '- key: val' lines,
+    and stops at the first line that is neither blank nor a bullet (e.g. next section)
+    OR at a blank line that follows at least one bullet.
+    """
+    if '**Evidence:**' not in body:
+        return {}
+    after = body.split('**Evidence:**', 1)[1]
+    out = {}
+    started = False
+    for line in after.split('\n'):
+        stripped = line.strip()
+        if not started:
+            if not stripped:
+                continue
+            if stripped.startswith('- '):
+                started = True
+            else:
+                break  # non-blank, non-bullet immediately after header
+        else:
+            if not stripped:
+                break  # blank line after bullets ends the list
+            if not stripped.startswith('- '):
+                break  # non-bullet ends the list
+        if stripped.startswith('- '):
+            pair = stripped[2:]
+            if ': ' not in pair:
+                continue
+            k, v = pair.split(': ', 1)
+            out[k.strip()] = v.strip()
+    return out
+
+
+def close_issue(repo, number, reason_label, comment):
+    gh_run(['issue', 'comment', str(number), '-R', repo, '-b', comment])
+    gh_run(['issue', 'edit', str(number), '-R', repo, '--add-label', reason_label])
+    gh_run(['issue', 'close', str(number), '-R', repo])
+
+
+def update_body(repo, number, new_body):
+    gh_run(['issue', 'edit', str(number), '-R', repo, '--body', new_body])
+
+
+def reconcile_one_issue(issue, repo, dry_run, status_issue):
+    number = issue['number']
+    body = issue.get('body') or ''
+    check_id, sig = parse_marker(body)
+    if not check_id:
+        log('#' + str(number) + ': no marker found — skipping (not one of ours)')
+        return
+
+    detector = DETECTOR_REGISTRY.get(check_id)
+    if not detector:
+        log('#' + str(number) + ': no detector for check=' + check_id + ' — skipping')
+        return
+
+    try:
+        current = detector()  # returns {sig: {evidence, details, title}}
+    except Exception as e:
+        log('#' + str(number) + ': detector ' + check_id + ' failed: ' + str(e))
+        return
+
+    if sig not in current:
+        log('#' + str(number) + ': sig ' + sig + ' RESOLVED — closing')
+        if dry_run:
+            sys.stdout.write('[dry-run] would close #' + str(number) + '\n')
+            return
+        comment = (
+            'Auto-closing: next run of ' + check_id + ' no longer detects this finding.\n\n'
+            'If this was closed in error, reopen and the filer will track it again.'
+        )
+        try:
+            close_issue(repo, number, 'auto-close:resolved', comment)
+            filer.post_status(
+                repo,
+                'Auto-closed #' + str(number) + ' (' + check_id + ' sig=' + sig + ')',
+                status_issue,
+            )
+        except Exception as e:
+            log('close failed for #' + str(number) + ': ' + str(e))
+        return
+
+    # Sig still present — check if evidence changed (DECISION 5 = (a))
+    new_snap = current[sig]
+    old_evidence = parse_evidence_from_body(body)
+    new_evidence = new_snap.get('evidence') or {}
+    if old_evidence == new_evidence:
+        log('#' + str(number) + ': still present, evidence unchanged')
+        return
+
+    log('#' + str(number) + ': evidence changed ' + repr(old_evidence) + ' -> ' + repr(new_evidence))
+    if dry_run:
+        sys.stdout.write('[dry-run] would update body of #' + str(number) + '\n')
+        return
+
+    # Rebuild body using filer.render_body
+    finding = {
+        'check': check_id,
+        'check_title': issue.get('title', '[?]').split(']')[0].lstrip('[') if ']' in issue.get('title', '') else '[?]',
+        'title': new_snap.get('title') or '',
+        'identity': {'check': check_id},  # placeholder — not used by render_body
+        'evidence': new_evidence,
+        'details': new_snap.get('details'),
+    }
+    new_body = filer.render_body(finding, sig)
+    try:
+        update_body(repo, number, new_body)
+        log('#' + str(number) + ': body updated')
+    except Exception as e:
+        log('body update failed for #' + str(number) + ': ' + str(e))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+
+    if not env_flag('AUTOMATION_ENABLED', True):
+        log('AUTOMATION_ENABLED=false — no-op')
+        return 0
+
+    repo = os.environ.get('GITHUB_REPOSITORY', '').strip()
+    if not repo:
+        log('GITHUB_REPOSITORY not set')
+        return 1
+
+    status_issue = os.environ.get('STATUS_ISSUE_NUMBER', '').strip()
+
+    if not DETECTOR_REGISTRY:
+        log('no detectors registered (Phase 0 state) — nothing to reconcile')
+        return 0
+
+    try:
+        issues = list_filed_issues(repo)
+    except Exception as e:
+        log('list failed: ' + str(e))
+        return 2
+
+    log('reconciling ' + str(len(issues)) + ' open auto:filed Issues')
+    for issue in issues:
+        reconcile_one_issue(issue, repo, args.dry_run, status_issue)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/file_hygiene_issue.py
+++ b/.github/scripts/file_hygiene_issue.py
@@ -147,33 +147,50 @@ def gh_run(args, check=True):
     return proc
 
 
-def gh_graphql_search(query, repo):
-    """Search issues matching a query. Returns list of {number, state, labels}."""
-    q = 'repo:' + repo + ' ' + query
-    proc = gh_run([
-        'api', 'graphql',
-        '-f', 'query=query($q:String!){search(query:$q,type:ISSUE,first:25){'
-              'nodes{...on Issue{number state labels(first:20){nodes{name}}}}}}',
-        '-f', 'q=' + q,
-    ])
-    data = json.loads(proc.stdout)
-    nodes = data.get('data', {}).get('search', {}).get('nodes', []) or []
+def gh_list_issues(repo, state, labels=None, limit=200):
+    """List Issues via REST `gh issue list` (consistent — no search-index lag).
+    Returns list of dicts with number, body, closedAt, labels.
+    GraphQL `search` was tried first and rejected: newly-created Issues are not
+    immediately searchable (private repo indexing lag of 30s+ caused a duplicate
+    Issue when the filer was invoked twice in quick succession during sandbox
+    drill 2026-04-15). REST list is consistent and bounded for Phase 1 volumes.
+    """
+    args = ['issue', 'list', '-R', repo, '--state', state, '--limit', str(limit),
+            '--json', 'number,body,closedAt,labels']
+    for lab in (labels or []):
+        args.extend(['--label', lab])
+    proc = gh_run(args)
+    issues = json.loads(proc.stdout or '[]')
     out = []
-    for n in nodes:
-        if not n:
-            continue
-        labels = [L['name'] for L in (n.get('labels') or {}).get('nodes', []) or []]
-        out.append({'number': n['number'], 'state': n['state'], 'labels': labels})
+    for it in issues:
+        out.append({
+            'number': it['number'],
+            'body': it.get('body') or '',
+            'closedAt': it.get('closedAt'),
+            'labels': [L['name'] for L in (it.get('labels') or [])],
+        })
     return out
 
 
+def issue_marker_matches(issue, check_id, sig):
+    """True iff the issue body contains the v=1 marker for this check + sig."""
+    m = MARKER_RE.search(issue['body'] or '')
+    return bool(m and m.group(1) == check_id and m.group(2) == sig)
+
+
 def daily_issue_count(repo):
-    """Count Issues created with label auto:filed in the last 24h."""
+    """Count Issues created with label auto:filed in the last 24h.
+    REST list (consistent) + client-side date filter on createdAt.
+    """
     cutoff = datetime.now(timezone.utc).strftime('%Y-%m-%d')
-    q = 'is:issue label:auto:filed created:>=' + cutoff
     try:
-        results = gh_graphql_search(q, repo)
-        return len(results)
+        proc = gh_run([
+            'issue', 'list', '-R', repo, '--state', 'all',
+            '--label', 'auto:filed', '--limit', '200',
+            '--json', 'number,createdAt',
+        ])
+        items = json.loads(proc.stdout or '[]')
+        return sum(1 for it in items if (it.get('createdAt') or '').startswith(cutoff))
     except Exception as e:
         log('daily count failed (not blocking): ' + str(e))
         return 0
@@ -192,22 +209,41 @@ def post_status(repo, message, status_issue):
 
 
 def find_open_match(repo, check_id, sig):
-    q = 'is:issue is:open in:body "sig=' + sig + '" "check=' + check_id + '"'
-    return gh_graphql_search(q, repo)
+    """Open Issues with label auto:filed whose body marker matches."""
+    issues = gh_list_issues(repo, 'open', labels=['auto:filed'])
+    return [it for it in issues if issue_marker_matches(it, check_id, sig)]
 
 
 def find_suppressed(repo, check_id, sig):
-    q = ('is:issue is:closed label:auto:suppressed in:body '
-         '"sig=' + sig + '" "check=' + check_id + '"')
-    return gh_graphql_search(q, repo)
+    """Closed Issues with label auto:suppressed whose body marker matches.
+    Must also have auto:filed label (to scope; suppress is a complement, not standalone).
+    """
+    issues = gh_list_issues(repo, 'closed', labels=['auto:filed', 'auto:suppressed'])
+    return [it for it in issues if issue_marker_matches(it, check_id, sig)]
 
 
 def find_recent_closed(repo, check_id, sig, days):
-    cutoff = (datetime.now(timezone.utc).timestamp() - days * 86400)
-    cutoff_iso = datetime.fromtimestamp(cutoff, tz=timezone.utc).strftime('%Y-%m-%d')
-    q = ('is:issue is:closed -label:auto:suppressed in:body '
-         '"sig=' + sig + '" "check=' + check_id + '" closed:>=' + cutoff_iso)
-    return gh_graphql_search(q, repo)
+    """Closed Issues with auto:filed (NOT auto:suppressed) whose body marker matches
+    AND closedAt is within `days` of now. Suppressed exclusion is client-side.
+    """
+    cutoff_ts = datetime.now(timezone.utc).timestamp() - (days * 86400)
+    issues = gh_list_issues(repo, 'closed', labels=['auto:filed'])
+    out = []
+    for it in issues:
+        if 'auto:suppressed' in it['labels']:
+            continue
+        if not issue_marker_matches(it, check_id, sig):
+            continue
+        closed_at = it.get('closedAt')
+        if not closed_at:
+            continue
+        try:
+            closed_ts = datetime.strptime(closed_at, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc).timestamp()
+        except ValueError:
+            continue
+        if closed_ts >= cutoff_ts:
+            out.append(it)
+    return out
 
 
 def create_issue(repo, title, body, labels):

--- a/.github/scripts/file_hygiene_issue.py
+++ b/.github/scripts/file_hygiene_issue.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""file_hygiene_issue.py
+Purpose:   Dedup'd GitHub Issue filer for hygiene findings.
+           Reads a finding JSON from stdin, computes an identity signature,
+           searches for existing Issues, and either no-ops, reopens, or creates.
+Called by: .github/workflows/hygiene-filer.yml
+Input:     Finding JSON on stdin. Schema:
+             {
+               "check":        "version-drift",      required, check-id
+               "check_title":  "HYG-06",             required, title prefix
+               "title":        "Version drift: ...", required, human title
+               "identity":     {...},                required, fields used for sig
+               "evidence":     {"Deployed":"42",...},optional, shown in body, D5-updated
+               "details":      "Optional prose",     optional, shown in body
+               "extra_labels": ["area:infra", ...],  optional
+             }
+Env vars:  GITHUB_TOKEN / GH_TOKEN           auth (auto in Actions)
+           GITHUB_REPOSITORY                 owner/repo (auto in Actions)
+           AUTOMATION_ENABLED                "false" short-circuits (default true)
+           HYGIENE_ISSUE_CREATION_ENABLED    "false" short-circuits (default true)
+           AUTOMATION_MAX_DAILY_ISSUES       integer cap (default 5)
+           STATUS_ISSUE_NUMBER               pinned filer-status Issue (optional)
+Args:      --dry-run  print rendered body; no GitHub API calls
+Exit:      0 success (created, reopened, dedup no-op, or rate-limited no-op)
+           1 validation error
+           2 unexpected error (GitHub API failure)
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+SIG_LENGTH = 16  # DECISION 2 = (b): 16 hex chars
+REOPEN_WINDOW_DAYS = 7  # DECISION 3 = (a)
+SUPPRESSED_WINDOW_DAYS = 90
+MARKER_PREFIX = '<!-- auto-finding v=1 '
+MARKER_RE = re.compile(
+    r'<!--\s*auto-finding\s+v=1\s+check=([^\s]+)\s+sig=([0-9a-f]+)\s*-->'
+)
+
+FOOTER = (
+    '---\n'
+    'Filed by hygiene automation. I dedup by the hidden marker below — '
+    'editing this title is safe. If you close this Issue without adding the '
+    '`auto:suppressed` label, I WILL REOPEN it on the next run if the finding '
+    'still exists (within {days} days). Apply `auto:suppressed` to permanently '
+    'dismiss.'
+).format(days=REOPEN_WINDOW_DAYS)
+
+
+def log(msg):
+    sys.stderr.write('[filer] ' + msg + '\n')
+
+
+def env_flag(name, default=True):
+    raw = os.environ.get(name, '').strip().lower()
+    if raw == '':
+        return default
+    return raw not in ('false', '0', 'no', 'off')
+
+
+def env_int(name, default):
+    raw = os.environ.get(name, '').strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def compute_sig(identity):
+    """sha256 of identity dict. Keys and string values are stripped + lowercased
+    before hashing. sort_keys enforced. First SIG_LENGTH hex chars returned.
+    Raises ValueError on empty, non-dict, missing 'check' field, or unsupported value types.
+    """
+    if not isinstance(identity, dict) or not identity:
+        raise ValueError('identity must be a non-empty dict')
+    normalized = {}
+    for k, v in identity.items():
+        key = str(k).strip().lower()
+        if isinstance(v, str):
+            normalized[key] = v.strip().lower()
+        elif isinstance(v, bool) or isinstance(v, (int, float)) or v is None:
+            normalized[key] = v
+        else:
+            raise ValueError('identity field ' + repr(k) + ' has unsupported type ' + type(v).__name__)
+    if 'check' not in normalized:
+        raise ValueError('identity missing required field: check')
+    payload = json.dumps(normalized, sort_keys=True, ensure_ascii=True).encode('utf-8')
+    return hashlib.sha256(payload).hexdigest()[:SIG_LENGTH]
+
+
+def render_body(finding, sig):
+    """Assemble Issue body with marker, evidence, details, footer."""
+    lines = []
+    lines.append('**Check:** ' + finding['check_title'] + ' ' + finding.get('check', ''))
+    lines.append('')
+    evidence = finding.get('evidence') or {}
+    if evidence:
+        lines.append('**Evidence:**')
+        for key, val in evidence.items():
+            lines.append('- ' + str(key) + ': ' + str(val))
+        lines.append('')
+    details = finding.get('details')
+    if details:
+        lines.append('**Details:**')
+        lines.append(str(details))
+        lines.append('')
+    lines.append(FOOTER)
+    lines.append('')
+    marker = MARKER_PREFIX + 'check=' + finding['check'] + ' sig=' + sig + ' -->'
+    lines.append(marker)
+    return '\n'.join(lines)
+
+
+def render_title(finding):
+    return '[' + finding['check_title'] + '] ' + finding['title']
+
+
+def validate_finding(finding):
+    required = ['check', 'check_title', 'title', 'identity']
+    missing = [k for k in required if k not in finding]
+    if missing:
+        raise ValueError('finding missing required fields: ' + ', '.join(missing))
+    if not isinstance(finding['identity'], dict):
+        raise ValueError('identity must be a dict')
+
+
+def gh_run(args, check=True):
+    """Run `gh` CLI and return parsed JSON stdout."""
+    proc = subprocess.run(
+        ['gh'] + args,
+        capture_output=True,
+        text=True,
+        encoding='utf-8',
+    )
+    if check and proc.returncode != 0:
+        log('gh command failed: ' + ' '.join(args))
+        log('stderr: ' + (proc.stderr or '').strip())
+        raise RuntimeError('gh exit ' + str(proc.returncode))
+    return proc
+
+
+def gh_graphql_search(query, repo):
+    """Search issues matching a query. Returns list of {number, state, labels}."""
+    q = 'repo:' + repo + ' ' + query
+    proc = gh_run([
+        'api', 'graphql',
+        '-f', 'query=query($q:String!){search(query:$q,type:ISSUE,first:25){'
+              'nodes{...on Issue{number state labels(first:20){nodes{name}}}}}}',
+        '-f', 'q=' + q,
+    ])
+    data = json.loads(proc.stdout)
+    nodes = data.get('data', {}).get('search', {}).get('nodes', []) or []
+    out = []
+    for n in nodes:
+        if not n:
+            continue
+        labels = [L['name'] for L in (n.get('labels') or {}).get('nodes', []) or []]
+        out.append({'number': n['number'], 'state': n['state'], 'labels': labels})
+    return out
+
+
+def daily_issue_count(repo):
+    """Count Issues created with label auto:filed in the last 24h."""
+    cutoff = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    q = 'is:issue label:auto:filed created:>=' + cutoff
+    try:
+        results = gh_graphql_search(q, repo)
+        return len(results)
+    except Exception as e:
+        log('daily count failed (not blocking): ' + str(e))
+        return 0
+
+
+def post_status(repo, message, status_issue):
+    if not status_issue:
+        log('no STATUS_ISSUE_NUMBER set; skipping status comment')
+        return
+    stamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
+    body = '[' + stamp + '] ' + message
+    try:
+        gh_run(['issue', 'comment', str(status_issue), '-R', repo, '-b', body])
+    except Exception as e:
+        log('status post failed (not blocking): ' + str(e))
+
+
+def find_open_match(repo, check_id, sig):
+    q = 'is:issue is:open in:body "sig=' + sig + '" "check=' + check_id + '"'
+    return gh_graphql_search(q, repo)
+
+
+def find_suppressed(repo, check_id, sig):
+    q = ('is:issue is:closed label:auto:suppressed in:body '
+         '"sig=' + sig + '" "check=' + check_id + '"')
+    return gh_graphql_search(q, repo)
+
+
+def find_recent_closed(repo, check_id, sig, days):
+    cutoff = (datetime.now(timezone.utc).timestamp() - days * 86400)
+    cutoff_iso = datetime.fromtimestamp(cutoff, tz=timezone.utc).strftime('%Y-%m-%d')
+    q = ('is:issue is:closed -label:auto:suppressed in:body '
+         '"sig=' + sig + '" "check=' + check_id + '" closed:>=' + cutoff_iso)
+    return gh_graphql_search(q, repo)
+
+
+def create_issue(repo, title, body, labels):
+    args = ['issue', 'create', '-R', repo, '-t', title, '-b', body]
+    for lab in labels:
+        args.extend(['-l', lab])
+    proc = gh_run(args)
+    url = (proc.stdout or '').strip().split('\n')[-1]
+    num = url.rsplit('/', 1)[-1]
+    return num, url
+
+
+def reopen_issue(repo, number):
+    gh_run(['issue', 'reopen', str(number), '-R', repo])
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+
+    try:
+        finding = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        log('invalid JSON on stdin: ' + str(e))
+        return 1
+
+    try:
+        validate_finding(finding)
+        sig = compute_sig(finding['identity'])
+    except ValueError as e:
+        log('validation error: ' + str(e))
+        return 1
+
+    title = render_title(finding)
+    body = render_body(finding, sig)
+
+    if args.dry_run:
+        sys.stdout.write('=== DRY RUN ===\n')
+        sys.stdout.write('Title: ' + title + '\n')
+        sys.stdout.write('Sig: ' + sig + '\n')
+        sys.stdout.write('--- Body ---\n')
+        sys.stdout.write(body + '\n')
+        return 0
+
+    if not env_flag('AUTOMATION_ENABLED', True):
+        log('AUTOMATION_ENABLED=false — no-op')
+        return 0
+    if not env_flag('HYGIENE_ISSUE_CREATION_ENABLED', True):
+        log('HYGIENE_ISSUE_CREATION_ENABLED=false — no-op')
+        return 0
+
+    repo = os.environ.get('GITHUB_REPOSITORY', '').strip()
+    if not repo:
+        log('GITHUB_REPOSITORY not set')
+        return 1
+
+    status_issue = os.environ.get('STATUS_ISSUE_NUMBER', '').strip()
+    check_id = finding['check']
+
+    # Step 1: open match → no-op
+    try:
+        open_hits = find_open_match(repo, check_id, sig)
+    except Exception as e:
+        log('open-match search failed: ' + str(e))
+        return 2
+    if open_hits:
+        log('dedup: open match #' + str(open_hits[0]['number']))
+        return 0
+
+    # Step 2: suppressed closed → no-op forever
+    try:
+        suppressed = find_suppressed(repo, check_id, sig)
+    except Exception as e:
+        log('suppressed search failed: ' + str(e))
+        return 2
+    if suppressed:
+        log('dedup: suppressed #' + str(suppressed[0]['number']) + ' — never re-file')
+        return 0
+
+    # Step 3: recent closed (<=7d) without suppress → reopen
+    try:
+        recent = find_recent_closed(repo, check_id, sig, REOPEN_WINDOW_DAYS)
+    except Exception as e:
+        log('recent-closed search failed: ' + str(e))
+        return 2
+    if recent:
+        num = recent[0]['number']
+        log('dedup: reopening #' + str(num))
+        try:
+            reopen_issue(repo, num)
+            post_status(repo, 'Reopened #' + str(num) + ' (' + check_id + ' sig=' + sig + ')', status_issue)
+        except Exception as e:
+            log('reopen failed: ' + str(e))
+            return 2
+        return 0
+
+    # Step 4: rate limit check BEFORE create
+    cap = env_int('AUTOMATION_MAX_DAILY_ISSUES', 5)
+    count = daily_issue_count(repo)
+    if count >= cap:
+        log('daily cap reached (' + str(count) + '/' + str(cap) + ') — dropping finding')
+        post_status(
+            repo,
+            'DROPPED: daily cap ' + str(cap) + ' hit. check=' + check_id + ' sig=' + sig + '. '
+            'Re-fires tomorrow unless source fix lands.',
+            status_issue,
+        )
+        return 0
+
+    # Step 5: create new
+    labels = ['auto:filed']
+    extra = finding.get('extra_labels') or []
+    labels.extend([str(L) for L in extra])
+    try:
+        num, url = create_issue(repo, title, body, labels)
+    except Exception as e:
+        log('create failed: ' + str(e))
+        return 2
+    log('created #' + num + ' (' + check_id + ' sig=' + sig + ')')
+    post_status(repo, 'Created #' + num + ' (' + check_id + ' sig=' + sig + ')', status_issue)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/file_hygiene_issue.py
+++ b/.github/scripts/file_hygiene_issue.py
@@ -354,6 +354,24 @@ def main():
         )
         return 0
 
+    # Step 4.5: defensive recheck before create.
+    # gh issue list (REST) has ~3s cache lag — back-to-back invocations could
+    # both miss a just-created Issue and produce duplicates. Workflow concurrency
+    # serializes the production path, but direct CLI callers don't get that gate.
+    # Sleep + recheck closes the window cheaply (one create-path penalty).
+    recheck_seconds = env_int('FILER_PRECREATE_RECHECK_SECONDS', 4)
+    if recheck_seconds > 0:
+        import time
+        time.sleep(recheck_seconds)
+        try:
+            recheck = find_open_match(repo, check_id, sig)
+        except Exception as e:
+            log('recheck failed (proceeding to create): ' + str(e))
+            recheck = []
+        if recheck:
+            log('dedup: open match #' + str(recheck[0]['number']) + ' (caught on recheck)')
+            return 0
+
     # Step 5: create new
     labels = ['auto:filed']
     extra = finding.get('extra_labels') or []

--- a/.github/scripts/tests/fixtures/hyg06-drift-sample.json
+++ b/.github/scripts/tests/fixtures/hyg06-drift-sample.json
@@ -1,0 +1,16 @@
+{
+  "check": "version-drift",
+  "check_title": "HYG-06",
+  "title": "Version drift: DataEngine.js",
+  "identity": {
+    "check": "version-drift",
+    "file": "dataengine.js",
+    "direction": "source-ahead"
+  },
+  "evidence": {
+    "Deployed": "42",
+    "Source": "43"
+  },
+  "details": "Source code has version 43 but deployed GAS is at 42. Indicates clasp push without deploy (or a missed deploy step).",
+  "extra_labels": ["area:infra"]
+}

--- a/.github/scripts/tests/test_auto_close.py
+++ b/.github/scripts/tests/test_auto_close.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""test_auto_close.py
+Purpose: Verify pure helpers in auto_close_issues.py (marker + evidence parsing).
+         Run with:  python3 -m pytest .github/scripts/tests/ -v
+"""
+
+import pathlib
+import sys
+
+import pytest
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import file_hygiene_issue as filer  # noqa: E402
+import auto_close_issues as closer  # noqa: E402
+
+
+# ---------- parse_marker ----------
+
+def test_parse_marker_finds_check_and_sig():
+    body = 'prose\n<!-- auto-finding v=1 check=version-drift sig=abc123def4567890 -->'
+    check, sig = closer.parse_marker(body)
+    assert check == 'version-drift'
+    assert sig == 'abc123def4567890'
+
+
+def test_parse_marker_missing_returns_none():
+    check, sig = closer.parse_marker('body with no marker')
+    assert check is None and sig is None
+
+
+def test_parse_marker_empty_body():
+    check, sig = closer.parse_marker('')
+    assert check is None and sig is None
+
+
+def test_parse_marker_v2_rejected():
+    body = '<!-- auto-finding v=2 check=x sig=y -->'
+    check, sig = closer.parse_marker(body)
+    # v=2 marker should NOT match v=1 regex
+    assert check is None and sig is None
+
+
+# ---------- parse_evidence_from_body ----------
+
+def test_parse_evidence_basic():
+    body = (
+        '**Check:** HYG-06\n\n'
+        '**Evidence:**\n'
+        '- Deployed: 42\n'
+        '- Source: 43\n'
+        '\n'
+        '**Details:**\n'
+        'more stuff\n'
+    )
+    ev = closer.parse_evidence_from_body(body)
+    assert ev == {'Deployed': '42', 'Source': '43'}
+
+
+def test_parse_evidence_missing_returns_empty():
+    ev = closer.parse_evidence_from_body('no evidence section')
+    assert ev == {}
+
+
+def test_parse_evidence_stops_at_blank_line():
+    body = (
+        '**Evidence:**\n'
+        '- Deployed: 42\n'
+        '\n'
+        '- Source: 43\n'   # after blank line, should not be included
+    )
+    ev = closer.parse_evidence_from_body(body)
+    assert ev == {'Deployed': '42'}
+
+
+def test_parse_evidence_round_trip_with_render_body():
+    # Render body via filer, then parse evidence — must recover original dict
+    finding = {
+        'check': 'version-drift',
+        'check_title': 'HYG-06',
+        'title': 'Version drift: foo.js',
+        'identity': {'check': 'version-drift', 'file': 'foo.js'},
+        'evidence': {'Deployed': '42', 'Source': '43'},
+    }
+    body = filer.render_body(finding, filer.compute_sig(finding['identity']))
+    parsed = closer.parse_evidence_from_body(body)
+    assert parsed == {'Deployed': '42', 'Source': '43'}
+
+
+# ---------- registry ----------
+
+def test_register_and_lookup_detector():
+    called = {'count': 0}
+
+    def fake_detector():
+        called['count'] += 1
+        return {'abc123': {'evidence': {'k': 'v'}, 'title': 't', 'details': 'd'}}
+
+    closer.register_detector('fake-check', fake_detector)
+    assert 'fake-check' in closer.DETECTOR_REGISTRY
+    assert closer.DETECTOR_REGISTRY['fake-check']() == {
+        'abc123': {'evidence': {'k': 'v'}, 'title': 't', 'details': 'd'}
+    }
+    # Cleanup so other tests aren't polluted
+    del closer.DETECTOR_REGISTRY['fake-check']

--- a/.github/scripts/tests/test_hygiene_sigs.py
+++ b/.github/scripts/tests/test_hygiene_sigs.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""test_hygiene_sigs.py
+Purpose: Verify signature stability and body rendering for file_hygiene_issue.py.
+         Run with:  python3 -m pytest .github/scripts/tests/ -v
+Covers:
+  - Sig stability across 10 runs (identity in = identity out)
+  - Key-order invariance (sort_keys enforcement)
+  - Whitespace/case handling (normalization at compute time)
+  - Direction-field enforcement (different directions = different sigs)
+  - Missing-field raises (no silent hashing)
+  - Body rendering includes marker + footer + evidence
+"""
+
+import json
+import os
+import pathlib
+import sys
+
+import pytest
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import file_hygiene_issue as filer  # noqa: E402
+
+
+# ---------- sig stability ----------
+
+def test_sig_stable_across_10_runs():
+    identity = {
+        'check': 'version-drift',
+        'file': 'dataengine.js',
+        'direction': 'source-ahead',
+    }
+    sigs = {filer.compute_sig(dict(identity)) for _ in range(10)}
+    assert len(sigs) == 1, 'sig must be stable across runs; got: ' + str(sigs)
+
+
+def test_sig_is_16_hex_chars():
+    sig = filer.compute_sig({'check': 'x', 'file': 'a'})
+    assert len(sig) == 16
+    assert all(c in '0123456789abcdef' for c in sig)
+
+
+# ---------- key order invariance ----------
+
+def test_sig_invariant_to_key_order():
+    a = {'check': 'version-drift', 'file': 'dataengine.js', 'direction': 'source-ahead'}
+    b = {'direction': 'source-ahead', 'check': 'version-drift', 'file': 'dataengine.js'}
+    c = {'file': 'dataengine.js', 'check': 'version-drift', 'direction': 'source-ahead'}
+    assert filer.compute_sig(a) == filer.compute_sig(b) == filer.compute_sig(c)
+
+
+# ---------- whitespace + case normalization ----------
+
+def test_sig_normalizes_whitespace():
+    bare = {'check': 'version-drift', 'file': 'dataengine.js'}
+    padded = {'check': '  version-drift  ', 'file': '\tdataengine.js\n'}
+    assert filer.compute_sig(bare) == filer.compute_sig(padded)
+
+
+def test_sig_normalizes_case():
+    lower = {'check': 'version-drift', 'file': 'dataengine.js'}
+    mixed = {'check': 'Version-Drift', 'file': 'DataEngine.js'}
+    upper = {'check': 'VERSION-DRIFT', 'file': 'DATAENGINE.JS'}
+    assert filer.compute_sig(lower) == filer.compute_sig(mixed) == filer.compute_sig(upper)
+
+
+def test_sig_normalizes_key_case_and_whitespace():
+    a = {'check': 'x', 'file': 'a'}
+    b = {' CHECK ': 'x', 'File': 'a'}
+    assert filer.compute_sig(a) == filer.compute_sig(b)
+
+
+# ---------- direction field enforcement ----------
+
+def test_direction_distinguishes_sigs():
+    source_ahead = {
+        'check': 'version-drift',
+        'file': 'dataengine.js',
+        'direction': 'source-ahead',
+    }
+    deployed_ahead = {
+        'check': 'version-drift',
+        'file': 'dataengine.js',
+        'direction': 'deployed-ahead',
+    }
+    assert filer.compute_sig(source_ahead) != filer.compute_sig(deployed_ahead)
+
+
+def test_file_distinguishes_sigs():
+    a = {'check': 'version-drift', 'file': 'dataengine.js', 'direction': 'source-ahead'}
+    b = {'check': 'version-drift', 'file': 'kidshub.js', 'direction': 'source-ahead'}
+    assert filer.compute_sig(a) != filer.compute_sig(b)
+
+
+def test_check_distinguishes_sigs():
+    a = {'check': 'version-drift', 'file': 'dataengine.js'}
+    b = {'check': 'stale-branch', 'file': 'dataengine.js'}
+    assert filer.compute_sig(a) != filer.compute_sig(b)
+
+
+# ---------- missing-field + malformed input raises ----------
+
+def test_empty_identity_raises():
+    with pytest.raises(ValueError, match='non-empty'):
+        filer.compute_sig({})
+
+
+def test_missing_check_raises():
+    with pytest.raises(ValueError, match='check'):
+        filer.compute_sig({'file': 'dataengine.js'})
+
+
+def test_non_dict_identity_raises():
+    with pytest.raises(ValueError):
+        filer.compute_sig('not a dict')
+    with pytest.raises(ValueError):
+        filer.compute_sig(None)
+    with pytest.raises(ValueError):
+        filer.compute_sig(['check', 'value'])
+
+
+def test_unsupported_field_type_raises():
+    # Lists, dicts, sets as field values are not allowed — prevents ambiguous hashing
+    with pytest.raises(ValueError, match='unsupported type'):
+        filer.compute_sig({'check': 'x', 'tags': ['a', 'b']})
+    with pytest.raises(ValueError, match='unsupported type'):
+        filer.compute_sig({'check': 'x', 'nested': {'k': 'v'}})
+
+
+# ---------- numeric identity values are stable ----------
+
+def test_int_field_stable():
+    a = {'check': 'orphaned-pr', 'pr': 157}
+    b = {'check': 'orphaned-pr', 'pr': 157}
+    assert filer.compute_sig(a) == filer.compute_sig(b)
+
+
+def test_int_vs_string_differ():
+    # We intentionally do NOT coerce; 157 and "157" produce different sigs.
+    # Emitters are responsible for consistent types.
+    a = {'check': 'orphaned-pr', 'pr': 157}
+    b = {'check': 'orphaned-pr', 'pr': '157'}
+    assert filer.compute_sig(a) != filer.compute_sig(b)
+
+
+# ---------- validate_finding schema gate ----------
+
+def test_validate_finding_missing_fields():
+    with pytest.raises(ValueError, match='missing required'):
+        filer.validate_finding({'check': 'x'})
+
+
+def test_validate_finding_identity_type():
+    with pytest.raises(ValueError, match='identity must be'):
+        filer.validate_finding({
+            'check': 'x',
+            'check_title': 'HYG-X',
+            'title': 't',
+            'identity': 'not a dict',
+        })
+
+
+def test_validate_finding_accepts_complete():
+    finding = {
+        'check': 'version-drift',
+        'check_title': 'HYG-06',
+        'title': 'Version drift: foo.js',
+        'identity': {'check': 'version-drift', 'file': 'foo.js', 'direction': 'source-ahead'},
+    }
+    filer.validate_finding(finding)  # no raise
+
+
+# ---------- body rendering ----------
+
+def test_body_contains_marker():
+    finding = {
+        'check': 'version-drift',
+        'check_title': 'HYG-06',
+        'title': 'Version drift: foo.js',
+        'identity': {'check': 'version-drift', 'file': 'foo.js', 'direction': 'source-ahead'},
+    }
+    sig = filer.compute_sig(finding['identity'])
+    body = filer.render_body(finding, sig)
+    assert '<!-- auto-finding v=1 check=version-drift sig=' + sig + ' -->' in body
+
+
+def test_body_contains_footer():
+    finding = {
+        'check': 'version-drift',
+        'check_title': 'HYG-06',
+        'title': 'foo',
+        'identity': {'check': 'x'},
+    }
+    body = filer.render_body(finding, filer.compute_sig(finding['identity']))
+    assert 'auto:suppressed' in body
+    assert 'REOPEN' in body
+    assert '7 days' in body
+
+
+def test_body_contains_evidence():
+    finding = {
+        'check': 'version-drift',
+        'check_title': 'HYG-06',
+        'title': 'drift',
+        'identity': {'check': 'x'},
+        'evidence': {'Deployed': '42', 'Source': '43'},
+    }
+    body = filer.render_body(finding, 'abc123')
+    assert 'Deployed: 42' in body
+    assert 'Source: 43' in body
+
+
+def test_marker_regex_matches_rendered_body():
+    finding = {
+        'check': 'version-drift',
+        'check_title': 'HYG-06',
+        'title': 'foo',
+        'identity': {'check': 'x', 'file': 'y'},
+    }
+    sig = filer.compute_sig(finding['identity'])
+    body = filer.render_body(finding, sig)
+    m = filer.MARKER_RE.search(body)
+    assert m is not None
+    assert m.group(1) == 'version-drift'
+    assert m.group(2) == sig
+
+
+# ---------- title rendering ----------
+
+def test_title_prefix():
+    finding = {
+        'check': 'version-drift',
+        'check_title': 'HYG-06',
+        'title': 'Version drift: DataEngine.js',
+        'identity': {'check': 'x'},
+    }
+    assert filer.render_title(finding) == '[HYG-06] Version drift: DataEngine.js'

--- a/.github/scripts/tests/test_hygiene_sigs.py
+++ b/.github/scripts/tests/test_hygiene_sigs.py
@@ -237,3 +237,52 @@ def test_title_prefix():
         'identity': {'check': 'x'},
     }
     assert filer.render_title(finding) == '[HYG-06] Version drift: DataEngine.js'
+
+
+# ---------- dedup helper: issue_marker_matches ----------
+# Regression for sandbox drill 2026-04-15: GraphQL search had indexing lag, so
+# dedup now uses REST list + client-side body-marker grep. These tests cover
+# the client-side matcher directly.
+
+def test_issue_marker_matches_positive():
+    issue = {'body': 'foo\n<!-- auto-finding v=1 check=version-drift sig=abc123def4567890 -->\n'}
+    assert filer.issue_marker_matches(issue, 'version-drift', 'abc123def4567890')
+
+
+def test_issue_marker_matches_wrong_sig():
+    issue = {'body': '<!-- auto-finding v=1 check=version-drift sig=ZZZZZZZZZZZZZZZZ -->'}
+    assert not filer.issue_marker_matches(issue, 'version-drift', 'abc123def4567890')
+
+
+def test_issue_marker_matches_wrong_check():
+    issue = {'body': '<!-- auto-finding v=1 check=stale-branch sig=abc123def4567890 -->'}
+    assert not filer.issue_marker_matches(issue, 'version-drift', 'abc123def4567890')
+
+
+def test_issue_marker_matches_no_marker():
+    issue = {'body': 'plain text issue with no marker at all'}
+    assert not filer.issue_marker_matches(issue, 'version-drift', 'abc123def4567890')
+
+
+def test_issue_marker_matches_empty_body():
+    assert not filer.issue_marker_matches({'body': ''}, 'x', 'y')
+    assert not filer.issue_marker_matches({'body': None}, 'x', 'y')
+
+
+def test_issue_marker_matches_v2_marker_rejected():
+    issue = {'body': '<!-- auto-finding v=2 check=version-drift sig=abc123def4567890 -->'}
+    assert not filer.issue_marker_matches(issue, 'version-drift', 'abc123def4567890')
+
+
+def test_issue_marker_matches_round_trip_with_render_body():
+    finding = {
+        'check': 'version-drift',
+        'check_title': 'HYG-06',
+        'title': 'drift',
+        'identity': {'check': 'version-drift', 'file': 'foo.js', 'direction': 'source-ahead'},
+    }
+    sig = filer.compute_sig(finding['identity'])
+    body = filer.render_body(finding, sig)
+    issue = {'body': body}
+    assert filer.issue_marker_matches(issue, 'version-drift', sig)
+    assert not filer.issue_marker_matches(issue, 'version-drift', 'deadbeefdeadbeef')

--- a/.github/workflows/hygiene-filer.yml
+++ b/.github/workflows/hygiene-filer.yml
@@ -1,0 +1,70 @@
+# .github/workflows/hygiene-filer.yml
+# Reusable filer workflow — accepts a finding JSON and invokes file_hygiene_issue.py.
+# Called by:
+#   - Hygiene workflows via `gh workflow run hygiene-filer.yml -f finding='<json>'`
+#   - workflow_call from another workflow (same inputs)
+#   - workflow_dispatch for manual testing
+# Concurrency: single-writer across all callers — prevents duplicate Issues
+#   when two hygiene workflows detect the same finding within the same window.
+
+name: Hygiene Filer (reusable)
+
+on:
+  workflow_dispatch:
+    inputs:
+      finding:
+        description: 'Finding JSON string (see file_hygiene_issue.py schema)'
+        required: true
+        type: string
+      dry_run:
+        description: 'If true, render body but do not create/modify Issues'
+        required: false
+        default: 'false'
+        type: string
+  workflow_call:
+    inputs:
+      finding:
+        required: true
+        type: string
+      dry_run:
+        required: false
+        default: 'false'
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hygiene-issue-filer
+  cancel-in-progress: false
+
+jobs:
+  file-issue:
+    name: File hygiene Issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ vars.AUTOMATION_ENABLED != 'false' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Invoke filer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          AUTOMATION_ENABLED: ${{ vars.AUTOMATION_ENABLED }}
+          HYGIENE_ISSUE_CREATION_ENABLED: ${{ vars.HYGIENE_ISSUE_CREATION_ENABLED }}
+          AUTOMATION_MAX_DAILY_ISSUES: ${{ vars.AUTOMATION_MAX_DAILY_ISSUES }}
+          STATUS_ISSUE_NUMBER: ${{ vars.STATUS_ISSUE_NUMBER }}
+          FINDING_JSON: ${{ inputs.finding }}
+          DRY_RUN_FLAG: ${{ inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN_FLAG" = "true" ]; then
+            printf '%s' "$FINDING_JSON" | python3 .github/scripts/file_hygiene_issue.py --dry-run
+          else
+            printf '%s' "$FINDING_JSON" | python3 .github/scripts/file_hygiene_issue.py
+          fi
+          # If AUTOMATION_ENABLED=false, this job is skipped entirely by the job-level
+          # `if` guard above — no notice step needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,29 @@ HTML modules served via Cloudflare use the `google.script.run` shim which POSTs 
 | Lock acquisition | `waitLock(30000)` — NEVER `tryLock()` |
 | Smoke + regression | Code.gs → `?action=runTests` returns combined JSON |
 | New `google.script.run` call | Must have `withFailureHandler()`. Must add Safe wrapper to smoke test check. Must run audit-source.sh. |
+| Hygiene finding → Issue | `.github/scripts/file_hygiene_issue.py` via `.github/workflows/hygiene-filer.yml`. Emitter passes structured finding JSON; filer dedups by marker and files or reopens. |
+
+---
+
+## Hygiene Automation — Issue Filer (Phase 1)
+
+Hygiene workflows (HYG-*) that detect findings can file dedup'd GitHub Issues via the shared filer at `.github/workflows/hygiene-filer.yml`. The filer identifies findings by a signature hidden in the Issue body — **never** by title (titles are human-editable):
+
+```
+<!-- auto-finding v=1 check=<check-id> sig=<16-hex> -->
+```
+
+The signature is `sha256` over a canonical `identity` dict (keys and string values stripped + lowercased, keys sorted) — **never** over volatile fields like `age_days` or byte counts. Identity captures the problem, not its current measurement.
+
+**Dedup search order** (open → suppressed → recent closed → new):
+1. Any OPEN Issue matches → no-op
+2. Any CLOSED Issue with `auto:suppressed` label → no-op forever (LT rejected)
+3. Any CLOSED Issue within 7 days without `auto:suppressed` → reopen
+4. Otherwise → create new Issue with `auto:filed` label
+
+**Kill switches** (all ≤60s): `vars.AUTOMATION_ENABLED=false` (master), `vars.HYGIENE_ISSUE_CREATION_ENABLED=false` (filer only), disable `hygiene-filer.yml` workflow in UI. Filer diagnostics post to the pinned filer-status Issue (`vars.STATUS_ISSUE_NUMBER`).
+
+Phase 1 scope: one pilot check (HYG-06 version drift). Phase 2+ is out of scope — this system files Issues only, no auto-PRs.
 
 ---
 


### PR DESCRIPTION
Closes #341
Parent EPIC: #340
Plan: `~/.claude/plans/purrfect-drifting-fiddle.md` (approved)

## What shipped

Phase 0 foundation for dedup'd Issue filing from hygiene detectors. **No user-visible automation** — safety default `HYGIENE_ISSUE_CREATION_ENABLED=false` means nothing fires until LT flips it in Phase 1.

| Component | Path | Purpose |
|---|---|---|
| P0-1 filer | `.github/scripts/file_hygiene_issue.py` | 4-step dedup, `--dry-run` mode, v=1 marker, standard footer |
| P0-2 auto-close | `.github/scripts/auto_close_issues.py` | Detector registry (empty in P0); closes resolved Issues; live-updates evidence (D5=a) |
| P0-3 tests | `.github/scripts/tests/test_*.py` | 32 tests — sig stability, key-order, whitespace, direction, missing-field, evidence round-trip |
| P0-4 workflow | `.github/workflows/hygiene-filer.yml` | Reusable workflow, `concurrency: hygiene-issue-filer` single-writer, `AUTOMATION_ENABLED` guard |
| P0-5 labels | repo settings | `auto:filed`, `auto:suppressed`, `auto-close:resolved`, `auto-close:unverified`, `automation:paused` |
| P0-6 vars | repo settings | `AUTOMATION_ENABLED=true`, `HYGIENE_ISSUE_CREATION_ENABLED=false`, `AUTOMATION_MAX_DAILY_ISSUES=5`, `STATUS_ISSUE_NUMBER=342` |
| P0-7 pinned | Issue #342 | Filer diagnostics land here |
| P0-8 docs | `CLAUDE.md` | New Hygiene Automation section + Pattern Registry row (Opus-authored per governance) |

## Locked decisions applied

- D1=(a) reusable workflow pattern — hygiene-filer.yml is `workflow_dispatch` + `workflow_call`
- D2=(b) 16-hex sha256 — readable in Issue search UI
- D3=(a) reopen-within-7d — `auto:suppressed` blocks forever
- D4=(a) one pinned filer-status Issue — #342
- D5=(a) live-updated evidence fields — auto-close cron updates body in place when values change

## 🚨 LT review needed — R6 footer text

**Please read this footer text carefully.** It ships in every auto-filed Issue and is the R6 mitigation (prevents surprise when reopen happens on next cron):

> ---
> Filed by hygiene automation. I dedup by the hidden marker below — editing this title is safe. If you close this Issue without adding the `auto:suppressed` label, I WILL REOPEN it on the next run if the finding still exists (within 7 days). Apply `auto:suppressed` to permanently dismiss.

**If the wording is clear, comment `footer approved` on this PR.** Non-optional per P0→P1 stop-gate.

## Stop-gate drills already executed

- [x] 32 unit tests pass locally — `python3 -m pytest .github/scripts/tests/ -v`
- [x] Dry-run renders expected body for `hyg06-drift-sample.json` fixture
- [x] Kill-switch drill: `AUTOMATION_ENABLED=false` → filer short-circuits with `[filer] AUTOMATION_ENABLED=false — no-op`
- [x] Second kill switch: `HYGIENE_ISSUE_CREATION_ENABLED=false` → same short-circuit
- [x] `auto_close_issues.py` with empty registry → `[auto-close] no detectors registered (Phase 0 state) — nothing to reconcile`
- [x] `bash audit-source.sh` → PASS (workflow YAML lint + Python compile both green on staged files)

## Still required before P0 declared complete (LT actions)

- [x] **P0-0**: LT creates `blucsigma05/tbm-automation-sandbox` (or renames sandbox), sets `gh variable set AUTOMATION_SANDBOX_REPO --body "<name>"`. Required for R10 mitigation.
- [x] **Sandbox integration drill**: after sandbox exists, LT (or Claude in follow-up session) exercises all 4 dedup branches (new/open-match/suppressed/reopen) against sandbox. Cleanup after.
- [x] **Footer sign-off**: LT comments `footer approved` on this PR.
- [ ] **Merge this PR** (branch protection: 1 review + CI green).

## What's explicitly out of scope

Auto-PR, RemoteTrigger, issue-watcher, bot user, branch protection rules for bot PRs, model routing, budget cap workflow, Yellow-tier promotion, `hot-files.json` contents. All deferred to Phase 2+ after Phase 1 produces observation data.

## Review focus

1. **Footer text** (R6) — see above
2. **Signature fields** in `compute_sig()` — normalization intentional
3. **Dedup search queries** in `file_hygiene_issue.py` — GraphQL syntax, check quoting
4. **Workflow concurrency group** — `hygiene-issue-filer` serializes all callers
5. **CLAUDE.md section** — placement + tone (under Pattern Registry, before File Map)