### PR TITLE
fix: correct ratelimits binding field name in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,12 +12,9 @@ compatibility_date = "2024-09-01"
 crons = ["0 12 * * *"]   # HYG-09: Tiller freshness check — daily 12:00 UTC
 
 [[ratelimits]]
-name = "PIN_RATE_LIMITER"
+binding = "PIN_RATE_LIMITER"
 namespace_id = "1001"
-
-[ratelimits.simple]
-limit = 2
-period = 10
+simple = { limit = 2, period = 10 }
 
 # Webhook idempotency store — globally replicated KV, prevents duplicate Pushover
 # alerts on GitHub retries and manual redeliveries (issue #373).


### PR DESCRIPTION
## Summary

- `[[ratelimits]]` block used `name = "PIN_RATE_LIMITER"` — wrangler expects `binding`, not `name`
- Wrong field → `env.PIN_RATE_LIMITER` was never populated → rate limiting silently disabled since PR #220
- Also inlines the `[ratelimits.simple]` table to standard inline syntax (avoids TOML array-of-tables ambiguity)
- `namespace_id = "1001"` is a valid user-defined integer per CF docs — no dashboard namespace needed

## What changes

`wrangler.toml` line 15: `name` → `binding` (one-word fix, 1 file changed)

## Test plan

- [ ] CF "Deploy Worker Preview" check should pass after this — it was failing on invalid `name` field
- [ ] `env.PIN_RATE_LIMITER.limit()` will now be invoked at runtime (the `if (env.PIN_RATE_LIMITER && typeof env.PIN_RATE_LIMITER.limit === 'function')` guard in `cloudflare-worker.js:713`)
- [ ] Verify 2-req/10s rate limit on `/api/verify-pin` is active in production post-deploy

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)