### PR TITLE
DOCS: Cloudflare Worker deploy verification pattern #403

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,6 +518,26 @@ LT applies branch protection in GitHub Settings > Branches > Branch protection r
 
 **Auto-merge policy:** Currently **manual review required**. Auto-merge can be enabled when the pipeline runs cleanly on 5 consecutive PRs without false negatives. Status: not yet enabled.
 
+### Cloudflare Worker Deploy Verification (issue #403)
+
+There are two separate Cloudflare integrations on this repo — do not confuse them:
+
+| Integration | What it does | Authoritative? |
+|-------------|--------------|----------------|
+| `deploy-worker.yml` (TBM-owned GitHub Action) | Runs `wrangler deploy` on push to main — **this is what actually deploys the worker** | ✅ Yes |
+| Cloudflare GitHub App "Workers Build" status | Posts a CI status badge to PRs — cosmetic signal only, does not gate anything | ❌ No |
+
+**When a Cloudflare worker change is pushed, the correct verification sequence is:**
+
+```bash
+curl -s https://thompsonfams.com/version            # expect HTTP 200 + version JSON
+gh run list --workflow=deploy-worker.yml --limit 1   # expect success
+```
+
+**Never ask LT to check the Cloudflare dashboard.** If `deploy-worker.yml` shows success and `curl /version` returns 200, the worker is live — regardless of whether the "Workers Build" badge appears in the PR.
+
+If the Cloudflare GitHub App badge is missing or stale, ignore it. It is a reliability issue with Cloudflare's external integration, not a deploy failure.
+
 ### Workflow Safety Rules
 1. **Workflow YAML should orchestrate only.** Real logic (Python, bash) belongs in `.github/scripts/`. No embedded heredocs. Each script gets a header comment: purpose, calling workflow, env vars expected.
 2. **New workflow files CANNOT review their own introduction** — they require manual lint plus one sacrificial test PR before becoming a required check.


### PR DESCRIPTION
## Summary
- Adds `### Cloudflare Worker Deploy Verification` section to project `CLAUDE.md`
- Documents two-integration table (deploy-worker.yml = authoritative; Workers Build badge = cosmetic)
- Adds `curl /version` + `gh run list` as canonical post-deploy verification sequence
- Eliminates future courier asks when Cloudflare GitHub App badge is missing

## Does not include
- Option A (remove Cloudflare GitHub App) — requires LT dashboard action at https://github.com/blucsigma05/tbm-apps-script/settings/installations. Recommend doing this separately.

## Test plan
- [ ] Confirm documentation appears correctly in CLAUDE.md CI/CD section
- [ ] No code changes — docs only

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)