### PR TITLE
fix: pre-push hook enforces EMERGENCY: commit prefix + handles non-JSON clasp output

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -26,15 +26,19 @@ if [[ "${EMERGENCY:-0}" == "1" ]]; then
       continue
     fi
     if [[ "$remote_sha" == "0000000000000000000000000000000000000000" ]]; then
-      range="$local_sha"
+      # New branch: git log <sha> would walk ALL of history reachable from the
+      # tip, including thousands of main commits that pre-date this emergency.
+      # Limit to commits not already present on any remote ref so only the
+      # commits being introduced are validated.
+      LOG_ARGS=("$local_sha" "--not" "--remotes")
     else
-      range="${remote_sha}..${local_sha}"
+      LOG_ARGS=("${remote_sha}..${local_sha}")
     fi
     while IFS= read -r subject; do
       if [[ "$subject" != EMERGENCY:* ]]; then
         MISSING="${MISSING}\n  BAD: $subject"
       fi
-    done < <(git log --format="%s" "$range" 2>/dev/null)
+    done < <(git log --format="%s" "${LOG_ARGS[@]}" 2>/dev/null)
   done
   if [[ -n "$MISSING" ]]; then
     echo ""

--- a/audit-source.sh
+++ b/audit-source.sh
@@ -440,6 +440,16 @@ else
       echo "         Tools are present but could not confirm freeze state — treating as blocked"
       echo "         To bypass (genuine emergency only): EMERGENCY=1 bash audit-source.sh"
       FAIL=1
+    elif [[ "${FREEZE_JSON:0:1}" != "{" ]]; then
+      # clasp returned non-JSON (e.g. "Script function not found. Please make sure
+      # script is deployed as API executable.") with exit code 0.
+      # Cannot determine freeze state — treat as SKIP/WARN, same degradation as
+      # jq/clasp absent. This is the current repo config until GAS is deployed
+      # as API executable.
+      echo "  SKIP -- clasp run returned non-JSON output; freeze check skipped"
+      echo "         Script may not be deployed as API executable."
+      echo "         Output: ${FREEZE_JSON:0:120}"
+      WARN=$((WARN + 1))
     else
       FREEZE_ACTIVE=$(echo "$FREEZE_JSON" | jq -r '.active // empty' 2>/dev/null)
       JQ_EXIT=$?


### PR DESCRIPTION
## Summary

Fixes two P1 audit gaps in the deploy freeze `EMERGENCY=1` bypass path found by Codex review:

- **P1-A: EMERGENCY push bypasses without commit-prefix validation.** The `pre-push` hook now reads git's stdin, iterates every outgoing commit via `git log --format="%s" <remote>..<local>`, and blocks if any subject does not start with `EMERGENCY:`. A commit made before a freeze was activated (no prefix) could previously be pushed under `EMERGENCY=1` with no audit trail.

- **P1-B: Non-JSON clasp output blocked all pushes.** When `clasp run getFreezeState_` is not deployed as API executable it returns `"Script function not found..."` with exit code 0. This passed the exit-code guard, failed `jq` parsing, and blocked **all** pushes even with no active freeze. Fixed: if `FREEZE_JSON` does not start with `{`, treat as `SKIP/WARN` (same degradation as jq/clasp absent) rather than `FAIL/BLOCK`.

Also adds:
- `.githooks/commit-msg` — blocks commit at point of origin if `EMERGENCY=1` and message lacks `EMERGENCY:` prefix
- `scripts/setup-hooks.sh` — wires `chmod +x` for both new hooks
- `audit-source.sh` — BYPASS echo notes the enforcement chain

## Build Skills
- `thompson-engineer` — hook shell scripting, git hook contracts

## Test plan
- [ ] `bash scripts/setup-hooks.sh` — confirm all 3 hooks wired
- [ ] `EMERGENCY=1 git push` with a commit missing `EMERGENCY:` prefix → blocked
- [ ] `EMERGENCY=1 git push` with all commits carrying `EMERGENCY:` prefix → passes
- [ ] `EMERGENCY=1 git commit -m "no-prefix"` → blocked by commit-msg hook
- [ ] `EMERGENCY=1 git commit -m "EMERGENCY: reason"` → passes
- [ ] Push when clasp returns non-JSON → WARN (not blocked)

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)