### PR TITLE
fix: surface schedule error in JJHome — empty withFailureHandler (#355)

### DIFF
--- a/JJHome.html
+++ b/JJHome.html
@@ -213,6 +213,7 @@ body {
     <div class="sk-today-card" onclick="window.location.href='/daily-missions?child=jj'">
       <div class="sk-today-main" id="sk-today-text">LET'S PLAY! &#x2728;</div>
       <div class="sk-today-sub">Tap to see today's missions</div>
+      <div id="schedule-error" style="display:none;font-size:12px;color:#F87171;margin-top:6px;">Schedule unavailable. Try again.</div>
     </div>
     <div class="sk-nav-cards">
       <button class="sk-card" onclick="window.location.href='/daily-missions?child=jj'">
@@ -529,7 +530,10 @@ function loadHomeData() {
 
     google.script.run
       .withSuccessHandler(onDailySchedule)
-      .withFailureHandler(function() {})
+      .withFailureHandler(function() {
+        var el = document.getElementById('schedule-error');
+        if (el) { el.style.display = 'block'; }
+      })
       .getDailyScheduleSafe('jj');
   } else {
     setTimeout(function() { showHomeView(); }, 400);


### PR DESCRIPTION
## Summary

- Replaced empty `withFailureHandler(function() {})` on `getDailyScheduleSafe` with an in-surface error message
- Added `#schedule-error` div inside `.sk-today-card` — hidden by default, shown on failure

## Changes

**JJHome.html:214** — added `#schedule-error` div  
**JJHome.html:532** — failure handler now sets `el.style.display = 'block'`

## Note on #356

#356 (ComicStudio gate-check bypass) is **blocked** — ComicStudio.html has ~100+ pre-existing ES6 violations (`const`, `let`, arrow functions) that cause the posttool hook to reject the whole file. #356 fix itself is ES5-compliant but cannot be committed until ComicStudio.html has an ES5 migration pass. Recommend filing a separate ES5 migration issue for ComicStudio before #356 can land.

## Test plan

- [ ] Schedule load failure shows "Schedule unavailable. Try again." below the today card
- [ ] No native `alert()` used
- [ ] Normal load path unaffected (error div stays hidden on success)

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)