### PR TITLE
fix(#422): v19 version bump + replace unicode dash in renderFridayProgressBanner_

### DIFF
--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="homework-module">
-<meta name="tbm-version" content="v18">
+<meta name="tbm-version" content="v19">
 <title>Wolfkid Training Module</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -2223,7 +2223,7 @@ function renderFridayProgressBanner_() {
   var totalSteps = _fridayQueue.length;
   var stepDay = _fridayQueue[_fridayQueueIndex].day;
   var stepLabel = isMakeupStep
-    ? 'Day ' + stepNum + ' of ' + totalSteps + ' \u2014 ' + stepDay + ' Catch-Up'
+    ? 'Day ' + stepNum + ' of ' + totalSteps + ' -- ' + stepDay + ' Catch-Up'
     : 'Friday Review (' + stepNum + ' of ' + totalSteps + ')';
 
   var banner = document.createElement('div');


### PR DESCRIPTION
## Summary

- **Version bump** `tbm-version` meta `v18` -> `v19` — two HomeworkModule.html edits (Friday queue feature + P1 overlay dismiss) made it into main without incrementing the version
- **Unicode fix** unicode em-dash replaced with `--` in `renderFridayProgressBanner_()` step label — Codex ES5 gate false-positive flag from #419 CI

## Context

PR #419 was squash-merged. The P1 overlay-dismiss commit was included in main via a subsequent merge. Neither the #419 squash nor the P1 fix bumped the version meta. This PR addresses both loose ends.

Closes #422

## Test Plan

- [ ] `?action=runTests` clean at @656
- [ ] CF routes return 200
- [ ] Friday with missed days: overlay dismisses before next step loads
- [ ] `tbm-version` content is `v19` in prod source

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>