### PR TITLE
fix: kill fake-data fallbacks — error instead of PRACTICE MODE sticker (#348)

### DIFF
--- a/Alertenginev1.js
+++ b/Alertenginev1.js
@@ -1,12 +1,12 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// AlertEngine.gs v11 — Push Notifications via Pushover API
+// AlertEngine.gs v12 — Push Notifications via Pushover API
 // WRITES TO: (Pushover API only — no sheet writes)
 // READS FROM: 💻🧮 Helpers (for config)
 // Replaces dead AT&T email-to-SMS gateway (killed June 17, 2025)
 // ════════════════════════════════════════════════════════════════════
 
-function getAlertEngineVersion() { return 11; }
+function getAlertEngineVersion() { return 12; }
 
 // v4: openById migration — trigger-safe spreadsheet accessor
 var _aeSS = null;
@@ -649,22 +649,28 @@ function dailyHealthCheck() {
   // v11: Homework module shape check — fires SYSTEM_ERROR if any child's module is broken
   try {
     var hwChildren = ['buggsy', 'jj'];
+    var validators = [
+      { name: 'Homework', fn: typeof validateHomeworkShape_ === 'function' ? validateHomeworkShape_ : null },
+      { name: 'Reading',  fn: typeof validateReadingShape_  === 'function' ? validateReadingShape_  : null },
+      { name: 'Writing',  fn: typeof validateWritingShape_  === 'function' ? validateWritingShape_  : null }
+    ];
     for (var hc = 0; hc < hwChildren.length; hc++) {
-      if (typeof validateHomeworkShape_ === 'function') {
-        var hwResult = validateHomeworkShape_(hwChildren[hc]);
-        if (!hwResult.valid) {
+      for (var v = 0; v < validators.length; v++) {
+        if (!validators[v].fn) continue;
+        var checkResult = validators[v].fn(hwChildren[hc]);
+        if (!checkResult.valid) {
           sendPush_(
-            'Homework broken: ' + hwResult.child,
-            'Missing: ' + hwResult.missing.join(', ') + '. Fix before kids wake up.',
+            validators[v].name + ' broken: ' + checkResult.child,
+            'Missing: ' + checkResult.missing.join(', ') + '. Fix before kids wake up.',
             'LT',
             PUSHOVER_PRIORITY.SYSTEM_ERROR
           );
-          logError_('dailyHealthCheck', 'Homework shape invalid for ' + hwResult.child, hwResult.missing);
+          logError_('dailyHealthCheck', validators[v].name + ' shape invalid for ' + checkResult.child, checkResult.missing);
         }
       }
     }
   } catch(e) {
-    console.log('dailyHealthCheck homework shape check failed: ' + e.message);
+    console.log('dailyHealthCheck education shape check failed: ' + e.message);
   }
 
   // Send all accumulated alerts
@@ -740,5 +746,5 @@ function checkTillerFreshness_() {
 }
 
 // ════════════════════════════════════════════════════════════════════
-// END OF FILE — AlertEngine v11
+// END OF FILE — AlertEngine v12
 // ════════════════════════════════════════════════════════════════════

--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="homework-module">
-<meta name="tbm-version" content="v16">
+<meta name="tbm-version" content="v17">
 <title>Wolfkid Training Module</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -1043,181 +1043,9 @@ var KNOWN_QUESTION_TYPES = [
 
 // ─── MODULE DATA ───
 var MODULE = null;
-var _usingFallback = false;
 
-// v16 (#345) — Visible signal when surface falls back / fails to load real curriculum.
-// Always-on banner so QA can detect silent fallback without DevTools.
-function _showFallbackBadge_() {
-  if (typeof document === 'undefined' || !document.body) { return; }
-  if (document.getElementById('_tbm_fallback_badge')) { return; }
-  var b = document.createElement('div');
-  b.id = '_tbm_fallback_badge';
-  b.textContent = '\u26A0 PRACTICE MODE \u2014 Today\u2019s lesson didn\u2019t load. Rings won\u2019t be earned.';
-  b.style.cssText = 'position:fixed;top:0;left:0;right:0;background:#f59e0b;color:#000;'
-    + 'padding:6px 12px;font:600 13px/1.4 system-ui,sans-serif;text-align:center;'
-    + 'z-index:99999;box-shadow:0 1px 4px rgba(0,0,0,0.3);';
-  document.body.appendChild(b);
-  document.body.style.paddingTop = '28px';
-}
+// v17 (#348) — Badge removed and _usingFallback dead-code stripped. Curriculum-or-error.
 
-// v14: FALLBACK_MODULE deleted — redirect to daily-missions instead
-var _FALLBACK_STUB = {
-  science: {
-    strand: "deleted",
-    teks: "4.7A \u2014 Forces (gravity, friction, magnetism)",
-    title: "Mission Briefing: The Physics of the Chase",
-    quickFact: "A wolf can run at speeds up to 40 mph, but friction between its paws and the ground is what lets it turn corners without sliding. Without friction, even the fastest wolf would just... keep sliding.",
-    passage: [
-      "Forces are pushes or pulls that act on objects. Some forces require contact \u2014 like when you push a door open or friction slows down a rolling ball. Other forces work at a distance \u2014 gravity pulls you toward Earth even though the ground isn\u2019t touching you, and a magnet can attract a paperclip without touching it.",
-      "Gravity is the force that pulls everything toward the center of Earth. It\u2019s why a basketball comes back down after you throw it, and why you don\u2019t float off the playground. The strength of gravity depends on mass \u2014 Earth has a lot of mass, so its gravitational pull is strong.",
-      "Friction is the force that resists motion when two surfaces rub together. Rough surfaces create more friction than smooth ones. Friction can be helpful \u2014 it lets your shoes grip the floor so you don\u2019t slip. But it can also slow things down, like when a rolling skateboard eventually stops.",
-      "Magnetism is a force that can attract or repel certain materials (like iron and steel) without touching them. Every magnet has a north pole and a south pole. Opposite poles attract each other, and matching poles push apart."
-    ],
-    questions: [
-      {
-        id: 1,
-        type: "multiple_choice",
-        teks: "4.7A",
-        difficulty: "Easy",
-        question: "Which of these is an example of a force acting at a DISTANCE (without contact)?",
-        options: [
-          "A) Kicking a soccer ball",
-          "B) A magnet pulling a paperclip across a table",
-          "C) Pushing a shopping cart",
-          "D) Rubbing your hands together"
-        ],
-        answer: 1,
-        explanation: "Magnetism is a non-contact force \u2014 the magnet can pull the paperclip without touching it. The other options all require direct contact."
-      },
-      {
-        id: 2,
-        type: "multiple_choice",
-        teks: "4.7A",
-        difficulty: "Medium",
-        question: "Wolfkid is chasing Hex across the gym floor. He\u2019s running fast, then hits a patch of water and starts sliding. What happened to the friction?",
-        options: [
-          "A) Friction increased because water is heavier than air",
-          "B) Friction decreased because the water made the surface smoother",
-          "C) Gravity pulled Wolfkid sideways",
-          "D) The magnetic force between his shoes and the floor changed"
-        ],
-        answer: 1,
-        explanation: "Water reduces friction between surfaces. Less friction = less grip = sliding. This is why wet floors have warning signs!"
-      },
-      {
-        id: 3,
-        type: "multiple_choice",
-        teks: "4.7A",
-        difficulty: "Medium",
-        question: "A student drops a ball from a second-floor window. Which force pulls the ball toward the ground?",
-        options: [
-          "A) Friction",
-          "B) Magnetism",
-          "C) Gravity",
-          "D) Air resistance only"
-        ],
-        answer: 2,
-        explanation: "Gravity is the force that pulls objects toward Earth\u2019s center. It acts on everything with mass, which is why dropped objects fall."
-      },
-      {
-        id: 4,
-        type: "short_answer",
-        teks: "4.7A",
-        difficulty: "Medium",
-        question: "Hex slides a book across the table. It slows down and stops. Name the force that stopped it, and explain whether this is a contact or non-contact force.",
-        sampleAnswer: "Friction stopped the book. Friction is a contact force because it happens when two surfaces (the book and the table) rub against each other."
-      },
-      {
-        id: 5,
-        type: "multiple_choice",
-        teks: "4.7A",
-        difficulty: "Medium",
-        question: "Look at this data table:\n\nSurface | Distance ball rolled\nTile floor | 8 feet\nCarpet | 3 feet\nSandpaper | 1 foot\nIce | 15 feet\n\nWhich conclusion is BEST supported by this data?",
-        options: [
-          "A) Gravity is stronger on carpet than ice",
-          "B) Smoother surfaces have less friction, so the ball rolls farther",
-          "C) The ball was pushed harder on the tile floor",
-          "D) Magnetism affected the ball on sandpaper"
-        ],
-        answer: 1,
-        explanation: "The data shows the ball rolled farther on smoother surfaces (ice, tile) and shorter on rougher surfaces (carpet, sandpaper). This pattern supports the conclusion about friction."
-      },
-      {
-        id: 6,
-        type: "why_question",
-        teks: "4.7A",
-        difficulty: "Hard",
-        question: "If you were designing shoes for Wolfkid to wear during a chase scene on a rainy day, would you make the soles smooth or rough? Explain WHY using what you know about friction.",
-        sampleAnswer: "Rough soles, because rough surfaces create more friction. On a rainy day, water reduces friction, so Wolfkid needs extra grip from rougher soles to keep from slipping during the chase."
-      }
-    ]
-  },
-  math: {
-    strand: "Number and Operations \u2014 Fractions",
-    teks: "4.3A-D \u2014 Representing and Comparing Fractions",
-    title: "Code Cracker: Fraction Intelligence",
-    questions: [
-      {
-        id: 7,
-        type: "computation",
-        teks: "4.3C",
-        difficulty: "Easy",
-        question: "What fraction is equivalent to 2/4?",
-        options: ["A) 1/3", "B) 1/2", "C) 3/4", "D) 2/8"],
-        answer: 1,
-        explanation: "2/4 can be simplified by dividing both numerator and denominator by 2: 2\u00f72 = 1, 4\u00f72 = 2. So 2/4 = 1/2."
-      },
-      {
-        id: 8,
-        type: "word_problem",
-        teks: "4.3E",
-        difficulty: "Medium",
-        question: "Wolfkid and Hex are splitting lookout duty. Wolfkid takes 3/8 of the shift. Hex takes 2/8 of the shift. What fraction of the shift have they covered together?",
-        options: ["A) 5/16", "B) 5/8", "C) 1/8", "D) 6/8"],
-        answer: 1,
-        explanation: "When adding fractions with the same denominator, add the numerators: 3/8 + 2/8 = 5/8. The denominator stays the same."
-      },
-      {
-        id: 9,
-        type: "visual",
-        teks: "4.3A",
-        difficulty: "Easy",
-        question: "Which symbol makes this statement true?\n\n    1/3  ___  1/2",
-        options: ["A) >", "B) <", "C) ="],
-        answer: 1,
-        explanation: "1/3 is less than 1/2. Think of it this way: if you cut a pizza into 3 pieces, each piece is smaller than if you cut it into 2 pieces."
-      },
-      {
-        id: 10,
-        type: "error_analysis",
-        teks: "4.3D",
-        difficulty: "Hard",
-        question: "A student said: \"3/4 is less than 5/8 because 4 is less than 8.\"\n\nIs this correct? Explain the mistake.",
-        sampleAnswer: "No, this is wrong. You can\u2019t just compare denominators. 3/4 = 6/8 when you find a common denominator. Since 6/8 > 5/8, the student\u2019s answer is incorrect. A larger denominator actually means smaller pieces, not a bigger fraction."
-      },
-      {
-        id: 11,
-        type: "multi_step",
-        teks: "4.3E,4.3D",
-        difficulty: "Hard",
-        question: "Hex intercepted a coded message. It was split into 3 parts. Part 1 is 2/6 of the message. Part 2 is 1/6 of the message. How much of the message is still missing?",
-        options: ["A) 3/6", "B) 1/6", "C) 4/6", "D) 2/6"],
-        answer: 0,
-        explanation: "First add what they have: 2/6 + 1/6 = 3/6. The whole message = 6/6. Missing = 6/6 - 3/6 = 3/6 (which equals 1/2)."
-      },
-      {
-        id: 12,
-        type: "real_world",
-        teks: "4.3A",
-        difficulty: "Medium",
-        question: "You earned 15 Rings this week. You want to save 1/3 of them and spend the rest. How many Rings do you save?",
-        options: ["A) 3 Rings", "B) 5 Rings", "C) 10 Rings", "D) 7 Rings"],
-        answer: 1,
-        explanation: "1/3 of 15 = 15 \u00f7 3 = 5 Rings saved. This connects fractions to real-world decisions about money! (And yes, this is basically how your Ring economy works.)"
-      }
-    ]
-  }
-};
 
 // ─── COLORS ───
 var C = {
@@ -1497,13 +1325,6 @@ function getCompletionStatusMarkup_() {
       showRetry: true
     };
   }
-  if (_usingFallback) {
-    return {
-      message: 'Practice mode only. This session is not being sent to the homework queue.',
-      style: 'background:rgba(148,163,184,0.10);border:1px solid rgba(148,163,184,0.25);color:#CBD5E1;',
-      showRetry: false
-    };
-  }
   return {
     message: 'Preparing final save...',
     style: 'background:rgba(148,163,184,0.10);border:1px solid rgba(148,163,184,0.25);color:#CBD5E1;',
@@ -1531,13 +1352,6 @@ function submitHomeworkCompletion_() {
     completionSubmitError = '';
     updateCompletionSaveStatusUi_();
     clearHomeworkDraft_();
-    return;
-  }
-  if (_usingFallback) {
-    completionSubmitState = 'idle';
-    completionSubmitError = '';
-    updateCompletionSaveStatusUi_();
-    saveHomeworkDraft_();
     return;
   }
 
@@ -1848,7 +1662,7 @@ function submitAnswer(qId) {
 
   // Log per-question result to QuestionLog for mastery tracking (#161)
   // Only log MC (auto-graded) questions — open-ended have correct=true hardcoded which inflates accuracy
-  if (isMC && !TBM_TEST_MODE && !_usingFallback && typeof google !== 'undefined' && google.script && google.script.run) {
+  if (isMC && !TBM_TEST_MODE && typeof google !== 'undefined' && google.script && google.script.run) {
     google.script.run
       .withSuccessHandler(function() {})
       .withFailureHandler(function(err) { console.error('QuestionLog failed:', err); })
@@ -2270,8 +2084,6 @@ function showLoadError_(reason) {
 function loadCurriculumContent() {
   if (typeof google === 'undefined' || !google.script || !google.script.run) {
     console.warn('[TBM FALLBACK] HomeworkModule \u2014 reason: no google.script.run available');
-    _usingFallback = true;
-    _showFallbackBadge_();
     showLoadError_('offline');
     return;
   }
@@ -2308,13 +2120,14 @@ function loadCurriculumContent() {
           MODULE.math.title     = MODULE.math.title     || '';
           MODULE.math.questions = MODULE.math.questions || [];
           MODULE.date = MODULE.date || '';
-          // v16 (#345) — Detect normalized-but-empty case: questions exist but enrichment fields are blank.
+          // v17 (#348) — Detect normalized-but-empty case: questions exist but enrichment fields blank.
+          // No badge — render a hard error instead of letting kids see questions with no passage/strand/teks.
           var mathHasContext = (MODULE.math.passage.length > 0) || MODULE.math.quickFact || MODULE.math.strand || MODULE.math.teks;
           var sciHasContext  = (MODULE.science.passage.length > 0) || MODULE.science.quickFact || MODULE.science.strand || MODULE.science.teks;
           if (!mathHasContext || !sciHasContext) {
             console.warn('[TBM FALLBACK] HomeworkModule \u2014 reason: questions present but enrichment fields empty (math context=' + !!mathHasContext + ', sci context=' + !!sciHasContext + ')');
-            _usingFallback = true;
-            _showFallbackBadge_();
+            showLoadError_('no-content');
+            return;
           }
           init();
         } else if (c.review_quiz && c.review_quiz.length > 0) {
@@ -2329,15 +2142,11 @@ function loadCurriculumContent() {
         }
       } else {
         console.warn('[TBM FALLBACK] HomeworkModule \u2014 reason: getTodayContentSafe returned empty/missing content');
-        _usingFallback = true;
-        _showFallbackBadge_();
         showLoadError_('no-content');
       }
     })
     .withFailureHandler(function(err) {
       console.warn('[TBM FALLBACK] HomeworkModule \u2014 reason: getTodayContentSafe failed: ' + (err && err.message ? err.message : 'unknown'));
-      _usingFallback = true;
-      _showFallbackBadge_();
       showLoadError_('load-error');
     })
     .getTodayContentSafe('buggsy');

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -1,11 +1,11 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// KidsHub.gs v69 — Kids Hub Server Backend (TBM Consolidated)
+// KidsHub.gs v70 — Kids Hub Server Backend (TBM Consolidated)
 // WRITES TO: 🧹📅 KH_Chores, 🧹📅 KH_History, 🧹📅 KH_Rewards, 🧹📅 KH_Redemptions, 🧹📅 KH_Requests, 🧹📅 KH_ScreenTime, 🧹📅 KH_Grades, 🧹📅 KH_Education, 🧹📅 KH_PowerScan, 🧹📅 KH_MissionState, 🧹📅 KH_LessonRuns, 💻 Curriculum, 💻 QuestionLog, 💻 MealPlan
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 69; }
+function getKidsHubVersion() { return 70; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -2636,7 +2636,7 @@ function normalizeModule_(mod) {
 // v69: Validates that all 6 required module fields are present and populated.
 // Called by dailyHealthCheck() to alert LT before kids wake up.
 function validateHomeworkShape_(child) {
-  var result = { valid: true, missing: [], child: String(child) };
+  var result = { valid: true, missing: [], child: String(child), surface: 'homework' };
   var resp = getTodayContent_(child);
   if (!resp || !resp.content || !resp.content.module) {
     result.valid = false;
@@ -2655,6 +2655,47 @@ function validateHomeworkShape_(child) {
       }
     }
   }
+  return result;
+}
+
+// v70 (#348) — Validate reading-module curriculum shape.
+// Surface needs response.content.cold_passage with title + (paragraphs[] OR passage/text) + questions[].
+// If cold_passage is absent, treat as valid — non-reading day, other surfaces handle today.
+function validateReadingShape_(child) {
+  var result = { valid: true, missing: [], child: String(child), surface: 'reading' };
+  var resp = getTodayContent_(child);
+  if (!resp || !resp.content) {
+    result.valid = false;
+    result.missing.push('content missing entirely');
+    return result;
+  }
+  if (!resp.content.cold_passage) {
+    return result;
+  }
+  var cp = resp.content.cold_passage;
+  if (!cp.title) { result.valid = false; result.missing.push('cold_passage.title'); }
+  var hasParagraphs = (cp.paragraphs && cp.paragraphs.length > 0) || cp.passage || cp.text;
+  if (!hasParagraphs) { result.valid = false; result.missing.push('cold_passage.paragraphs (or passage/text)'); }
+  var hasQuestions = (cp.questions && cp.questions.length > 0);
+  if (!hasQuestions) { result.valid = false; result.missing.push('cold_passage.questions'); }
+  return result;
+}
+
+// v70 (#348) — Validate writing-module curriculum shape.
+// Surface needs response.content.quick_write.prompt. If quick_write absent, treat as valid (non-writing day).
+function validateWritingShape_(child) {
+  var result = { valid: true, missing: [], child: String(child), surface: 'writing' };
+  var resp = getTodayContent_(child);
+  if (!resp || !resp.content) {
+    result.valid = false;
+    result.missing.push('content missing entirely');
+    return result;
+  }
+  if (!resp.content.quick_write) {
+    return result;
+  }
+  var qw = resp.content.quick_write;
+  if (!qw.prompt) { result.valid = false; result.missing.push('quick_write.prompt'); }
   return result;
 }
 
@@ -5216,5 +5257,5 @@ function checkHomeworkGateSafe(child) {
   });
 }
 
-// END OF FILE — KidsHub.gs v69
+// END OF FILE — KidsHub.gs v70
 // ════════════════════════════════════════════════════════════════════

--- a/reading-module.html
+++ b/reading-module.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="reading-module">
-<meta name="tbm-version" content="v8">
+<meta name="tbm-version" content="v9">
 <title>Wolfkid Reading Module</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -1013,117 +1013,33 @@ function endBrainBreak() {
 
 var _dayOfWeek = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'][new Date().getDay()];
 
-var MODULE_VERSION = 'v8';
+var MODULE_VERSION = 'v9';
 var CHILD = 'buggsy';
-var _usingFallback = false;
 
-// v8 (#345) — Visible signal when surface falls back / fails to load real curriculum.
-// Always-on banner so QA can detect silent fallback without DevTools.
-function _showFallbackBadge_() {
-  if (typeof document === 'undefined' || !document.body) { return; }
-  if (document.getElementById('_tbm_fallback_badge')) { return; }
-  var b = document.createElement('div');
-  b.id = '_tbm_fallback_badge';
-  b.textContent = '\u26A0 PRACTICE MODE \u2014 Today\u2019s lesson didn\u2019t load. Rings won\u2019t be earned.';
-  b.style.cssText = 'position:fixed;top:0;left:0;right:0;background:#f59e0b;color:#000;'
-    + 'padding:6px 12px;font:600 13px/1.4 system-ui,sans-serif;text-align:center;'
-    + 'z-index:99999;box-shadow:0 1px 4px rgba(0,0,0,0.3);';
-  document.body.appendChild(b);
-  document.body.style.paddingTop = '28px';
+// v9 (#348) — No fallback content. If curriculum doesn't load we render an error screen, not a fake essay.
+function showLoadError_(reason) {
+  var msg = 'Having trouble loading today\u2019s reading.';
+  if (reason === 'offline') { msg = 'Cannot reach the server right now.'; }
+  var body = document.body;
+  if (!body) { return; }
+  body.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;'
+    + 'min-height:100vh;background:#0B0F1A;color:#E2E8F0;font-family:Nunito,sans-serif;'
+    + 'flex-direction:column;gap:16px;padding:20px;text-align:center;">'
+    + '<div style="font-size:48px;">&#9888;&#65039;</div>'
+    + '<div style="font-family:Orbitron,sans-serif;font-size:18px;color:#F59E0B;'
+    + 'letter-spacing:2px;">READING LOAD FAILED</div>'
+    + '<div style="font-size:16px;max-width:400px;">' + msg + '</div>'
+    + '<div style="font-size:13px;color:#94a3b8;max-width:360px;">Tell Mom or Dad. They\u2019ll fix it.</div>'
+    + '<button onclick="window.location.reload()" style="margin-top:12px;padding:12px 32px;'
+    + 'background:#F59E0B;color:#0B0F1A;border:none;border-radius:8px;font-family:Orbitron,sans-serif;'
+    + 'font-size:14px;font-weight:700;cursor:pointer;letter-spacing:1px;">TRY AGAIN</button>'
+    + '</div>';
 }
 
 // ─── PASSAGE DATA ───
+// v9 (#348) — FALLBACK_PASSAGE + FALLBACK_QUESTIONS deleted. Curriculum-or-error.
 var PASSAGE = null;
 var QUESTIONS = null;
-var FALLBACK_PASSAGE = {
-  title: 'The Deep Ocean',
-  paragraphs: [
-    'The ocean is the largest habitat on Earth, covering more than 70 percent of the planet\'s surface. Most people are familiar with the shallow waters near the shore, where sunlight brightens the sandy bottom and waves lap against the beach. But the ocean is far deeper than most people realize. In some places, it plunges nearly seven miles below the surface. Scientists divide the ocean into distinct zones based on how much sunlight reaches each depth, and the deeper you go, the more alien the world becomes.',
-    'The sunlight zone is the top layer of the ocean, stretching from the surface down to about 656 feet. This is where most ocean life exists. Sunlight floods this zone, allowing tiny plants called phytoplankton to grow. These microscopic organisms produce more than half of the world\'s oxygen through photosynthesis. Fish, dolphins, sea turtles, and sharks all thrive here because food is plentiful. The water is warm and bright, making it the most hospitable part of the ocean.',
-    'Below the sunlight zone lies the twilight zone, which extends from about 656 feet to 3,280 feet deep. Only a faint blue glow of light reaches this region. The water grows colder, and the pressure increases. Many creatures here have developed bioluminescence, meaning they can produce their own light. Lanternfish, jellyfish, and squid use glowing body parts to attract prey, communicate, or confuse predators. Food is scarcer in the twilight zone, so animals must descend to darker waters or wait for scraps to drift down from above.',
-    'The midnight zone begins at about 3,280 feet and extends to roughly 13,000 feet. No sunlight penetrates this deep. The water temperature hovers just above freezing, and the pressure is crushing. Despite these extreme conditions, life persists. Giant squid, anglerfish with their eerie glowing lures, and strange tube worms cluster around hydrothermal vents on the ocean floor. These vents release superheated water and minerals from deep within the Earth, supporting entire ecosystems without any sunlight at all.',
-    'The deepest region is the abyssal zone, found below 13,000 feet. Temperatures here are near freezing, and the pressure is more than 1,000 times what we experience at the surface. Very few creatures can survive in such harsh conditions. Those that do, like certain species of sea cucumbers and microscopic organisms, have adapted to thrive in total darkness with almost no food. Scientists estimate that more than 80 percent of the ocean floor remains unexplored, meaning the abyssal zone may hold secrets we have not yet imagined.'
-  ],
-  vocabWords: ['descend', 'bioluminescence', 'hospitable', 'photosynthesis']
-};
-
-// ─── QUESTIONS DATA ───
-var FALLBACK_QUESTIONS = [
-  {
-    id: 1,
-    type: 'multiple_choice',
-    teks: 'ELA 4.6',
-    difficulty: 'Easy',
-    label: 'Main Idea',
-    question: 'What is the MAIN idea of this passage?',
-    options: [
-      'A) The ocean is too dangerous for humans to explore.',
-      'B) The ocean is divided into zones that get darker, colder, and more extreme as depth increases.',
-      'C) Anglerfish are the most interesting creatures in the deep ocean.',
-      'D) Scientists have already explored every part of the ocean floor.'
-    ],
-    answer: 1,
-    explanation: 'The passage is organized around the different ocean zones and describes how conditions change as depth increases. Each paragraph introduces a deeper zone with harsher conditions, making this the main idea.'
-  },
-  {
-    id: 2,
-    type: 'multiple_choice',
-    teks: 'ELA 4.3B',
-    difficulty: 'Medium',
-    label: 'Vocabulary in Context',
-    question: 'In paragraph 3, the author writes that animals "must descend to darker waters." What does the word "descend" mean as it is used here?',
-    options: [
-      'A) To swim in circles',
-      'B) To move downward to a lower level',
-      'C) To float near the surface',
-      'D) To hide from predators'
-    ],
-    answer: 1,
-    explanation: 'The word "descend" means to move downward. The context clue is "to darker waters" \u2014 since the passage explains that deeper water is darker, descending means moving down to a lower depth.'
-  },
-  {
-    id: 3,
-    type: 'multiple_choice',
-    teks: 'ELA 4.10',
-    difficulty: 'Medium',
-    label: "Author's Purpose",
-    question: "What is the author's MAIN purpose for writing this passage?",
-    options: [
-      'A) To persuade readers to become ocean scientists',
-      'B) To entertain readers with a fictional story about the ocean',
-      'C) To inform readers about the different zones of the ocean and what lives there',
-      'D) To warn readers about the dangers of deep-sea diving'
-    ],
-    answer: 2,
-    explanation: "The author's purpose is to inform. The passage presents factual information about each ocean zone in an organized way. It does not try to persuade, entertain with fiction, or warn about danger."
-  },
-  {
-    id: 4,
-    type: 'multiple_choice',
-    teks: 'ELA 4.9D',
-    difficulty: 'Medium',
-    label: 'Text Structure',
-    question: 'How is this passage MAINLY organized?',
-    options: [
-      'A) Problem and solution \u2014 it describes ocean pollution and how to fix it',
-      'B) Cause and effect \u2014 it explains why the ocean exists',
-      'C) Sequential order \u2014 it describes ocean zones from shallowest to deepest',
-      'D) Compare and contrast \u2014 it only compares two zones side by side'
-    ],
-    answer: 2,
-    explanation: 'The passage follows a sequential (top-to-bottom) order, moving through each ocean zone from the sunlight zone near the surface down to the abyssal zone at the very bottom. Each paragraph introduces the next deeper zone.'
-  },
-  {
-    id: 5,
-    type: 'short_answer',
-    teks: 'ELA 4.6',
-    difficulty: 'Hard',
-    label: 'Inference',
-    question: 'Based on the passage, why do you think FEWER creatures live in the abyssal zone compared to the sunlight zone? Use evidence from the passage to support your answer.',
-    hint: 'Think about what living things need to survive: light, food, comfortable temperature, and manageable pressure. How do these factors differ between the two zones?',
-    sampleAnswer: 'Fewer creatures live in the abyssal zone because the conditions are much harsher. The passage says the sunlight zone has warm water, plentiful food, and sunlight for photosynthesis. In contrast, the abyssal zone has near-freezing temperatures, crushing pressure over 1,000 times what we feel at the surface, total darkness, and almost no food. Most organisms cannot adapt to such extreme conditions, so only a few specialized species survive there.'
-  }
-];
 
 // ─── COLORS ───
 var C = {
@@ -1536,7 +1452,7 @@ function lockInMC(qId) {
   ans.correct = (ans.selected === q.answer);
 
   // Log per-question result to QuestionLog for mastery tracking (#161)
-  if (!TBM_TEST_MODE && !_usingFallback && typeof google !== 'undefined' && google.script && google.script.run) {
+  if (!TBM_TEST_MODE && typeof google !== 'undefined' && google.script && google.script.run) {
     google.script.run
       .withSuccessHandler(function() {})
       .withFailureHandler(function(err) { console.error('QuestionLog failed:', err); })
@@ -1796,8 +1712,6 @@ function renderResults() {
       console.log('[TEST MODE] awardRingsSafe skipped, rings=' + earnedRings);
       console.log('[TEST MODE] submitHomeworkSafe skipped');
       console.log('[TEST MODE] logHomeworkCompletionSafe skipped');
-    } else if (_usingFallback) {
-      console.log('Practice mode — rings not awarded');
     } else {
       google.script.run
         .withSuccessHandler(function(result) {
@@ -1905,11 +1819,7 @@ function applyPassageVisibility(visibility) {
 function loadCurriculumContent() {
   if (typeof google === 'undefined' || !google.script || !google.script.run) {
     console.warn('[TBM FALLBACK] reading-module \u2014 reason: no google.script.run available');
-    _usingFallback = true;
-    _showFallbackBadge_();
-    PASSAGE = FALLBACK_PASSAGE;
-    QUESTIONS = FALLBACK_QUESTIONS;
-    init();
+    showLoadError_('offline');
     return;
   }
   google.script.run
@@ -1920,27 +1830,26 @@ function loadCurriculumContent() {
         if (adhd.brainBreakAfter) { _brainBreakAfter = adhd.brainBreakAfter; }
         if (adhd.brainBreakPrompt) { _brainBreakPrompt = adhd.brainBreakPrompt; }
       }
-      if (response && response.content && response.content.cold_passage) {
-        var cp = response.content.cold_passage;
-        PASSAGE = { title: cp.title || 'Reading Passage', text: cp.passage || cp.text || '', paragraphs: cp.paragraphs || [], vocabWords: cp.vocabWords || [], passageVisibility: cp.passageVisibility };
-        QUESTIONS = cp.questions || [];
-        init();
-      } else {
+      if (!response || !response.content || !response.content.cold_passage) {
         console.warn('[TBM FALLBACK] reading-module \u2014 reason: getTodayContentSafe returned no cold_passage in content');
-        _usingFallback = true;
-        _showFallbackBadge_();
-        PASSAGE = FALLBACK_PASSAGE;
-        QUESTIONS = FALLBACK_QUESTIONS;
-        init();
+        showLoadError_('no-content');
+        return;
       }
+      var cp = response.content.cold_passage;
+      var hasParagraphs = (cp.paragraphs && cp.paragraphs.length > 0) || cp.passage || cp.text;
+      var hasQuestions = (cp.questions && cp.questions.length > 0);
+      if (!hasParagraphs || !hasQuestions) {
+        console.warn('[TBM FALLBACK] reading-module \u2014 reason: cold_passage missing paragraphs or questions (paragraphs=' + !!hasParagraphs + ', questions=' + !!hasQuestions + ')');
+        showLoadError_('no-content');
+        return;
+      }
+      PASSAGE = { title: cp.title || 'Reading Passage', text: cp.passage || cp.text || '', paragraphs: cp.paragraphs || [], vocabWords: cp.vocabWords || [], passageVisibility: cp.passageVisibility };
+      QUESTIONS = cp.questions || [];
+      init();
     })
     .withFailureHandler(function(err) {
       console.warn('[TBM FALLBACK] reading-module \u2014 reason: getTodayContentSafe failed: ' + (err && err.message ? err.message : 'unknown'));
-      _usingFallback = true;
-      _showFallbackBadge_();
-      PASSAGE = FALLBACK_PASSAGE;
-      QUESTIONS = FALLBACK_QUESTIONS;
-      init();
+      showLoadError_('load-error');
     })
     .getTodayContentSafe('buggsy');
 }

--- a/writing-module.html
+++ b/writing-module.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="tbm-module" content="writing-module">
-<meta name="tbm-version" content="v8">
+<meta name="tbm-version" content="v9">
 <title>Writing Module - Buggsy</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -967,24 +967,28 @@ function endBrainBreak() {
   if (overlay) overlay.style.display = 'none';
 }
 
-var MODULE_VERSION = 'v8';
+var MODULE_VERSION = 'v9';
 var CHILD = TBM_SANDBOX ? 'sandbox-buggsy' : 'buggsy';
 var TARGET_MINUTES = 12;
-var _usingFallback = false;
 
-// v8 (#345) — Visible signal when surface falls back / fails to load real curriculum.
-// Always-on banner so QA can detect silent fallback without DevTools.
-function _showFallbackBadge_() {
-  if (typeof document === 'undefined' || !document.body) { return; }
-  if (document.getElementById('_tbm_fallback_badge')) { return; }
-  var b = document.createElement('div');
-  b.id = '_tbm_fallback_badge';
-  b.textContent = '\u26A0 PRACTICE MODE \u2014 Today\u2019s lesson didn\u2019t load. Rings won\u2019t be earned.';
-  b.style.cssText = 'position:fixed;top:0;left:0;right:0;background:#f59e0b;color:#000;'
-    + 'padding:6px 12px;font:600 13px/1.4 system-ui,sans-serif;text-align:center;'
-    + 'z-index:99999;box-shadow:0 1px 4px rgba(0,0,0,0.3);';
-  document.body.appendChild(b);
-  document.body.style.paddingTop = '28px';
+// v9 (#348) — No fallback content. If curriculum doesn't load we render an error screen, not default prompts.
+function showLoadError_(reason) {
+  var msg = 'Having trouble loading today\u2019s writing assignment.';
+  if (reason === 'offline') { msg = 'Cannot reach the server right now.'; }
+  var body = document.body;
+  if (!body) { return; }
+  body.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;'
+    + 'min-height:100vh;background:#0B0F1A;color:#E2E8F0;font-family:Nunito,sans-serif;'
+    + 'flex-direction:column;gap:16px;padding:20px;text-align:center;">'
+    + '<div style="font-size:48px;">&#9888;&#65039;</div>'
+    + '<div style="font-family:Orbitron,sans-serif;font-size:18px;color:#F59E0B;'
+    + 'letter-spacing:2px;">WRITING LOAD FAILED</div>'
+    + '<div style="font-size:16px;max-width:400px;">' + msg + '</div>'
+    + '<div style="font-size:13px;color:#94a3b8;max-width:360px;">Tell Mom or Dad. They\u2019ll fix it.</div>'
+    + '<button onclick="window.location.reload()" style="margin-top:12px;padding:12px 32px;'
+    + 'background:#F59E0B;color:#0B0F1A;border:none;border-radius:8px;font-family:Orbitron,sans-serif;'
+    + 'font-size:14px;font-weight:700;cursor:pointer;letter-spacing:1px;">TRY AGAIN</button>'
+    + '</div>';
 }
 
 // ─── 4 Writing Formats ───
@@ -1575,9 +1579,7 @@ function handleSubmit() {
   }
 
   // Submit homework via GAS backend (if available)
-  if (_usingFallback) {
-    console.log('Practice mode — rings not awarded');
-  } else if (!TBM_TEST_MODE) {
+  if (!TBM_TEST_MODE) {
     try {
       if (typeof google !== 'undefined' && google.script && google.script.run) {
         google.script.run
@@ -1601,9 +1603,7 @@ function handleSubmit() {
   }
 
   // Award rings via GAS backend (if available)
-  if (_usingFallback) {
-    // Already logged above
-  } else if (TBM_TEST_MODE) {
+  if (TBM_TEST_MODE) {
     console.log('[TEST MODE] awardRingsSafe skipped, rings=3');
   } else {
     try {
@@ -1647,9 +1647,7 @@ function handleSubmit() {
 function loadWritingContent() {
   if (typeof google === 'undefined' || !google.script || !google.script.run) {
     console.warn('[TBM FALLBACK] writing-module \u2014 reason: no google.script.run available');
-    _usingFallback = true;
-    _showFallbackBadge_();
-    init();
+    showLoadError_('offline');
     return;
   }
   google.script.run
@@ -1660,37 +1658,30 @@ function loadWritingContent() {
         if (adhd.brainBreakAfter) { _brainBreakAfter = adhd.brainBreakAfter; }
         if (adhd.brainBreakPrompt) { _brainBreakPrompt = adhd.brainBreakPrompt; }
       }
-      if (result && result.content) {
-        var c = result.content;
-        if (c.quick_write || c.grammar_sprint) {
-          // Use curriculum content to override default prompts
-          if (c.quick_write && c.quick_write.prompt) {
-            for (var i = 0; i < FORMATS.length; i++) {
-              if (FORMATS[i].id === 'quick_write' || FORMATS[i].id === 'journal') {
-                FORMATS[i].prompt = c.quick_write.prompt;
-                if (c.quick_write.guidance) { FORMATS[i].guidance = c.quick_write.guidance; }
-              }
-            }
-          }
-          init();
-        } else {
-          console.warn('[TBM FALLBACK] writing-module \u2014 reason: response had content but no quick_write or grammar_sprint fields');
-          _usingFallback = true;
-          _showFallbackBadge_();
-          init();
-        }
-      } else {
+      if (!result || !result.content) {
         console.warn('[TBM FALLBACK] writing-module \u2014 reason: getTodayContentSafe returned empty/missing content');
-        _usingFallback = true;
-        _showFallbackBadge_();
-        init();
+        showLoadError_('no-content');
+        return;
       }
+      var c = result.content;
+      var qw = c.quick_write && c.quick_write.prompt ? c.quick_write : null;
+      if (!qw) {
+        console.warn('[TBM FALLBACK] writing-module \u2014 reason: response had content but no quick_write.prompt');
+        showLoadError_('no-content');
+        return;
+      }
+      // Override default prompts with today's curriculum.
+      for (var i = 0; i < FORMATS.length; i++) {
+        if (FORMATS[i].id === 'quick_write' || FORMATS[i].id === 'journal') {
+          FORMATS[i].prompt = qw.prompt;
+          if (qw.guidance) { FORMATS[i].guidance = qw.guidance; }
+        }
+      }
+      init();
     })
     .withFailureHandler(function(err) {
       console.warn('[TBM FALLBACK] writing-module \u2014 reason: getTodayContentSafe failed: ' + (err && err.message ? err.message : 'unknown'));
-      _usingFallback = true;
-      _showFallbackBadge_();
-      init();
+      showLoadError_('load-error');
     })
     .getTodayContentSafe('buggsy');
 }


### PR DESCRIPTION
## Summary

#346 added a 'PRACTICE MODE' badge over the silent fallbacks. LT correction: kids shouldn't see a tag on a live surface. **Either curriculum loads or the surface errors. The fallback content itself is the problem.**

This PR removes the fake content + the badge + the badge helper, and pages LT at 6AM if any of the three surfaces would fail to load real curriculum.

### Client (no more fake content)

| File | Version | Change |
|------|---------|--------|
| HomeworkModule.html | v16 → v17 | Removed `_showFallbackBadge_` helper, `_usingFallback` dead-code paths, and the unused 158-line `_FALLBACK_STUB` object (fake forces/fractions homework). Empty-normalized case calls `showLoadError_('no-content')`. |
| reading-module.html | v8 → v9 | Deleted `FALLBACK_PASSAGE` (5-paragraph hardcoded ocean-zones essay) + `FALLBACK_QUESTIONS` (5 generic comprehension Qs). Added `showLoadError_(reason)` patterned on HomeworkModule. |
| writing-module.html | v8 → v9 | Removed badge + `_usingFallback` gating. Curriculum must supply `quick_write.prompt` or surface errors. FORMATS structure retained (defines the 4 writing modes); default prompts no longer surface as today's curriculum. |

Error UI on all 3 surfaces: amber 'TRY AGAIN' button + 'Tell Mom or Dad. They'll fix it.' subtext. No fake passages, no canned questions, no default prompts pretending to be today's lesson.

### Server (LT gets paged before kids touch the device)

| File | Version | Change |
|------|---------|--------|
| Kidshub.js | v69 → v70 | Added `validateReadingShape_()` + `validateWritingShape_()` next to existing `validateHomeworkShape_()`. Reading/writing validators treat absent rotation-day content as valid (only fail on present-but-malformed shapes — a non-reading day correctly serves no `cold_passage`). |
| Alertenginev1.js | v11 → v12 | `dailyHealthCheck()` loops Homework + Reading + Writing validators across both kids at 6AM. Each broken surface fires its own SYSTEM_ERROR Pushover: 'Reading broken: buggsy. Missing: cold_passage.questions. Fix before kids wake up.' |

### Net diff

`5 files changed, 151 insertions(+), 395 deletions(-)`

The 244-line negative delta is the FALLBACK content getting deleted.

## Test plan

- [x] `bash audit-source.sh` — PASS (0 failures, 0 warnings)
- [x] Deployed @626
- [x] `?action=runTests` → `11_behavioral: PASS`, `9_html_contracts: PASS`, `1_wiring: PASS`
- [x] CF routes `/homework`, `/reading`, `/writing` — all 200
- [ ] LT manual: hit each surface, confirm content renders OR error UI shows; no fake passages anywhere

Closes #348
Supersedes the #346 badge approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)