### PR TITLE
fix(#410): Friday Review queues missed days before pre-seeded content

### DIFF
--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -769,6 +769,12 @@ var _todayIso = (function() {
   return _d.getFullYear() + '-' + (_m.length < 2 ? '0' + _m : _m) + '-' + (_dd.length < 2 ? '0' + _dd : _dd);
 })();
 
+// ── Friday Makeup Queue state (#410) ──
+var _fridayQueue = [];        // [{day, dayISO, content, priority}, ...], last entry = Friday itself
+var _fridayQueueIndex = 0;    // current position in the queue
+var _isFridayMakeupMode = false;
+var _pendingFridayResponse = null;
+
 // ── Audio System (Marco / ElevenLabs) — Lazy Loading ──
 // Loads clips on demand per phase, not all 21 at page load.
 // Follows SparkleLearning.html lazy loader pattern.
@@ -1356,7 +1362,7 @@ function buildHomeworkCompletionPayload_() {
       responseText: responseText,
       prompt: allOpenEnded.length > 0 ? allOpenEnded.length + ' open-ended question(s)' : '',
       rings: ringsEarned,
-      makeupDate: MAKEUP_MODE ? MAKEUP_DATE_ISO : ''
+      makeupDate: MAKEUP_MODE ? MAKEUP_DATE_ISO : (_isFridayMakeupMode && _fridayQueueIndex < _fridayQueue.length - 1 ? _fridayQueue[_fridayQueueIndex].dayISO : '')
     }
   };
 }
