### PR TITLE
DOCS: Cloudflare Worker deploy verification pattern #403

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,6 +518,26 @@ LT applies branch protection in GitHub Settings > Branches > Branch protection r
 
 **Auto-merge policy:** Currently **manual review required**. Auto-merge can be enabled when the pipeline runs cleanly on 5 consecutive PRs without false negatives. Status: not yet enabled.
 
+### Cloudflare Worker Deploy Verification (issue #403)
+
+There are two separate Cloudflare integrations on this repo — do not confuse them:
+
+| Integration | What it does | Authoritative? |
+|-------------|--------------|----------------|
+| `deploy-worker.yml` (TBM-owned GitHub Action) | Runs `wrangler deploy` on push to main — **this is what actually deploys the worker** | ✅ Yes |
+| Cloudflare GitHub App "Workers Build" status | Posts a CI status badge to PRs — cosmetic signal only, does not gate anything | ❌ No |
+
+**When a Cloudflare worker change is pushed, the correct verification sequence is:**
+
+```bash
+curl -s https://thompsonfams.com/version            # expect HTTP 200 + version JSON
+gh run list --workflow=deploy-worker.yml --limit 1   # expect success
+```
+
+**Never ask LT to check the Cloudflare dashboard.** If `deploy-worker.yml` shows success and `curl /version` returns 200, the worker is live — regardless of whether the "Workers Build" badge appears in the PR.
+
+If the Cloudflare GitHub App badge is missing or stale, ignore it. It is a reliability issue with Cloudflare's external integration, not a deploy failure.
+
 ### Workflow Safety Rules
 1. **Workflow YAML should orchestrate only.** Real logic (Python, bash) belongs in `.github/scripts/`. No embedded heredocs. Each script gets a header comment: purpose, calling workflow, env vars expected.
 2. **New workflow files CANNOT review their own introduction** — they require manual lint plus one sacrificial test PR before becoming a required check.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,11 +533,10 @@ There are two separate Cloudflare integrations on this repo — do not confuse t
 # Verify HTTP 200 and body — -f causes non-zero exit on 4xx/5xx
 curl -sf https://thompsonfams.com/version
 
-# Verify the deploy-worker.yml run succeeded AND matches the expected branch/commit
-gh run list --workflow=deploy-worker.yml --branch main --limit 1
+# Verify the correct run succeeded — --json exposes headSha and conclusion
+gh run list --workflow=deploy-worker.yml --branch main --limit 1 --json headSha,conclusion,status
+# expect: conclusion=="success", headSha matches the SHA you pushed
 ```
-
-Confirm the `gh run list` SHA matches the commit you pushed before treating it as proof.
 
 **Never ask LT to check the Cloudflare dashboard.** If `deploy-worker.yml` shows success and `curl -sf /version` exits 0, the worker is live — regardless of whether the "Workers Build" badge appears in the PR.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,11 +530,16 @@ There are two separate Cloudflare integrations on this repo — do not confuse t
 **When a Cloudflare worker change is pushed, the correct verification sequence is:**
 
 ```bash
-curl -s https://thompsonfams.com/version            # expect HTTP 200 + version JSON
-gh run list --workflow=deploy-worker.yml --limit 1   # expect success
+# Verify HTTP 200 and body — -f causes non-zero exit on 4xx/5xx
+curl -sf https://thompsonfams.com/version
+
+# Verify the deploy-worker.yml run succeeded AND matches the expected branch/commit
+gh run list --workflow=deploy-worker.yml --branch main --limit 1
 ```
 
-**Never ask LT to check the Cloudflare dashboard.** If `deploy-worker.yml` shows success and `curl /version` returns 200, the worker is live — regardless of whether the "Workers Build" badge appears in the PR.
+Confirm the `gh run list` SHA matches the commit you pushed before treating it as proof.
+
+**Never ask LT to check the Cloudflare dashboard.** If `deploy-worker.yml` shows success and `curl -sf /version` exits 0, the worker is live — regardless of whether the "Workers Build" badge appears in the PR.
 
 If the Cloudflare GitHub App badge is missing or stale, ignore it. It is a reliability issue with Cloudflare's external integration, not a deploy failure.
 


### PR DESCRIPTION
## Summary
- Adds `### Cloudflare Worker Deploy Verification` section to project `CLAUDE.md`
- Two-integration table: `deploy-worker.yml` = authoritative; "Workers Build" badge = cosmetic
- Verification sequence uses `curl -sf` (fails on HTTP 4xx/5xx) and `gh run list --branch main` (scoped + SHA confirmation note)

## Replaces
PR #405 — that branch had an unrelated `OpsTriggers.js` commit from local main contaminating its base. This branch is clean: `origin/main` + docs commit + P1/P2 fix commit only.

## Findings addressed
- **P1** (Codex): `curl -s` doesn't surface HTTP errors — fixed with `-f` flag
- **P2** (Codex): `gh run list --limit 1` could bless wrong run — fixed with `--branch main` + SHA confirmation note

## Option A not included
Removing the Cloudflare GitHub App requires LT dashboard action at `github.com/blucsigma05/tbm-apps-script/settings/installations`.

## Test plan
- [ ] Confirm CLAUDE.md section appears in CI/CD Pipeline section between auto-merge policy and Workflow Safety Rules
- [ ] No code changes — docs only

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)