### PR TITLE
fix: remove user-scalable=no from SparkleLearning viewport #394

### DIFF
--- a/SparkleLearning.html
+++ b/SparkleLearning.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="tbm-module" content="sparkle-learn">
-  <meta name="tbm-version" content="v21">
+  <meta name="tbm-version" content="v22">
   <title>SparkleLearn v3 — JJ's Learning Games</title>
   <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
   <style>


### PR DESCRIPTION
## Summary
- Removes `user-scalable=no` from `SparkleLearning.html` viewport meta tag (line 5)
- Enables pinch-zoom for JJ tablet (Samsung S10 FE)
- Version bumped v21 → v22

## WCAG compliance
Fixes SC 1.4.4 (Resize Text) and SC 1.4.10 (Reflow) violations. Sister fix to #358 (BaselineDiagnostic already corrected).

## Test plan
- [ ] Load `/sparkle` on JJ tablet — confirm pinch-zoom works
- [ ] Confirm layout intact at 200% zoom
- [ ] Verify no other viewport changes in diff

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)