### PR TITLE
fix: restore name field in [[ratelimits]] — revert bad binding rename

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,7 +12,7 @@ compatibility_date = "2024-09-01"
 crons = ["0 12 * * *"]   # HYG-09: Tiller freshness check — daily 12:00 UTC
 
 [[ratelimits]]
-binding = "PIN_RATE_LIMITER"
+name = "PIN_RATE_LIMITER"
 namespace_id = "1001"
 simple = { limit = 2, period = 10 }
 


### PR DESCRIPTION
## What happened

PR #412 changed `name` → `binding` in `[[ratelimits]]`. This was wrong.

Wrangler 4.83.0 requires `name` for rate limiting bindings, not `binding`. The deploy-worker.yml failed immediately with:

```
✘ [ERROR] Processing wrangler.toml configuration:
  - "ratelimits[0]" bindings must have a string "name" field
```

## This PR

Restores `name = "PIN_RATE_LIMITER"`. Also keeps the inline `simple` table from PR #412 (cleaner TOML, no functional difference).

The `[[ratelimits]]` config after this PR:
```toml
[[ratelimits]]
name = "PIN_RATE_LIMITER"
namespace_id = "1001"
simple = { limit = 2, period = 10 }
```

## Issue #380 status

The original `name` field was correct all along. The `Deploy Worker Preview` failure mentioned in #380 has a different root cause (not the field name). Issue #380 remains open for further investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)