### PR TITLE
feat: whitelist admin functions via API with shared-secret auth (closes #414, closes #379)

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,6 +1,6 @@
 // Version history tracked in Notion deploy page. Do not add version comments here.
 // ════════════════════════════════════════════════════════════════════
-// Code.gs v91 — Apps Script Router (TBM Consolidated)
+// Code.gs v93 — Apps Script Router (TBM Consolidated)
 // WRITES TO: (routes only — delegates to DataEngine, KidsHub, etc.)
 // READS FROM: (routes only — delegates to DataEngine, KidsHub, etc.)
 // ════════════════════════════════════════════════════════════════════
@@ -19,7 +19,7 @@ function isLessonRunsEnabled_() {
   } catch (e) { return false; }
 }
 
-function getCodeVersion() { return 92; }
+function getCodeVersion() { return 93; }
 
 // v37 FIX 5: ES5-safe left-pad helper — replaces String.padStart()
 function leftPad2_(n) {
@@ -552,17 +552,37 @@ function serveData(e) {
         'getPendingReviewsSafe': getPendingReviewsSafe,
         // ContentEngine.gs v2 — Vocabulary usage grading (#225)
         'gradeVocabUsageSafe': gradeVocabUsageSafe,
-        'diagOpsTriggersSafe': diagOpsTriggersSafe
+        'diagOpsTriggersSafe': diagOpsTriggersSafe,
+        'diagFeedbackPipelineSafe': diagFeedbackPipelineSafe
       };
 
-      if (!fn || !API_WHITELIST[fn]) {
+      // v93 (#414, #379): Write admin functions require OPS_ADMIN_TOKEN shared-secret.
+      var ADMIN_WHITELIST = {
+        'installAllOpsTriggersSafe': installAllOpsTriggersSafe,
+        'reconcileOpsTriggersSafe': reconcileOpsTriggersSafe,
+        'uninstallOpsTriggerSafe': uninstallOpsTriggerSafe,
+        'installTriageFeedbackTriggerSafe': installTriageFeedbackTriggerSafe,
+        'uninstallTriageFeedbackTriggerSafe': uninstallTriageFeedbackTriggerSafe
+      };
+
+      if (!fn || (!API_WHITELIST[fn] && !ADMIN_WHITELIST[fn])) {
         return ContentService.createTextOutput(
           JSON.stringify({ error: 'Unknown or missing function: ' + (fn || 'null') })
         ).setMimeType(ContentService.MimeType.JSON);
       }
 
+      if (ADMIN_WHITELIST[fn]) {
+        var reqToken = e.parameter.token || '';
+        var opsToken = PropertiesService.getScriptProperties().getProperty('OPS_ADMIN_TOKEN') || '';
+        if (!opsToken || reqToken !== opsToken) {
+          return ContentService.createTextOutput(
+            JSON.stringify({ error: 'Unauthorized' })
+          ).setMimeType(ContentService.MimeType.JSON);
+        }
+      }
+
       try {
-        var apiResult = API_WHITELIST[fn].apply(null, args);
+        var apiResult = (API_WHITELIST[fn] || ADMIN_WHITELIST[fn]).apply(null, args);
         if (apiResult === undefined) apiResult = null;
         return ContentService.createTextOutput(
           JSON.stringify(apiResult)
@@ -1920,4 +1940,4 @@ function getOpsHealthSafe() {
   });
 }
 
-// END OF FILE — Code.gs v91
+// END OF FILE — Code.gs v93

--- a/FeedbackPipeline.js
+++ b/FeedbackPipeline.js
@@ -1,5 +1,5 @@
 // ════════════════════════════════════════════════════════════════════
-// FeedbackPipeline.gs v1 — Gemini Triage + Auto-Issue + Weekly Digest
+// FeedbackPipeline.gs v2 — Gemini Triage + Auto-Issue + Weekly Digest
 // WRITES TO: Feedback (Processed, Classification columns)
 // READS FROM: Feedback, Script Properties (GEMINI_API_KEY, GITHUB_PAT)
 // DEPENDENCIES: callGemini_ (ContentEngine.gs), sendPush_ (AlertEngine),
@@ -7,7 +7,7 @@
 // Issue: #231
 // ════════════════════════════════════════════════════════════════════
 
-function getFeedbackPipelineVersion() { return 1; }
+function getFeedbackPipelineVersion() { return 2; }
 
 // ════════════════════════════════════════════════════════════════════
 // LAYER 2: GEMINI TRIAGE — classify unprocessed feedback rows
@@ -355,5 +355,107 @@ function runFeedbackPipeline() {
   Logger.log('=== Pipeline Complete ===');
 }
 
+// ── DIAG + TRIGGER MANAGEMENT (v2, #379) ─────────────────────────
+
+function diagFeedbackPipelineSafe() {
+  try {
+    var ss = SpreadsheetApp.openById(SSID);
+    var tabName = (typeof TAB_MAP !== 'undefined' && TAB_MAP['Feedback']) || '💻 Feedback';
+    var sheet = ss.getSheetByName(tabName);
+    if (!sheet) return { ok: false, error: 'Feedback sheet missing' };
+
+    var headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+    var colMap = {};
+    for (var h = 0; h < headers.length; h++) { colMap[headers[h]] = h; }
+
+    var lastRow = sheet.getLastRow();
+    if (lastRow < 2) return { ok: true, pipelineVersion: getFeedbackPipelineVersion(), totalRows: 0 };
+
+    var data = sheet.getRange(2, 1, lastRow - 1, headers.length).getValues();
+    var totalRows = data.length;
+    var unprocessed = 0;
+    var processedToday = 0;
+    var classifications = {};
+    var oldestUnprocessed = null;
+    var todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    for (var i = 0; i < data.length; i++) {
+      var row = data[i];
+      var processed = String(row[colMap['Processed']] || '');
+      var timestamp = new Date(row[colMap['Timestamp']] || 0);
+      var classification = String(row[colMap['Classification']] || '');
+
+      if (!processed) {
+        unprocessed++;
+        if (!oldestUnprocessed || timestamp < new Date(oldestUnprocessed)) {
+          oldestUnprocessed = timestamp.toISOString();
+        }
+      } else if (timestamp >= todayStart) {
+        processedToday++;
+      }
+      if (classification) {
+        classifications[classification] = (classifications[classification] || 0) + 1;
+      }
+    }
+
+    var triggers = ScriptApp.getProjectTriggers();
+    var triageTriggers = [];
+    for (var t = 0; t < triggers.length; t++) {
+      if (triggers[t].getHandlerFunction() === 'triageFeedback') {
+        triageTriggers.push({
+          type: String(triggers[t].getEventType()),
+          source: String(triggers[t].getTriggerSource())
+        });
+      }
+    }
+
+    return {
+      ok: true,
+      pipelineVersion: getFeedbackPipelineVersion(),
+      sheetName: tabName,
+      totalRows: totalRows,
+      unprocessed: unprocessed,
+      processedToday: processedToday,
+      oldestUnprocessed: oldestUnprocessed,
+      classifications: classifications,
+      triggersInstalled: triageTriggers.length,
+      triggerDetails: triageTriggers,
+      triggersHealthy: triageTriggers.length >= 1,
+      checkedAt: new Date().toISOString()
+    };
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('diagFeedbackPipelineSafe', e);
+    return { ok: false, error: e.message || String(e) };
+  }
+}
+
+function installTriageFeedbackTriggerSafe() {
+  return withMonitor_('installTriageFeedbackTriggerSafe', function() {
+    var triggers = ScriptApp.getProjectTriggers();
+    for (var t = 0; t < triggers.length; t++) {
+      if (triggers[t].getHandlerFunction() === 'triageFeedback') {
+        return { ok: true, installed: false, msg: 'Trigger already installed' };
+      }
+    }
+    ScriptApp.newTrigger('triageFeedback').timeBased().atHour(7).nearMinute(0).everyDays(1).create();
+    return { ok: true, installed: true, msg: 'triageFeedback daily trigger installed at 7 AM' };
+  });
+}
+
+function uninstallTriageFeedbackTriggerSafe() {
+  return withMonitor_('uninstallTriageFeedbackTriggerSafe', function() {
+    var triggers = ScriptApp.getProjectTriggers();
+    var removed = 0;
+    for (var t = 0; t < triggers.length; t++) {
+      if (triggers[t].getHandlerFunction() === 'triageFeedback') {
+        ScriptApp.deleteTrigger(triggers[t]);
+        removed++;
+      }
+    }
+    return { ok: true, removed: removed };
+  });
+}
+
 // Version history tracked in Notion deploy page. Do not add version comments here.
-// FeedbackPipeline.gs v1 — EOF
+// FeedbackPipeline.gs v2 — EOF


### PR DESCRIPTION
## Summary
- Adds `OPS_ADMIN_TOKEN`-guarded `ADMIN_WHITELIST` to Code.js API router — 5 write-admin functions now callable remotely without LT opening GAS editor
- Adds `diagFeedbackPipelineSafe` to read whitelist (no auth) — returns triage stats, trigger health, classification breakdown
- Adds `diagFeedbackPipelineSafe`, `installTriageFeedbackTriggerSafe`, `uninstallTriageFeedbackTriggerSafe` to FeedbackPipeline.js

## Functions added

| Endpoint | Auth | Purpose |
|---|---|---|
| `diagFeedbackPipelineSafe` | none | Read-only health check |
| `installAllOpsTriggersSafe` | OPS_ADMIN_TOKEN | Install/re-install all spec triggers |
| `reconcileOpsTriggersSafe` | OPS_ADMIN_TOKEN | Drift detection on-demand |
| `uninstallOpsTriggerSafe` | OPS_ADMIN_TOKEN | Surgical trigger removal |
| `installTriageFeedbackTriggerSafe` | OPS_ADMIN_TOKEN | Install daily 7 AM triage trigger |
| `uninstallTriageFeedbackTriggerSafe` | OPS_ADMIN_TOKEN | Remove triage trigger |

## Auth pattern
`?fn=<adminFn>&args=[]&token=<OPS_ADMIN_TOKEN>` — token matches Script Property `OPS_ADMIN_TOKEN`. Missing/wrong token → `{"error":"Unauthorized"}`. Read-only diag functions bypass auth.

## Verified on production (@657)
- `curl .../api?fn=diagFeedbackPipelineSafe` → `{"ok":true,"pipelineVersion":2,...,"triggersHealthy":true}`
- `curl .../api?fn=installAllOpsTriggersSafe` (no token) → `{"error":"Unauthorized"}`

## Required: set OPS_ADMIN_TOKEN Script Property
LT must set `OPS_ADMIN_TOKEN` in GAS Script Properties to enable admin endpoint calls.

Closes #414
Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)