@@ -1434,8 +1440,10 @@ function submitHomeworkCompletion_() {
       completionLogged = true;
       clearHomeworkDraft_();
       // #409: stamp completion so catch-up banner skips this day going forward
+      // #410: for Friday queue steps, stamp the original day's ISO, not today
       try {
-        var _doneIso = MAKEUP_MODE ? MAKEUP_DATE_ISO : _todayIso;
+        var _doneIso = MAKEUP_MODE ? MAKEUP_DATE_ISO
+          : (_isFridayMakeupMode && _fridayQueue[_fridayQueueIndex] ? _fridayQueue[_fridayQueueIndex].dayISO : _todayIso);
         if (_doneIso) { window.localStorage.setItem('tbm_hw_complete_' + _doneIso, '1'); }
       } catch(e2) { /* localStorage unavailable */ }
       updateCompletionSaveStatusUi_();
@@ -1454,6 +1462,11 @@ function submitHomeworkCompletion_() {
 
       if (payload.openEndedCount > 0) {
         console.log('Rings deferred — ' + payload.openEndedCount + ' open-ended question(s) pending parent review');
+      }
+
+      // #410: Friday queue — advance to next step after submit; last step (Friday Review) flows to completion screen normally
+      if (_isFridayMakeupMode && _fridayQueueIndex < _fridayQueue.length - 1) {
+        _advanceFridayQueue_();
       }
     })
     .withFailureHandler(function(err) {
@@ -2198,6 +2211,79 @@ function renderCatchUpBanner_(fullWeek) {
   document.body.insertBefore(banner, document.body.firstChild);
 }
 
+// ─── FRIDAY PROGRESS BANNER (#410) ───
+function renderFridayProgressBanner_() {
+  var existing = document.getElementById('friday-queue-banner');
+  if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
+  if (!_isFridayMakeupMode || _fridayQueue.length <= 1) return;
+
+  var missedCount = _fridayQueue.length - 1;
+  var isMakeupStep = _fridayQueueIndex < _fridayQueue.length - 1;
+  var stepNum = _fridayQueueIndex + 1;
+  var totalSteps = _fridayQueue.length;
+  var stepDay = _fridayQueue[_fridayQueueIndex].day;
+  var stepLabel = isMakeupStep
+    ? 'Day ' + stepNum + ' of ' + totalSteps + ' \u2014 ' + stepDay + ' Catch-Up'
+    : 'Friday Review (' + stepNum + ' of ' + totalSteps + ')';
+
+  var banner = document.createElement('div');
+  banner.id = 'friday-queue-banner';
+  banner.style.cssText = 'background:rgba(249,115,22,0.10);border:2px solid #f97316;border-radius:10px;' +
+    'padding:12px 16px;margin-bottom:16px;text-align:center;';
+  banner.innerHTML =
+    '<div style="color:#F59E0B;font-family:Orbitron,sans-serif;font-size:12px;font-weight:700;' +
+    'letter-spacing:1px;margin-bottom:4px;">CATCH-UP MODE</div>' +
+    '<div style="color:#E2E8F0;font-size:14px;margin-bottom:4px;">You missed ' +
+    missedCount + ' day' + (missedCount !== 1 ? 's' : '') +
+    ' this week. Let\'s catch up first, then review.</div>' +
+    '<div style="color:#94A3B8;font-size:13px;">' + stepLabel + '</div>';
+
+  var body = document.body;
+  if (body) body.insertBefore(banner, body.firstChild);
+}
+
+// ─── FRIDAY QUEUE ADVANCE (#410) ───
+function _advanceFridayQueue_() {
+  _fridayQueueIndex++;
+  if (_fridayQueueIndex >= _fridayQueue.length) return; // all done
+
+  var step = _fridayQueue[_fridayQueueIndex];
+  MODULE = step.content.module;
+  if (!MODULE.science) MODULE.science = {};
+  MODULE.science.strand    = MODULE.science.strand    || '';
+  MODULE.science.teks      = MODULE.science.teks      || '';
+  MODULE.science.quickFact = MODULE.science.quickFact || '';
+  MODULE.science.passage   = MODULE.science.passage   || [];
+  MODULE.science.title     = MODULE.science.title     || '';
+  MODULE.science.questions = MODULE.science.questions || [];
+  if (!MODULE.math) MODULE.math = {};
+  MODULE.math.strand    = MODULE.math.strand    || '';
+  MODULE.math.teks      = MODULE.math.teks      || '';
+  MODULE.math.quickFact = MODULE.math.quickFact || '';
+  MODULE.math.passage   = MODULE.math.passage   || [];
+  MODULE.math.title     = MODULE.math.title     || '';
+  MODULE.math.questions = MODULE.math.questions || [];
+
+  // Reset per-step state
+  answers = {};
+  completionSubmitState = 'idle';
+  completionSubmitError = '';
+  completionLogged = false;
+  moduleStarted = false;
+  _questionsSinceBrainBreak = 0;
+  scienceQs = MODULE.science.questions;
+  mathQs = MODULE.math.questions;
+  allQs = scienceQs.concat(mathQs);
+
+  renderFridayProgressBanner_();
+  renderOverview();
+  renderScience();
+  renderMath();
+  renderResults();
+  switchTab('overview');
+  updateProgress();
+}
+
 // ─── CURRICULUM LOADING ───
 function loadCurriculumContent() {
   if (typeof google === 'undefined' || !google.script || !google.script.run) {
@@ -2259,6 +2345,45 @@ function loadCurriculumContent() {
             console.warn('[TBM FALLBACK] HomeworkModule \u2014 reason: questions present but enrichment fields empty (math context=' + !!mathHasContext + ', sci context=' + !!sciHasContext + ')');
             showLoadError_('no-content');
             return;
+          }
+          // v19 (#410): Friday — check for missed Mon-Thu days and queue them before Friday Review
+          if (_dayOfWeek === 'Friday' && !MAKEUP_MODE) {
+            _pendingFridayResponse = response;
+            google.script.run
+              .withSuccessHandler(function(queue) {
+                if (queue && queue.length > 0) {
+                  var fridayStep = { day: 'Friday', dayISO: _todayIso, content: _pendingFridayResponse.content, priority: 99 };
+                  _fridayQueue = queue.concat([fridayStep]);
+                  _fridayQueueIndex = 0;
+                  _isFridayMakeupMode = true;
+                  // Override MODULE to first missed day and remove the catch-up banner (replaced by progress banner)
+                  var firstStep = _fridayQueue[0];
+                  MODULE = firstStep.content.module;
+                  if (!MODULE.science) MODULE.science = {};
+                  MODULE.science.strand    = MODULE.science.strand    || '';
+                  MODULE.science.teks      = MODULE.science.teks      || '';
+                  MODULE.science.quickFact = MODULE.science.quickFact || '';
+                  MODULE.science.passage   = MODULE.science.passage   || [];
+                  MODULE.science.title     = MODULE.science.title     || '';
+                  MODULE.science.questions = MODULE.science.questions || [];
+                  if (!MODULE.math) MODULE.math = {};
+                  MODULE.math.strand    = MODULE.math.strand    || '';
+                  MODULE.math.teks      = MODULE.math.teks      || '';
+                  MODULE.math.quickFact = MODULE.math.quickFact || '';
+                  MODULE.math.passage   = MODULE.math.passage   || [];
+                  MODULE.math.title     = MODULE.math.title     || '';
+                  MODULE.math.questions = MODULE.math.questions || [];
+                  var existing = document.getElementById('tbm-catchup-banner');
+                  if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
+                }
+                init();
+                if (_isFridayMakeupMode) renderFridayProgressBanner_();
+              })
+              .withFailureHandler(function() {
+                init(); // queue fetch failed — fall through to normal Friday
+              })
+              .getFridayMakeupQueueSafe('buggsy');
+            return; // init() called from queue callback, not here
           }
           init();
         } else if (c.review_quiz && c.review_quiz.length > 0) {

--- a/Kidshub.js
+++ b/Kidshub.js
@@ -5,7 +5,7 @@
 // READS FROM: 🧹📅 KH_* (all KH tabs), 💻🧮 Helpers, 💻 Curriculum
 // ════════════════════════════════════════════════════════════════════
 
-function getKidsHubVersion() { return 73; }
+function getKidsHubVersion() { return 74; }
 
 // ── TAB NAMES (logical → resolved via TAB_MAP in DataEngine) ─────
 var KH_TABS = {
@@ -3511,6 +3511,65 @@ function getTodayContentSafe(child) {
       setCachedPayload_(cacheKey, result, 300);
     }
     return result;
+  });
+}
+
+// ─── v74: Friday Makeup Queue (#410) ────────────────────────────────────────
+
+function isStaarWindow_() {
+  var mmdd = getTodayISO_().slice(5);
+  return (mmdd >= '12-01' && mmdd <= '12-11') || (mmdd >= '04-06' && mmdd <= '04-30');
+}
+
+function hasScience_(dayContent) {
+  return !!(dayContent && dayContent.module && dayContent.module.science &&
+    dayContent.module.science.questions && dayContent.module.science.questions.length > 0);
+}
+
+function buildFridayMakeupQueue_(child) {
+  var bounds = _computeWeekBounds_();
+  var eduData = readSheet_('KH_Education');
+  var attendance = _aggregateKHEducation_(child, bounds, eduData);
+  var weekLog = attendance.weekLog; // index 0=Mon … 3=Thu (first 4 of 5)
+
+  var todayContent = getTodayContent_(child);
+  if (!todayContent || !todayContent.fullWeek) return [];
+  var days = todayContent.fullWeek.days || todayContent.fullWeek;
+
+  var dayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday'];
+  var staarBoost = isStaarWindow_();
+  var monday = bounds.monday;
+  var queue = [];
+
+  for (var i = 0; i < 4; i++) {
+    var wlEntry = weekLog[i];
+    if (!wlEntry || wlEntry.status !== 'missed') continue;
+
+    var dayDate = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + i);
+    var dayISO = _isoDate_(dayDate);
+
+    var capName = dayNames[i];
+    var lcName = capName.toLowerCase();
+    var dayContent = days[lcName] !== undefined ? days[lcName] : (days[capName] !== undefined ? days[capName] : null);
+    if (!dayContent || !dayContent.module) continue;
+
+    if (typeof normalizeModule_ === 'function') {
+      dayContent.module = normalizeModule_(dayContent.module);
+    }
+
+    var priority = i;
+    if (staarBoost && hasScience_(dayContent)) priority = i - 10;
+
+    queue.push({ day: capName, dayISO: dayISO, content: dayContent, priority: priority });
+  }
+
+  queue.sort(function(a, b) { return a.priority - b.priority; });
+  return queue;
+}
+
+function getFridayMakeupQueueSafe(child) {
+  return withMonitor_('getFridayMakeupQueueSafe', function() {
+    return buildFridayMakeupQueue_(String(child || 'buggsy').toLowerCase());
   });
 }
 

--- a/ops/specs/2026-04-16-friday-review-missed-day-queue.md
+++ b/ops/specs/2026-04-16-friday-review-missed-day-queue.md
@@ -1,0 +1,82 @@
+# Spec: Friday Review — Missed Day Catch-Up Queue
+
+**Issue:** #410
+**Date:** 2026-04-16
+**Status:** Implementing
+
+---
+
+## Problem
+
+Friday Review is pre-seeded generic curriculum, not a dynamic rollup of missed content. If Buggsy missed Tuesday + Wednesday, Friday silently walks past the missed material. A kid who misses Wednesday's Food Chains science but aces Friday's 2 generic science questions gets a false green signal. That is a measurement lie and breaks LT-trust.
+
+## Verified On
+
+- `CurriculumSeed.js:1176-1219` — Week 2 Friday has only 2 science questions (predator/prey + hibernation), both from Monday's Animal Adaptations. Wednesday's Food Chains (TEKS 4.9A/4.9B) is not represented.
+- `Kidshub.js:3294-3398` — `_aggregateKHEducation_` initializes weekLog with `status: 'missed'` for any past day without a KH_Education row. The data is there; it was never surfaced on Friday.
+- 2026-04-16 STAAR incident: Wednesday's Food Chains science got no Friday surfacing before Thursday's test.
+
+## Why It Matters
+
+Friday is the only catch-all chance in the week. Silent Friday = silent weekly miss. Severity:critical per rubric (#378) — directly breaks unsupervised trust and TEKS coverage measurement.
+
+## What Changes
+
+### Server (Kidshub.js v73 → v74)
+
+New functions added after `getTodayContentSafe`:
+
+- `isStaarWindow_()` — returns true if today is Apr 6–30 or Dec 1–11 (Nance STAAR windows per `nance-school-data.md`)
+- `hasScience_(dayContent)` — returns true if a day's content has science module questions
+- `buildFridayMakeupQueue_(child)` — private; reads weekLog via `_aggregateKHEducation_`, finds missed Mon-Thu days, fetches their content from fullWeek, sorts with STAAR-window science-first priority
+- `getFridayMakeupQueueSafe(child)` — public `withMonitor_` wrapper; callable from surface AND diagnostics
+
+No schema changes. Existing `makeupDate` field in `submitHomework_` (added in #409) handles crediting to original day — no server changes needed there.
+
+### Client (HomeworkModule.html)
+
+New state: `_fridayQueue`, `_fridayQueueIndex`, `_isFridayMakeupMode`, `_pendingFridayResponse`
+
+New functions:
+- `renderFridayProgressBanner_()` — "CATCH-UP MODE / You missed N days / Day N of N — Wednesday Catch-Up"
+- `_advanceFridayQueue_()` — resets per-step state (answers, completionSubmitState, moduleStarted, etc.), loads next MODULE, re-renders all tabs
+
+Modified:
+- `loadCurriculumContent()` — on Friday (non-`MAKEUP_MODE`), fires `getFridayMakeupQueueSafe` after `getTodayContentSafe` succeeds; if queue non-empty, builds `_fridayQueue = [...missedDays, fridayStep]`, overrides MODULE to first step, removes generic catch-up banner, calls `init()` then `renderFridayProgressBanner_()`
+- `buildHomeworkCompletionPayload_()` — passes `makeupDate = _fridayQueue[_fridayQueueIndex].dayISO` for non-Friday steps
+- `submitHomeworkCompletion_()` success handler — localStorage stamps original day ISO; calls `_advanceFridayQueue_()` if more steps remain
+
+## Unknowns
+
+None at build time. All data (weekLog, fullWeek) was already available server-side; this change wires it to the Friday surface.
+
+## LT Decisions Needed
+
+- **Friday credit:** Spec says makeup earns TEKS coverage but does NOT extend streak. Ring award still happens via `kh_awardEducationPoints_` using today's dedup UID — rings are earned for work done today. Original-day ISO only affects KH_Education Timestamp (for weekLog) and localStorage. Confirm this matches intent.
+- **No cap on queue depth:** A kid who missed 4 days and shows up Friday sees 5 steps. Hyperfocus catching up is a WIN. Confirm no cap desired.
+
+## Acceptance Tests
+
+1. Load `/homework` on Friday where Buggsy has missed Tuesday + Wednesday → banner shows "You missed 2 days", MODULE = Tuesday content
+2. STAAR window active (Apr 6-30): if Wednesday had science, Wednesday sorts before Tuesday
+3. Complete Tuesday step → KH_Education row timestamps to Tuesday ISO, surface advances to Wednesday
+4. Complete Wednesday → advances to Friday Review
+5. Complete Friday Review → normal completion screen, no extra step
+6. Friday with zero missed days → no banner, normal Friday Review loads directly
+7. `?day=wednesday` on Friday → MAKEUP_MODE active, Friday queue does NOT fire
+8. `getFridayMakeupQueueSafe('buggsy')` callable from GAS editor independently
+
+## Evidence After Completion
+
+- [ ] PR #419 green CI
+- [ ] `?action=runTests` clean
+- [ ] Manual walkthrough on Buggsy's Surface Pro 5 with simulated 2-day-missed week
+- [ ] KH_Education row for makeup step shows Tuesday ISO as Timestamp, not Friday
+
+## Codex Review Checklist
+
+- [ ] `buildFridayMakeupQueue_` handles edge case: day exists in weekLog as missed but has no content in fullWeek (skipped via `if (!dayContent || !dayContent.module) continue`)
+- [ ] `_advanceFridayQueue_` resets all per-step state (answers, completionSubmitState, completionLogged, moduleStarted, brain break counter)
+- [ ] ES5 compliance — no arrow functions, template literals, let/const in HomeworkModule.html
+- [ ] `withMonitor_` wrapper on public server function
+- [ ] `makeupDate` not sent as empty string when it should be '' — checked: `_fridayQueueIndex < _fridayQueue.length - 1` guard ensures Friday step sends `makeupDate: ''`


### PR DESCRIPTION
## Summary

- **Server (Kidshub.js v74):** `getFridayMakeupQueueSafe` + `buildFridayMakeupQueue_` return an ordered list of missed Mon-Thu day content. STAAR-window science days (Apr 6-30, Dec 1-11) sort first within the queue via `isStaarWindow_` + `hasScience_`.
- **Client (HomeworkModule.html):** On Friday (non-`MAKEUP_MODE`), a second `getFridayMakeupQueueSafe` call fires after `getTodayContentSafe`. If missed days exist, the surface enters `_isFridayMakeupMode` — missed days play in priority order before Friday Review.
- **Progress banner:** "Day N of N — [Wednesday] Catch-Up" updates at each step. Suppresses the generic catch-up banner while in queue mode.
- **Credit:** Each missed-day step passes `makeupDate` (original day ISO) to `submitHomeworkSafe`, so KH_Education rows timestamp to the original day. `localStorage` stamps that day as done so the catch-up banner skips it.
- **Advancement:** Queue auto-advances on successful submit. Last step (Friday Review) flows to normal completion screen.

## Test plan

- [ ] Load `/homework` on a Friday where Buggsy has missed Tuesday + Wednesday → banner shows "You missed 2 days", starts with Tuesday content
- [ ] STAAR window active (Apr 6-30): if Wednesday had science, Wednesday appears before Tuesday in queue
- [ ] Complete Tuesday step → KH_Education row timestamps to Tuesday ISO, advances to Wednesday
- [ ] Complete Wednesday step → advances to Friday Review
- [ ] Complete Friday Review → normal completion screen
- [ ] Friday with no missed days → no banner, normal Friday Review loads directly
- [ ] `MAKEUP_MODE` (`?day=wednesday`) on Friday → Friday queue does NOT activate, existing makeup flow runs
- [ ] `getFridayMakeupQueueSafe` callable from diagnostics independently

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)