### PR TITLE
fix(#429): Friday Reflection test — getFridayMakeupQueueSafe fixture + catch-up banner Fix A+C

### DIFF
--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -2160,7 +2160,14 @@ function showLoadError_(reason) {
 // Shows missed weekdays from fullWeek that have module content and haven't been dismissed.
 function dismissCatchUpBanner_() {
   var b = document.getElementById('tbm-catchup-banner');
-  if (b && b.parentNode) b.parentNode.removeChild(b);
+  if (!b) return;
+  var keys = (b.getAttribute('data-dismiss-keys') || '').split(',');
+  for (var i = 0; i < keys.length; i++) {
+    if (keys[i]) {
+      try { window.localStorage.setItem(keys[i], '1'); } catch(e) {}
+    }
+  }
+  if (b.parentNode) b.parentNode.removeChild(b);
 }
 
 function renderCatchUpBanner_(fullWeek) {
@@ -2199,8 +2206,10 @@ function renderCatchUpBanner_(fullWeek) {
   }
   if (!missed.length) return;
   var items = '';
+  var dismissKeys = [];
   for (var j = 0; j < missed.length; j++) {
     var m = missed[j];
+    dismissKeys.push(m.dismissKey);
     items += '<a href="/homework?day=' + m.day.toLowerCase() + '" ' +
       'style="display:inline-block;background:#1e293b;border:1px solid #f97316;border-radius:8px;' +
       'padding:8px 16px;margin:4px;color:#fdba74;font-family:Orbitron,sans-serif;font-size:12px;' +
@@ -2209,6 +2218,7 @@ function renderCatchUpBanner_(fullWeek) {
   }
   var banner = document.createElement('div');
   banner.id = 'tbm-catchup-banner';
+  banner.setAttribute('data-dismiss-keys', dismissKeys.join(','));
   banner.style.cssText = 'position:fixed;top:0;left:0;right:0;background:#1a1200;border-bottom:2px solid #f97316;' +
     'padding:10px 16px;text-align:center;font-family:Nunito,sans-serif;z-index:200;';
   banner.innerHTML = '<div style="font-size:13px;color:#fde68a;font-weight:700;margin-bottom:6px;">' +

--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="tbm-module" content="homework-module">
-<meta name="tbm-version" content="v19">
+<meta name="tbm-version" content="v20">
 <title>Wolfkid Training Module</title>
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Orbitron:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -2158,6 +2158,11 @@ function showLoadError_(reason) {
 
 // ─── CATCH-UP BANNER (#409) ───
 // Shows missed weekdays from fullWeek that have module content and haven't been dismissed.
+function dismissCatchUpBanner_() {
+  var b = document.getElementById('tbm-catchup-banner');
+  if (b && b.parentNode) b.parentNode.removeChild(b);
+}
+
 function renderCatchUpBanner_(fullWeek) {
   var ORDERED_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
   var today = new Date();
@@ -2204,10 +2209,13 @@ function renderCatchUpBanner_(fullWeek) {
   }
   var banner = document.createElement('div');
   banner.id = 'tbm-catchup-banner';
-  banner.style.cssText = 'background:#1a1200;border-bottom:2px solid #f97316;padding:10px 16px;' +
-    'text-align:center;font-family:Nunito,sans-serif;';
+  banner.style.cssText = 'position:fixed;top:0;left:0;right:0;background:#1a1200;border-bottom:2px solid #f97316;' +
+    'padding:10px 16px;text-align:center;font-family:Nunito,sans-serif;z-index:200;';
   banner.innerHTML = '<div style="font-size:13px;color:#fde68a;font-weight:700;margin-bottom:6px;">' +
-    '\uD83D\uDCC5 Missed days this week \u2014 tap to catch up:</div>' + items;
+    '\uD83D\uDCC5 Missed days this week \u2014 tap to catch up:</div>' + items +
+    '<button data-testid="catchup-banner-dismiss" onclick="dismissCatchUpBanner_()" ' +
+    'style="position:absolute;top:6px;right:10px;background:none;border:none;color:#fde68a;' +
+    'font-size:16px;cursor:pointer;padding:4px 8px;line-height:1;">\u2715</button>';
   document.body.insertBefore(banner, document.body.firstChild);
 }
 

--- a/tests/tbm/education-workflows.spec.js
+++ b/tests/tbm/education-workflows.spec.js
@@ -63,6 +63,17 @@ function filterRealErrors(errors) {
   });
 }
 
+// Dismiss the catch-up banner (added in #411) if present, then wait for the
+// Plan Your Attack overlay. The banner renders when the server returns fullWeek
+// data with missed days — dismiss before asserting plan overlay visibility.
+async function waitForPlanAttack(page) {
+  var dismissBtn = page.locator('[data-testid="catchup-banner-dismiss"]');
+  if (await dismissBtn.count() > 0) {
+    await dismissBtn.click();
+  }
+  await page.locator('.es-plan-attack').waitFor({ state: 'visible', timeout: 20000 });
+}
+
 // ---------------------------------------------------------------------------
 // Homework Module
 // ---------------------------------------------------------------------------
@@ -78,7 +89,7 @@ test.describe('Homework: Plan Your Attack → answer flow → completion', funct
 
     // Plan Your Attack screen should be visible — wait for dynamic render (ExecSkills.showPlanYourAttack
     // injects .es-plan-attack into #plan-overlay after getTodayContentSafe returns).
-    await page.locator('.es-plan-attack').waitFor({ state: 'visible', timeout: 20000 });
+    await waitForPlanAttack(page);
 
     // Click ready button to start session
     await page.locator('.es-ready-btn').click();
@@ -121,7 +132,7 @@ test.describe('Homework: wrong answer shows purple not red', function() {
     await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
 
     // Wait for Plan Your Attack to render before clicking the ready button.
-    await page.locator('.es-plan-attack').waitFor({ state: 'visible', timeout: 20000 });
+    await waitForPlanAttack(page);
     // Start the session
     await page.locator('.es-ready-btn').click();
     await page.waitForTimeout(2000);
@@ -242,7 +253,7 @@ test.describe('Homework: brain break fires after 4 answers', function() {
 
     await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
     // Wait for Plan Your Attack to render (replaces fixed 6s timeout)
-    await page.locator('.es-plan-attack').waitFor({ state: 'visible', timeout: 20000 });
+    await waitForPlanAttack(page);
     await page.locator('.es-ready-btn').click();
     await page.locator('.es-session-timer').waitFor({ state: 'visible', timeout: 10000 });
 
@@ -281,7 +292,7 @@ test.describe('Homework: Monday Error Journal appears', function() {
     await shimGAS(page, FIXTURES);
 
     await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
-    await page.locator('.es-plan-attack').waitFor({ state: 'visible', timeout: 20000 });
+    await waitForPlanAttack(page);
     await page.locator('.es-ready-btn').click();
     await page.locator('.es-session-timer').waitFor({ state: 'visible', timeout: 10000 });
 
@@ -315,7 +326,7 @@ test.describe('Homework: Friday Reflection appears', function() {
     await shimGAS(page, FIXTURES);
 
     await page.goto(BASE_URL + '/homework', { waitUntil: 'domcontentloaded', timeout: 60000 });
-    await page.locator('.es-plan-attack').waitFor({ state: 'visible', timeout: 20000 });
+    await waitForPlanAttack(page);
     await page.locator('.es-ready-btn').click();
     await page.locator('.es-session-timer').waitFor({ state: 'visible', timeout: 10000 });
 

--- a/tests/tbm/fixtures/gas-shim.js
+++ b/tests/tbm/fixtures/gas-shim.js
@@ -165,6 +165,11 @@ var EDUCATION_FIXTURES = {
   logScaffoldEventSafe: { success: true },
   getAudioBatchSafe: {},
 
+  // getFridayMakeupQueueSafe: return empty queue so the Friday clock test
+  // enters init() directly without hitting the real GAS backend.
+  // Empty array = no makeup days queued → _isFridayMakeupMode stays false.
+  getFridayMakeupQueueSafe: [],
+
   // getAssetRegistrySafe: not yet in Cloudflare FNS list — shimGAS injects it
   // so SparkleLearning.html doesn't throw "is not a function".
   getAssetRegistrySafe: {}


### PR DESCRIPTION
## Summary

- **Root cause (confirmed from CI run 24538473514):** `getFridayMakeupQueueSafe` missing from test fixtures. Friday clock test entered the Friday code path, `route.continue()` sent a real GAS request, success handler crashed on non-JSON response body, `init()` never ran, `.es-plan-attack` never appeared — 20s timeout, 3 retries, FAIL.
- **Fix 1 — `tests/tbm/fixtures/gas-shim.js`:** Add `getFridayMakeupQueueSafe: []`. Empty array → no makeup queue → Friday branch calls `init()` directly.
- **Fix A — `tests/tbm/education-workflows.spec.js`:** Extract `waitForPlanAttack(page)` helper that dismisses the catch-up banner (`data-testid="catchup-banner-dismiss"`) before asserting `.es-plan-attack` visibility. Replaces 5 raw `waitFor` calls. Defensive for live-server runs where `fullWeek` data is returned.
- **Fix C — `HomeworkModule.html` v20:** Add `dismissCatchUpBanner_()` function + dismiss button with `data-testid`. Lift banner to `position:fixed; z-index:200` so it renders as a visible top strip above the plan overlay instead of behind it — kid sees missed-days strip AND Plan Your Attack screen together.

## Test plan

- [ ] CI Playwright education workflow tests: 11 passed, 0 failed (was 10 passed, 1 failed)
- [ ] Specifically: `Homework: Friday Reflection appears > reflection panel renders when clock is set to Friday` — should PASS
- [ ] `/homework` with fullWeek data: catch-up banner appears at top as a fixed strip; dismiss button (✕) closes it; Plan Your Attack screen visible below
- [ ] `/homework?day=wednesday` makeup mode: catch-up banner still renders for other missed days; no regression

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)