### PR TITLE
feat(#442): Play-Gate PR 1 — architecture spike

### DIFF
--- a/.claude/skills/play-buggsy/SKILL.md
+++ b/.claude/skills/play-buggsy/SKILL.md
@@ -1,151 +1,33 @@
 ---
 name: play-buggsy
-description: Run MVSS v1 Play gate against a single Buggsy education route. Produce a ship/ship-with-backlog/do-not-ship verdict with evidence. Use when evaluating /homework, /reading, /writing, /wolfkid, /facts, /investigation, /comic-studio, /daily-missions, /wolfdome, /power-scan, or /baseline for Buggsy. Invoked by LT or Mastermind for P0-15 Play gate runs.
+description: STUB — delegates to the play-gate skill with child=buggsy. Kept for one release cycle per v8 plan B1 so any caller referring to this skill name continues to work. Runs the Play-Gate quality check against a Buggsy route and produces a schema-identical verdict to play-gate.
 ---
 
-# Play/Buggsy — MVSS v1 Quality Gate for Buggsy's Education Surfaces
+# play-buggsy — Legacy stub (one release cycle)
 
-You are the Play gate evaluator for one Buggsy route. You produce one machine-readable verdict per invocation.
+This skill is a thin stub. The authoritative skill is `.claude/skills/play-gate/SKILL.md`.
 
-## Inputs
+## Invocation
 
-- **Route slug** — one of: `/homework`, `/reading`, `/writing`, `/wolfkid`, `/facts`, `/investigation`, `/comic-studio`, `/daily-missions`, `/wolfdome`, `/power-scan`, `/baseline` (with `child=buggsy`)
-- **MVSS v1 rubric** — `ops/play-gate-rubric.v1.json`
-- **Surface map** — `ops/surface-map.md`
-- **Benchmark anchors**:
-  - Prodigy Math (https://www.prodigygame.com/main-en/prodigy-math)
-  - Pixton Education (https://www.pixton.com/proven-impacts)
-  - Book Creator Comics (https://bookcreator.com/features/comics/)
+For any Buggsy route (`/homework`, `/reading`, `/writing`, `/wolfkid`, `/facts`, `/investigation`, `/comic-studio`, `/daily-missions`, `/wolfdome`, `/power-scan`, `/baseline`), run:
 
-## Audience context
+```
+node scripts/play-gate.js --route <route> --child buggsy --mode fixture
+```
 
-Buggsy is 4th grade. Diagnosed ADHD. Attends Nance Elementary (math Meets 48%, science Meets 34%). STAAR windows: Dec 1–11, Apr 6–30. Needs:
-- 3-2-1 rule (max 3 same-type questions consecutive)
-- Count-up timers with milestones, NOT countdown (except Fact Sprint exception per `adhd-accommodations/SKILL.md:80`)
-- Amber feedback on incorrect, never red
-- Brain breaks every 4 questions
-- Surface Pro 5 is primary device (per Notion canon Surface × Device × User)
-- Marco ElevenLabs voice for audio
-- Wolfdome theme (dark grid, neon, tech aesthetic)
+The output conforms to `ops/play-gate-verdict.schema.json` and is written to `ops/evidence/play-gate/<route>/buggsy/<yyyy-mm-dd>/verdict.json`.
 
-## Per-family subsections
+## Why this is a stub
 
-Buggsy route set is heterogeneous. Apply the family-specific benchmark + subset of rubric:
+v8 plan B1 consolidates `play-jj` + `play-buggsy` into a single `play-gate` skill that reads child + route as parameters. Keeping this stub file for one cycle prevents breakage for any external caller that still references `play-buggsy` by name. D3 regression test asserts the stub produces a verdict schema-identical to the main skill.
 
-| Family | Routes | Primary competitor | Key criteria |
-|---|---|---|---|
-| `buggsy.curriculum` | `/homework`, `/reading`, `/writing`, `/wolfkid`, `/facts`, `/investigation` | Prodigy Math / Khan Academy | U1-U16, B1-B6, accessibility D-section, consistency X1-X5 |
-| `buggsy.hub` | `/daily-missions`, `/wolfdome` | (no direct competitor — internal hub) | U-set except U5/U6 (hubs don't complete loops), B1/B2 emphasized |
-| `buggsy.diagnostic` | `/baseline`, `/power-scan` | Khan Academy diagnostic flow | U-set with B5 (challenge-fit) emphasis |
-| `buggsy.creation` | `/comic-studio` | Book Creator Comics (NOT Pixton — LT 2026-04-15) | C1-C6 (creation criteria) + U-set |
+## Removal schedule
 
-## Process
+PR 2 cycle close: remove this stub if no caller outside the repo still references it (grep `ops/`, `.github/`, external procedure docs).
 
-### Step 1 — Resolve surface
+## Reference
 
-Read `ops/surface-map.md`. Identify route's family (from `product_class` column). Extract device, code, persistence contract, primary competitor, comparison anchor.
-
-**Family override — `/wolfdome`:** The surface map currently labels `/wolfdome` as `creation-tool`, but it is a hub surface. Treat `/wolfdome` as `buggsy.hub` regardless of what `product_class` says in the map. Apply hub criteria (U-set minus U5/U6, B1/B2 emphasis) and skip ComicStudio C1-C6 subfamily.
-
-For all other routes: if `product_class` is `curriculum-module` → `buggsy.curriculum`; `hub` → `buggsy.hub`; `diagnostic` → `buggsy.diagnostic`; `creation-tool` → `buggsy.creation`.
-
-### Step 2 — Preconditions
-
-Same as Play/JJ: PRE-1 (skip for modern-JS tier), PRE-2 (failure handlers), PRE-3 (Wolfdome palette vs `ops/themes/palettes.md`), PRE-4 (Safe wrapper chain).
-
-### Step 3 — Gather evidence
-
-Identical tool pattern to Play/JJ but:
-- Viewport: 1368×912 for `buggsy-workstation` routes (Surface Pro 5)
-- Voice check: Marco voice ID, not Nia
-
-Artifact paths: `ops/evidence/preview/<route-slug>/buggsy/<yyyy-mm-dd>/`.
-
-### Step 4 — Evaluate criteria
-
-**Universal (U1-U16):** same as Play/JJ skill.
-
-**Buggsy-specific (B1-B6):**
-- B1 mission-clarity: goal stated in ≤1 short sentence + visible at top of surface
-- B2 progress-reward-clarity: XP/rings/completion meter visible and updating believably
-- B3 creation-usability: for creation family — typing/drawing/panel-selection feels responsive on Surface Pro 5
-- B4 resume-integrity: per `persistence_contract` — draft/submitted/configured-once state restored correctly on reload
-- B5 challenge-fit: content difficulty appropriate (not babyish, not frustrating). Sample 3 questions against grade-4 standards
-- B6 artifact-or-accomplishment: evidence the kid can point to as "I did this" — saved artifact, submitted answer, earned ring
-
-**Family-specific additions:**
-
-For `buggsy.curriculum`:
-- 3-2-1 rule: scan question sequence, no 3+ same-type consecutive (per `adhd-accommodations/SKILL.md:63`)
-- Count-up timer only (exception: `/facts`): look for countdown syntax, fail if present outside Fact Sprint
-- Amber feedback on wrong: grep CSS for `color: red` or similar in feedback states; fail if present
-- Brain break every 4Q: look for break affordance or inserted micro-pause every 4 question indices
-
-For `buggsy.creation` (ComicStudio only):
-- C1 panel-layout-library: count available panel layouts, must be ≥6 without freeform drawing
-- C2 dialogue-affordance: speech bubble placement + text entry works on Surface Pro 5
-- C3 character-placement: drag-drop character/image onto panel — no rigging required
-- C4 canvas-freeform: freeform drawing + image import as panel layer
-- C5 artifact-export: save and export as single comic (PNG or PDF), restorable
-- C6 multi-comic-library: past comics persist, reopenable
-
-For `buggsy.hub`:
-- **Skip U5 and U6 entirely** — hub surfaces do not own a completable loop or a persistence contract, so evaluating core-loop-completes or save-reload-holds will produce false failures. Mark both as `not_applicable` in the verdict.
-- Focus evaluation on U1-U4, U7-U16, B1/B2, X1-X5.
-- Navigation to all gated surfaces is functional.
-
-For `buggsy.diagnostic`:
-- B5 challenge-fit: critical (diagnostic must calibrate to actual grade-level)
-- U6 save-reload-holds: critical (diagnostic can take multiple sessions; mid-flight state must persist)
-
-**Accessibility (D-section):** same as Play/JJ but target size threshold is ≥24 CSS px (not 60 — Surface Pro 5 is not JJ tablet).
-
-**Consistency (X1-X5):**
-- X1 nav-placement: consistent header position across Buggsy surface set
-- X2 back-behavior: destination matches `back_destination` column in surface-map
-- X3 save-indicator: only allowed tokens (`Saved`, `Saving…`, `Unsaved changes`)
-- X4 success-copy: drawn from `ops/copy-patterns.md` allowed vocab
-- X5 error-copy: pattern `[what failed] + [user-actionable next step]`
-
-### Step 5 — Emit verdict
-
-Write to `ops/evidence/preview/<route-slug>/buggsy/<yyyy-mm-dd>/verdict.json`.
-
-Schema identical to Play/JJ but with `child: "buggsy"`, Buggsy-family criteria in passed/failed lists, and benchmark notes comparing against family's primary competitor.
-
-Special cases for Buggsy:
-- If the route is `/comic-studio` AND C1-C6 subfamily applies, include explicit comparison to Book Creator Comics in `benchmarkNotes`.
-- If `adhd-accommodations` 3-2-1/amber/countdown rules fail → severity `critical` (kid-facing reward pattern broken, akin to LT's #377 calibration).
-
-### Step 6 — Escalation
-
-Same #378 contract. Buggsy-specific note: ADHD-rule violations (3-2-1, countdown-where-banned, red feedback) default to severity `critical` unless the surface is explicitly whitelisted.
-
-### Step 7 — Return summary
-
-Print verdict JSON. One paragraph prose. Stop.
-
-## Guardrails
-
-- Do NOT modify code.
-- If comic-studio times out (known Issue #377), emit `config_drift` with note "blocked by #377" — don't falsely mark as do-not-ship.
-- Respect the Nance Elementary context: Buggsy's math/science baseline is below state average. Content that's "too hard" for a 4th grader elsewhere may be appropriate scaffolding here; use B5 judgment, not generic grade-4 benchmarks.
-
-## Related
-
-- Parent: MVSS v1 PR #361 (merged)
+- Consolidated skill: `.claude/skills/play-gate/SKILL.md`
 - Rubric: `ops/play-gate-rubric.v1.json`
-- Spec: `ops/specs/2026-04-15-play-surface-minimum-viable-standard.md`
-- Companion: Play/JJ skill (P0-12 Issue)
-- Successor work: P0-15 (run skill against all 11 Buggsy routes), P0-16 (fix findings)
-- Inline-finding contract: #378
-- Known blocker: #377 (ComicStudio timeout — may gate full evaluation of /comic-studio)
-
-## Build Skills
-
-- `thompson-engineer` — server architecture
-- `adhd-accommodations` — 3-2-1, countdown exception, amber rule, brain breaks
-- `references:teks-math-grade4` — math content evaluation context
-- `references:teks-science-grade4` — science content evaluation context
-- `references:nance-school-data` — STAAR windows, school baselines
-- `education-qa` — 7-gate framework
+- Schema: `ops/play-gate-verdict.schema.json`
+- Build Issue: #442

--- a/.claude/skills/play-gate/SKILL.md
+++ b/.claude/skills/play-gate/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: play-gate
+description: Run the Play-Gate quality check against a single TBM education route. Produce a ship / ship-with-backlog / do-not-ship verdict with evidence conforming to ops/play-gate-verdict.schema.json. Supports both JJ and Buggsy routes. Invoked by LT, Mastermind, or scheduled tasks for Play-Gate runs. Replaces the legacy play-jj / play-buggsy skills (those remain as thin stubs for one cycle per v8 plan).
+---
+
+# Play-Gate — MVSS v1 Quality Gate (consolidated)
+
+You are the Play-Gate evaluator. You produce exactly one machine-readable verdict per invocation. This is the architecture-spike skill for PR 1 — `scripts/play-gate.js` is the code registry that dispatches the 12 PR-1 criteria.
+
+## Inputs
+
+- **Route slug** — JJ routes: `/sparkle`, `/sparkle-free`, `/daily-adventures`, `/sparkle-kingdom`. Buggsy routes: `/homework`, `/reading`, `/writing`, `/wolfkid`, `/facts`, `/investigation`, `/comic-studio`, `/daily-missions`, `/wolfdome`, `/power-scan`, `/baseline`.
+- **Rubric** — `ops/play-gate-rubric.v1.json` (authoritative criterion list + thresholds)
+- **Profiles** — `ops/play-gate-profiles.json` (canonical device/viewport/voice/theme; all consumers read from this)
+- **Surface map** — `ops/surface-map.md`
+- **Schema** — `ops/play-gate-verdict.schema.json` (ajv-validated verdict shape; D1 regression enforces `ship_decision` field, forbids legacy `verdict` field)
+
+## How it runs
+
+```
+node scripts/play-gate.js --route /sparkle --child jj --mode fixture
+node scripts/play-gate.js --route /homework --child buggsy --mode fixture
+```
+
+The CLI spawns Playwright against `tests/tbm/play-gate/play-gate.spec.js`, which:
+1. Resolves device viewport from `ops/play-gate-profiles.json:routeViewports[<route>]`
+2. Shims GAS via `tests/tbm/fixtures/gas-shim.js` (PR-1 = fixture mode only)
+3. Runs every criterion in `tests/tbm/play-gate/measurements/` via the registry in `measurements/index.js`
+4. Synthesizes `ship_decision` per rules below
+5. Writes verdict to `ops/evidence/play-gate/<route>/<child>/<yyyy-mm-dd>/verdict.json`
+
+## Decision rules (PR-1 spike)
+
+| Condition | Verdict | Notes |
+|---|---|---|
+| Any precondition (`PRE-*`) fails | `do-not-ship` + `failure_state: preconditions_not_met` | Surface-level blocker |
+| Any universal/family `fail` (not surrogate) | `do-not-ship` + `failure_state: null` | Criterion-level blocker |
+| At least one `surrogate` result | `ship-with-backlog` | Must include `surrogateNote` on every surrogate |
+| All `pass` or `skip` | `ship` | Clean sheet |
+
+## Criteria (PR-1 = 12 total)
+
+**Preconditions:** PRE-2 (failure-handler-coverage), PRE-4 (safe-wrapper-chain-intact)
+**Universal:** U1, U2, U3, U7, U11, U12, U13, U14
+**JJ-only:** J1 (theme-integrity)
+**Buggsy-only:** B1 (mission-clarity)
+
+PR-2+ adds U5, U6, U8, U9, U10, U15, U16, the remaining J* and B* criteria, and live-mode backfill.
+
+## Non-goals for PR 1 (per v8 plan B1)
+
+- Not a WCAG compliance claim
+- Not proof the standard holds across product families
+- Not proof live save/progress/reporting paths work
+- Not `screenshots.spec.js` migration (PR 2)
+- Not shared-shim consumer migration (PR 2)
+- Not evidence-root rename (migration PR)
+
+## U4 status
+
+`U4 (core-loop-starts-fast)` is `blocked_on: "instrumentation-issue"` per rubric. PR 1 does not run U4. PR 3 closes U4 via: (a) real instrumentation, (b) LT-approved rubric waiver, or (c) LT-approved surrogate. Surrogate requires LT written approval AND a follow-up Issue (`kind:task` + `area:qa`) — a verdict.json note alone is insufficient (v8 rule).
+
+## Legacy stubs
+
+`.claude/skills/play-jj/SKILL.md` and `.claude/skills/play-buggsy/SKILL.md` are stubs for one release cycle. They invoke this skill's CLI with the appropriate child parameter. D3 regression test asserts both return schema-identical verdicts to `play-gate`.
+
+## Reference
+
+- Rubric: `ops/play-gate-rubric.v1.json` (version `2026-04-15-play-gate-v1`)
+- Schema: `ops/play-gate-verdict.schema.json`
+- Profile source: `ops/play-gate-profiles.json`
+- Parent EPIC: #439
+- Build Issue: #442
+- Prototype: #440

--- a/.claude/skills/play-jj/SKILL.md
+++ b/.claude/skills/play-jj/SKILL.md
@@ -1,184 +1,33 @@
 ---
 name: play-jj
-description: Run MVSS v1 Play gate against a single JJ education route. Produce a ship/ship-with-backlog/do-not-ship verdict with evidence. Use when evaluating /sparkle, /sparkle-kingdom, /daily-adventures, /sparkle-free, or /baseline for JJ. Invoked by LT or Mastermind for P0-14 Play gate runs.
+description: STUB — delegates to the play-gate skill with child=jj. Kept for one release cycle per v8 plan B1 so any caller referring to this skill name continues to work. Runs the Play-Gate quality check against a JJ route and produces a schema-identical verdict to play-gate.
 ---
 
-# Play/JJ — MVSS v1 Quality Gate for JJ's Education Surfaces
+# play-jj — Legacy stub (one release cycle)
 
-You are the Play gate evaluator for one JJ route. You produce one machine-readable verdict per invocation. You do not ship code; you judge shipping.
+This skill is a thin stub. The authoritative skill is `.claude/skills/play-gate/SKILL.md`.
 
-## Inputs
+## Invocation
 
-- **Route slug** — one of: `/sparkle`, `/sparkle-kingdom`, `/daily-adventures`, `/sparkle-free`, `/baseline` (with `child=jj`)
-- **MVSS v1 rubric** — `ops/play-gate-rubric.v1.json` (canonical)
-- **Surface map** — `ops/surface-map.md` (route → device + code + data deps)
-- **Benchmark anchors** — ABCmouse (https://www.abcmouse.com/learn/program/early-childhood-learning-programs-online), Khan Academy Kids (https://www.khanacademy.org/kids), PBS KIDS (https://pbskids.org/)
+For any JJ route (`/sparkle`, `/sparkle-free`, `/daily-adventures`, `/sparkle-kingdom`), run:
 
-## Audience context
-
-JJ is 4 years old. Pre-reader. Short attention span. Needs:
-- Touch targets ≥60px on S10 FE tablet (per `prek-milestones.md:93`)
-- Nia ElevenLabs voice for all audio
-- Sparkle Kingdom theme (purple-pink gradient, gold, stars)
-- Gentle failure (no red, no punishing copy)
-- Auto-redirect fallback to `/sparkle-kingdom` hub when stuck
-
-## Process
-
-### Step 1 — Resolve the surface
-
-Read `ops/surface-map.md`. Find the row for the input route. Extract:
-- Primary device
-- Primary code files
-- Data sources
-- `persistence_contract`, `product_class`, `primary_competitor`, `comparison_anchor_url`, `back_destination`
-
-**Device assertion (child-aware):** `/baseline` is a shared row covering both children. When `child=jj`, assert the S10 FE device column is present — do NOT emit `config_drift` just because the row also lists Surface Pro 5 for Buggsy. For all other JJ routes (JJ Personal surfaces), the row should list S10 FE exclusively; emit `config_drift` if the device is not S10 FE.
-
-### Step 2 — Run preconditions (PRE-1..PRE-4)
-
-Load rubric. For each precondition, apply its `measurement_method`:
-- PRE-1 (ES5 Fire-OS-only): skip for JJ Personal surfaces (S10 FE is modern-JS tier per Notion canon)
-- PRE-2 (failure-handler coverage): grep target .html for `withFailureHandler(function(){})` or `withFailureHandler(function() {})` — any match = fail
-- PRE-3 (theme palette): read `ops/themes/palettes.md`, extract Sparkle Kingdom hex set, grep surface CSS for deviations
-- PRE-4 (safe-wrapper chain): grep for `google.script.run\.` in surface, assert every callee ends in `Safe`
-
-Any fail → emit `preconditions_not_met`, abort run, write verdict.json, stop.
-
-### Step 3 — Gather evidence
-
-Use Claude Preview MCP tools in this order:
-1. `preview_start` — start the `tbm-preview` config
-2. `preview_resize` — set viewport to match surface-map primary device (1200×1920 portrait for JJ Personal)
-3. Navigate to route (via `preview_eval` — `window.location.href = '<route>'`)
-4. `preview_screenshot` — capture initial state
-5. `preview_snapshot` — accessibility tree
-6. `preview_console_logs` — capture console errors / warnings
-7. `preview_network` — capture network requests, check for 4xx/5xx
-8. Read surface HTML source with `Read` tool
-9. Read companion server file (e.g., `Kidshub.js` for education surfaces) — focus on functions the surface calls
-
-Artifact paths (following `ops/evidence/preview/<route-slug>/<child>/<yyyy-mm-dd>/`):
-- `screenshot.png` — preview capture
-- `snapshot.json` — accessibility tree
-- `console-logs.txt` — console output
-- `network.json` — request list
-- `verdict.json` — the final output (see Step 5)
-
-### Step 4 — Evaluate criteria
-
-For each rubric entry, evaluate against gathered evidence.
-
-**Universal (U1-U16):**
-- U1 correct-device: viewport match? If not match, major finding.
-- U2 loads-cleanly: status 200, no blocking console error (filter info-level), no endless spinner
-- U3 correct-child-context: child theme present (Sparkle Kingdom hex palette, Nia-voice audio clips), right data
-- U4 core-loop-starts-fast: measure time from route-ready to first state transition via preview_eval performance API. Target ≤5s. (Marked `blocked_on: "instrumentation-issue"` per rubric — emit `perf_unknown` for now.)
-- U5 core-loop-completes: simulate one interaction via preview_click, assert completion state
-- U6 save-reload-holds: per surface's `persistence_contract` column — if `submitted|draft`, perform save → reload → assert state
-- U7 no-silent-failure: introduce a forced failure (e.g., network offline via preview eval), assert visible fallback state
-- U8 feedback-understandable: interaction produces visible change within 200ms
-- U9 controls-fit-device: target sizes ≥60px for JJ routes (query computed styles via preview_inspect)
-- U10 no-dead-ends: from any state, assert either a back destination, a retry, or a completion
-- U11 truthful-promise: look for UI text promising save/reward; confirm backend records the event
-- U12 written-judgment: (emitted by this skill's own output — always passes if we're here)
-- U13 empty-state-defined: force empty data (e.g., mock empty curriculum), assert specific CTA + message
-- U14 error-has-retry-path: look for native `alert()` in HTML source, empty withFailureHandler, gate-check bypass — any = fail
-- U15 loading-has-max-time: grep for spinner/loading state timeout config
-- U16 offline-behavior-declared: per surface-map `persistence_contract` — if queue-required but no queue evidence, fail
-
-**JJ-specific (J1-J6):**
-- J1 theme-integrity: visual match to Sparkle Kingdom promise (screenshot comparison vs anchor)
-- J2 audio-consistency: grep for ElevenLabs Nia voice ID in audio src / phrases.json; no voice switches mid-session
-- J3 delighted-success: trigger a correct action, assert visible celebration (sparkle/star/confetti) + positive audio
-- J4 gentle-failure: trigger a wrong answer, assert no red, no punishing copy, gentle redirect
-- J5 age-fit-content: text density ≤ 3 choices on screen, ≤ one line of instruction at a time, font ≥32pt (per prek-game-design memory)
-- J6 adult-confidence-signal: saved state / star count / logged completion visible OR present in backend data
-
-**Accessibility (D-section):**
-- `<html lang>` present — grep first 10 lines
-- No `user-scalable=no` in viewport meta — grep viewport
-- Target size ≥60px (JJ routes) — preview_inspect computed style `width`/`height`/`padding`
-- `prefers-reduced-motion` respected — grep for `@media (prefers-reduced-motion: reduce)` in CSS OR reduced-motion code path
-- Visible focus — preview_eval `document.activeElement` styles after tab
-- Contrast 4.5:1 body / 3:1 UI — run axe-core via preview_eval (if available) or flag `unchecked`
-- Reflow at 320px — preview_resize 320×568, assert no horizontal scroll
-
-**Should-pass (S1-S5):**
-Evaluate as polish-level; S-failures don't block ship but accumulate toward `ship-with-backlog`.
-
-### Step 5 — Emit verdict
-
-Write to `ops/evidence/preview/<route-slug>/jj/<yyyy-mm-dd>/verdict.json`:
-
-```json
-{
-  "route": "/sparkle",
-  "child": "jj",
-  "device": "Samsung S10 FE 1200x1920",
-  "runAt": "2026-04-16T15:00:00Z",
-  "runner": "play-jj",
-  "rubricVersion": "2026-04-15-play-gate-v1",
-  "verdict": "ship-with-backlog",
-  "preconditionsResult": "pass",
-  "passedCriteria": ["U1", "U2", "U3", "U6", "U7", "U8", "U10", "U11", "U14", "U15", "U16", "J1", "J2", "J3", "J4", "J6"],
-  "failedCriteria": [
-    {"id": "J5", "evidence": "Three-plus choices visible simultaneously on letter-match screen", "severity": "major"},
-    {"id": "A11Y-LANG", "evidence": "<html> missing lang attribute", "severity": "major"}
-  ],
-  "unmeasuredCriteria": [
-    {"id": "U4", "reason": "blocked_on instrumentation-issue (perf trace not wired)"},
-    {"id": "U13", "reason": "could not simulate empty-data fallback without backend mutation"}
-  ],
-  "shouldPassWeaknesses": ["S1", "S3"],
-  "benchmarkNotes": "Compared against ABCmouse + Khan Kids: JJ Sparkle feels more cohesive on theme (J1); lags on stickered progress celebration depth (S2).",
-  "evidence": {
-    "screenshot": "ops/evidence/preview/sparkle/jj/2026-04-16/screenshot.png",
-    "snapshot": "ops/evidence/preview/sparkle/jj/2026-04-16/snapshot.json",
-    "consoleLogs": "ops/evidence/preview/sparkle/jj/2026-04-16/console-logs.txt",
-    "network": "ops/evidence/preview/sparkle/jj/2026-04-16/network.json"
-  },
-  "recommendation": "ship-with-backlog — fix J5 (choice-density) and add lang attribute (A11Y-LANG) before next release cycle; both are blockers to a full ship verdict"
-}
+```
+node scripts/play-gate.js --route <route> --child jj --mode fixture
 ```
 
-### Step 6 — Escalation per #378 contract
+The output conforms to `ops/play-gate-verdict.schema.json` and is written to `ops/evidence/play-gate/<route>/jj/<yyyy-mm-dd>/verdict.json`.
 
-For every `failedCriteria` entry:
-- `severity: "blocker"` → file Issue with `kind:bug` + `severity:blocker` + `area:jj` + `found-by:play-jj` + PR/Issue link. Pushover to LT (once Tier B webhook lands).
-- `severity: "critical"` → same as blocker. Pushover.
-- `severity: "major"` → file Issue + labels; no Pushover; add to weekly digest queue.
-- `severity: "minor"` → file Issue + labels; backlog.
+## Why this is a stub
 
-If Issue body would be >1000 lines, link to verdict.json in repo instead of inlining.
+v8 plan B1 consolidates `play-jj` + `play-buggsy` into a single `play-gate` skill that reads child + route as parameters. Keeping this stub file for one cycle prevents breakage for any external caller that still references `play-jj` by name. D3 regression test asserts the stub produces a verdict schema-identical to the main skill.
 
-### Step 7 — Return output
+## Removal schedule
 
-Print the verdict JSON. Stop. Do not add prose unless the invoker explicitly asked for a summary (e.g., `"summarize": true` in input or a verbal request).
+PR 2 cycle close: remove this stub if no caller outside the repo still references it (grep `ops/`, `.github/`, external procedure docs).
 
-## Guardrails
+## Reference
 
-- Do NOT modify product code or surface files during evaluation. Writing evidence artifacts under `ops/evidence/` is required and permitted; editing anything else is not.
-- Do NOT fill in `unmeasuredCriteria` with invented answers. If you can't measure, flag it.
-- Do NOT skip preconditions even if they feel obviously fine. Run each.
-- If preview_start fails to load the route, emit `config_drift` not `do-not-ship`. Distinguish environment problem from surface problem.
-
-## Output contract
-
-One verdict JSON per invocation. Evidence artifacts written to `ops/evidence/preview/<route-slug>/jj/<yyyy-mm-dd>/`. No prose appended unless the invoker explicitly requests it.
-
-## Related
-
-- Parent: MVSS v1 PR #361 (merged)
+- Consolidated skill: `.claude/skills/play-gate/SKILL.md`
 - Rubric: `ops/play-gate-rubric.v1.json`
-- Spec: `ops/specs/2026-04-15-play-surface-minimum-viable-standard.md`
-- Companion: Play/Buggsy skill (separate P0-13 Issue)
-- Successor work: P0-14 (run skill against all JJ routes, produce 5 verdicts), P0-16 (fix findings)
-- Inline-finding contract: #378
-
-## Build Skills
-
-- `thompson-engineer` — understand server architecture the surfaces call
-- `adhd-accommodations` — (not applicable to JJ but referenced by Buggsy companion)
-- `references:prek-milestones` — JJ age-appropriate criteria
-- `education-qa` — 7-gate QA framework
+- Schema: `ops/play-gate-verdict.schema.json`
+- Build Issue: #442

--- a/.github/scripts/check_profile_sync.py
+++ b/.github/scripts/check_profile_sync.py
@@ -25,6 +25,12 @@ VERBOSE = os.environ.get('VERBOSE', '0') == '1'
 PROFILES_PATH = os.path.join(REPO_ROOT, 'ops', 'play-gate-profiles.json')
 PARSER_PATH = os.path.join(REPO_ROOT, 'scripts', 'parse-profile-consumer.js')
 
+# Substring that migrated consumers must contain to prove they derive their
+# device data from the canonical source. Kept as a substring match so consumers
+# can format the require path however makes sense in their own code style
+# (path.join(), direct string, etc.).
+PROFILES_IMPORT_MARKER = 'play-gate-profiles.json'
+
 # Sync manifest: each entry maps one consumer to its kind + alias->canonical mapping.
 # kind=perf_devices  — compare all rich fields (viewport, dSF, isMobile, hasTouch, UA)
 # kind=basic_devices — compare viewport.width/height only (consumer has {width, height})
@@ -228,11 +234,31 @@ def main():
     drifts = []
     parsed_consumers = {}
 
+    migrated = []
     for entry in SYNC_MANIFEST:
         parsed, err = parse_consumer(entry['file'], entry['target'])
         if err:
             drifts.append({'file': entry['file'], 'problem': 'parser error', 'detail': err})
             continue
+
+        # Migrated consumer path: parser identified the target as dynamically
+        # derived (CallExpression). Confirm the file imports profiles.json
+        # and mark as in-sync-by-construction.
+        if parsed.get('source') == 'js:migrated-callexpr':
+            abs_path = os.path.join(REPO_ROOT, entry['file'])
+            with open(abs_path, 'r', encoding='utf-8') as fh:
+                src = fh.read()
+            if PROFILES_IMPORT_MARKER not in src:
+                drifts.append({
+                    'file': entry['file'],
+                    'problem': 'consumer uses dynamic init but does not import play-gate-profiles.json',
+                    'detail': 'Either add the import or revert to a static map the parser can validate.',
+                })
+                continue
+            migrated.append(entry['file'])
+            parsed_consumers[entry['file']] = {'__migrated': True}
+            continue
+
         consumer_data = parsed.get('data', {})
         parsed_consumers[entry['file']] = consumer_data
 
@@ -248,6 +274,7 @@ def main():
     report = {
         'canonical': os.path.relpath(PROFILES_PATH, REPO_ROOT).replace(os.sep, '/'),
         'consumers_checked': [e['file'] for e in SYNC_MANIFEST],
+        'migrated_consumers': migrated,
         'drift_count': len(drifts),
         'drifts': drifts,
     }

--- a/.github/scripts/check_profile_sync.py
+++ b/.github/scripts/check_profile_sync.py
@@ -242,8 +242,12 @@ def main():
             continue
 
         # Migrated consumer path: parser identified the target as dynamically
-        # derived (CallExpression). Confirm the file imports profiles.json
-        # and mark as in-sync-by-construction.
+        # derived (CallExpression). Confirm (a) the file imports profiles.json,
+        # (b) the file references its own alias-lookup key, and (c) profiles.json
+        # actually contains that alias key with the expected local-alias value
+        # for every canonical device in the consumer's mapping. Catches typos
+        # in the JS alias string and missing/renamed entries in profiles.json
+        # that would otherwise silently produce an empty DEVICES map at runtime.
         if parsed.get('source') == 'js:migrated-callexpr':
             abs_path = os.path.join(REPO_ROOT, entry['file'])
             with open(abs_path, 'r', encoding='utf-8') as fh:
@@ -255,8 +259,37 @@ def main():
                     'detail': 'Either add the import or revert to a static map the parser can validate.',
                 })
                 continue
+
+            alias_key = entry['file'] + ':' + entry['target']
+            if alias_key not in src:
+                drifts.append({
+                    'file': entry['file'],
+                    'problem': 'migrated consumer does not reference its alias-lookup key',
+                    'detail': "source must contain the literal string '" + alias_key + "' so the buildDevices() lookup matches profiles.json aliases",
+                })
+                continue
+
+            mismatches = []
+            for local_alias, canonical_device in entry.get('mapping', {}).items():
+                device = profiles.get('devices', {}).get(canonical_device, {})
+                aliases = device.get('aliases', {}) or {}
+                actual = aliases.get(alias_key)
+                if actual != local_alias:
+                    mismatches.append({
+                        'canonical_device': canonical_device,
+                        'expected_alias': local_alias,
+                        'actual_alias': actual,
+                    })
+            if mismatches:
+                drifts.append({
+                    'file': entry['file'],
+                    'problem': 'migrated consumer alias mapping drift in profiles.json',
+                    'detail': mismatches,
+                })
+                continue
+
             migrated.append(entry['file'])
-            parsed_consumers[entry['file']] = {'__migrated': True}
+            parsed_consumers[entry['file']] = {'__migrated': True, 'alias_key': alias_key}
             continue
 
         consumer_data = parsed.get('data', {})

--- a/.github/workflows/play-gate.yml
+++ b/.github/workflows/play-gate.yml
@@ -96,10 +96,7 @@ jobs:
         run: |
           VERDICT="${{ steps.verdict.outputs.dir }}/verdict.json"
           if [ -f "$VERDICT" ]; then
-            echo "### Play-Gate verdict" >> "$GITHUB_STEP_SUMMARY"
-            echo '```json' >> "$GITHUB_STEP_SUMMARY"
-            cat "$VERDICT" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            { echo "### Play-Gate verdict"; echo '```json'; cat "$VERDICT"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "::warning::Verdict file not written — play-gate failed before emit."
           fi

--- a/.github/workflows/play-gate.yml
+++ b/.github/workflows/play-gate.yml
@@ -1,0 +1,105 @@
+# .github/workflows/play-gate.yml
+# Play-Gate MVSS v1 — on-demand quality check for a single education route.
+# Invokes scripts/play-gate.js which spawns tests/tbm/play-gate/play-gate.spec.js.
+# Uploads ops/evidence/play-gate/<route>/<child>/<date>/ artifacts.
+# PR-1 scope: fixture mode only. Live mode lands in PR 3 after LIVE_SMOKE_SSID exists.
+
+name: Play-Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      route:
+        description: 'Route slug (e.g. /sparkle, /homework)'
+        required: true
+        default: '/sparkle'
+      child:
+        description: 'Child identifier'
+        required: true
+        default: 'jj'
+        type: choice
+        options:
+          - jj
+          - buggsy
+      mode:
+        description: 'fixture (PR-1) or live (PR-3+, not yet wired)'
+        required: true
+        default: 'fixture'
+        type: choice
+        options:
+          - fixture
+          - live
+
+permissions:
+  contents: read
+
+concurrency:
+  group: play-gate-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  play-gate:
+    name: Play-Gate (${{ inputs.route }} / ${{ inputs.child }} / ${{ inputs.mode }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Playwright + Chromium
+        run: |
+          npm install -D @playwright/test @babel/parser
+          npx playwright install --with-deps chromium
+
+      - name: Reject live mode in PR-1
+        if: inputs.mode == 'live'
+        run: |
+          echo "::error::Live mode is not wired in PR-1 (architecture spike scope). See v8 plan B1 non-goals."
+          exit 1
+
+      - name: Run Play-Gate
+        id: run
+        run: |
+          node scripts/play-gate.js \
+            --route "${{ inputs.route }}" \
+            --child "${{ inputs.child }}" \
+            --mode "${{ inputs.mode }}"
+
+      - name: Locate verdict path
+        if: always()
+        id: verdict
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          SLUG=$(echo "${{ inputs.route }}" | sed 's|^/||; s|?|__|g; s|=|-|g; s|&|_|g')
+          DIR="ops/evidence/play-gate/${SLUG}/${{ inputs.child }}/${DATE}"
+          echo "dir=$DIR" >> "$GITHUB_OUTPUT"
+          echo "Evidence directory: $DIR"
+          ls -la "$DIR" || echo "(directory not present — play-gate likely failed before writing)"
+
+      - name: Upload verdict + evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: play-gate-verdict-${{ github.run_id }}
+          path: ${{ steps.verdict.outputs.dir }}
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Summarize verdict
+        if: always()
+        run: |
+          VERDICT="${{ steps.verdict.outputs.dir }}/verdict.json"
+          if [ -f "$VERDICT" ]; then
+            echo "### Play-Gate verdict" >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat "$VERDICT" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Verdict file not written — play-gate failed before emit."
+          fi

--- a/.github/workflows/play-gate.yml
+++ b/.github/workflows/play-gate.yml
@@ -76,7 +76,7 @@ jobs:
         id: verdict
         run: |
           DATE=$(date -u +%Y-%m-%d)
-          SLUG=$(echo "${{ inputs.route }}" | sed 's|^/||; s|?|__|g; s|=|-|g; s|&|_|g')
+          SLUG=$(echo "${{ inputs.route }}" | sed 's|^/||; s|?|__|g; s|=|-|g; s|&|__|g')
           DIR="ops/evidence/play-gate/${SLUG}/${{ inputs.child }}/${DATE}"
           echo "dir=$DIR" >> "$GITHUB_OUTPUT"
           echo "Evidence directory: $DIR"

--- a/ops/play-gate-verdict.schema.json
+++ b/ops/play-gate-verdict.schema.json
@@ -41,8 +41,8 @@
     },
     "route": {
       "type": "string",
-      "pattern": "^/[a-z0-9\\-/]*$",
-      "description": "Route path being tested (e.g. /sparkle, /homework)."
+      "pattern": "^/[a-z0-9\\-/]+(\\?[a-z0-9][a-z0-9\\-=&_]*)?$",
+      "description": "Route path being tested (e.g. /sparkle, /homework, /daily-missions?child=jj). Optional query string allowed because ops/play-gate-profiles.json routeViewports keys query-bearing routes."
     },
     "child": {
       "type": "string",

--- a/ops/play-gate-verdict.schema.json
+++ b/ops/play-gate-verdict.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://thompsonfams.com/schemas/play-gate-verdict/v1",
+  "title": "Play-Gate Verdict",
+  "description": "Canonical verdict shape emitted by scripts/play-gate.js for one route/child run. Ajv-validated. The required 'ship_decision' field is the D1 regression fence — legacy 'verdict' field is forbidden via additionalProperties:false at the root.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "rubricVersion",
+    "ship_decision",
+    "route",
+    "child",
+    "profile",
+    "mode",
+    "timestamp",
+    "commitSha",
+    "preconditions",
+    "criteria"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "Verdict schema version. Bumped only with a migration plan."
+    },
+    "rubricVersion": {
+      "type": "string",
+      "description": "Value of 'version' field in ops/play-gate-rubric.v1.json at runtime.",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}-.+$"
+    },
+    "ship_decision": {
+      "type": "string",
+      "enum": ["ship", "ship-with-backlog", "do-not-ship"],
+      "description": "Canonical decision. D1 regression: ajv rejects 'verdict' or any alias."
+    },
+    "failure_state": {
+      "type": ["string", "null"],
+      "enum": ["config_drift", "preconditions_not_met", null],
+      "description": "Set when the run aborted before criteria could complete. When present, ship_decision MUST be 'do-not-ship'."
+    },
+    "route": {
+      "type": "string",
+      "pattern": "^/[a-z0-9\\-/]*$",
+      "description": "Route path being tested (e.g. /sparkle, /homework)."
+    },
+    "child": {
+      "type": "string",
+      "enum": ["jj", "buggsy", "both"],
+      "description": "Child identity for the run. 'both' reserved for hub surfaces."
+    },
+    "profile": {
+      "type": "string",
+      "description": "Device profile key from ops/play-gate-profiles.json (e.g. 'surface-pro-5', 'samsung-s10-fe')."
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["fixture", "live"],
+      "description": "fixture = GAS shim; live = seeded sandbox (requires live-smoke infra, PR 3+)."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp of the run (e.g. 2026-04-17T12:34:56Z)."
+    },
+    "commitSha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{7,40}$",
+      "description": "Git commit SHA at which the run was executed."
+    },
+    "preconditions": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/checkResult" },
+      "description": "PRE-* results. If any fails with failure_action=abort, criteria array is empty and failure_state is set."
+    },
+    "criteria": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/checkResult" },
+      "description": "Per-criterion results. Empty iff preconditions aborted the run."
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "screenshots": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Paths relative to the verdict directory."
+        },
+        "consoleLog": { "type": "string" },
+        "networkLog": { "type": "string" },
+        "traceZip": { "type": "string" }
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional human-readable context (surrogate approvals, inherited tests, etc.)."
+    }
+  },
+  "definitions": {
+    "checkResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^(PRE-[0-9]+|[UJBCPD][0-9]+)$",
+          "description": "Criterion ID from ops/play-gate-rubric.v1.json (PRE-1..4, U1..16, J1..n, B1..n, C1..6, etc.)."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pass", "fail", "skip", "blocked", "surrogate"],
+          "description": "blocked = rubric marks criterion blocked_on; surrogate = measurement used an LT-approved surrogate."
+        },
+        "measurement": {
+          "type": ["string", "number", "boolean", "object", "array", "null"],
+          "description": "Raw measurement output. Shape is criterion-specific (e.g. viewport dimensions, match count, duration ms)."
+        },
+        "expected": {
+          "type": ["string", "number", "boolean", "object", "array", "null"]
+        },
+        "evidence": {
+          "type": "string",
+          "description": "Path to criterion-specific evidence relative to verdict directory."
+        },
+        "surrogateNote": {
+          "type": "string",
+          "description": "Required when status=surrogate. Must name the LT approval (Issue # + approval date)."
+        },
+        "reducedMotionInheritsFrom": {
+          "type": "string",
+          "description": "When a route inherits reduced-motion proof from a family-shared component, name the component here (e.g. 'shared/SparkleCelebration.html')."
+        }
+      }
+    }
+  }
+}

--- a/scripts/canonical-verdict.js
+++ b/scripts/canonical-verdict.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * canonical-verdict.js — Deterministic verdict normalizer for Play-Gate determinism tests.
+ *
+ * Reads a verdict.json (path arg or stdin) and prints a canonicalized form to stdout:
+ *   - Volatile fields (timestamp, evidence paths that embed timestamps) replaced with sentinels
+ *   - All object keys sorted recursively
+ *   - Numbers normalized to JSON default representation (avoids locale differences)
+ *
+ * Two runs of play-gate.js against the same commit should produce canonical outputs that
+ * diff to zero bytes. That is the D-family determinism regression guard.
+ *
+ * Usage:
+ *   node scripts/canonical-verdict.js path/to/verdict.json > canonical.json
+ *   cat verdict.json | node scripts/canonical-verdict.js > canonical.json
+ *   node scripts/canonical-verdict.js a.json b.json  # diff mode — exits 0 if canonical forms match
+ *
+ * Exit codes:
+ *   0 — ok (or diff mode match)
+ *   1 — usage / read error
+ *   2 — parse error
+ *   3 — diff mode mismatch (two-file mode only)
+ */
+
+'use strict';
+
+var fs = require('fs');
+
+var VOLATILE_STRING_FIELDS = {
+  'timestamp': '<TIMESTAMP>',
+  'traceZip': '<EVIDENCE_PATH>',
+  'consoleLog': '<EVIDENCE_PATH>',
+  'networkLog': '<EVIDENCE_PATH>'
+};
+
+// Evidence path fields that may embed dated directories (e.g. 2026-04-17/screenshot.png).
+var EVIDENCE_PATH_KEYS = { 'screenshots': true, 'evidence': true };
+
+function normalize(value, keyName) {
+  if (value === null || value === undefined) return value;
+
+  if (typeof value === 'string') {
+    if (VOLATILE_STRING_FIELDS.hasOwnProperty(keyName)) {
+      return VOLATILE_STRING_FIELDS[keyName];
+    }
+    if (EVIDENCE_PATH_KEYS[keyName]) {
+      // A string-valued evidence path (checkResult.evidence).
+      return stripDatedSegment(value);
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(function(item) { return normalize(item, keyName); });
+  }
+
+  if (typeof value === 'object') {
+    var out = {};
+    var keys = Object.keys(value).sort();
+    for (var i = 0; i < keys.length; i++) {
+      var k = keys[i];
+      out[k] = normalize(value[k], k);
+    }
+    return out;
+  }
+
+  return value;
+}
+
+function stripDatedSegment(path) {
+  // Replace YYYY-MM-DD directory segments with <DATE>; leaves the rest intact
+  // so structural drift (missing file, wrong route name) still surfaces in diff.
+  return path.replace(/\b\d{4}-\d{2}-\d{2}\b/g, '<DATE>');
+}
+
+function readInput(path) {
+  var raw;
+  try {
+    if (path === '-' || path === undefined) {
+      raw = fs.readFileSync(0, 'utf8');
+    } else {
+      raw = fs.readFileSync(path, 'utf8');
+    }
+  } catch (err) {
+    process.stderr.write('canonical-verdict: read failed: ' + err.message + '\n');
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    process.stderr.write('canonical-verdict: parse failed: ' + err.message + '\n');
+    process.exit(2);
+  }
+}
+
+function main(argv) {
+  var args = argv.slice(2);
+
+  if (args.length === 2) {
+    // Diff mode.
+    var a = JSON.stringify(normalize(readInput(args[0])));
+    var b = JSON.stringify(normalize(readInput(args[1])));
+    if (a === b) {
+      process.stdout.write('canonical-verdict: MATCH\n');
+      process.exit(0);
+    }
+    process.stderr.write('canonical-verdict: MISMATCH\n');
+    process.stderr.write('--- ' + args[0] + '\n');
+    process.stderr.write('+++ ' + args[1] + '\n');
+    process.stderr.write('A: ' + a + '\n');
+    process.stderr.write('B: ' + b + '\n');
+    process.exit(3);
+  }
+
+  if (args.length > 2) {
+    process.stderr.write('usage: canonical-verdict.js [path] | [a.json b.json]\n');
+    process.exit(1);
+  }
+
+  var normalized = normalize(readInput(args[0]));
+  process.stdout.write(JSON.stringify(normalized, null, 2) + '\n');
+}
+
+main(process.argv);

--- a/scripts/parse-profile-consumer.js
+++ b/scripts/parse-profile-consumer.js
@@ -90,11 +90,17 @@ function extractJsConstant(src, target, file) {
     var node = body[i];
     if (node.type === 'VariableDeclaration') {
       var found = tryExtractFromDeclarations(node.declarations, target);
-      if (found !== null) return wrap(file, target, 'js:variable', found);
+      if (found !== null) {
+        if (found && found.__dynamic) return wrap(file, target, 'js:migrated-callexpr', found);
+        return wrap(file, target, 'js:variable', found);
+      }
     }
     if (node.type === 'ExportNamedDeclaration' && node.declaration && node.declaration.type === 'VariableDeclaration') {
       var found2 = tryExtractFromDeclarations(node.declaration.declarations, target);
-      if (found2 !== null) return wrap(file, target, 'js:export-variable', found2);
+      if (found2 !== null) {
+        if (found2 && found2.__dynamic) return wrap(file, target, 'js:migrated-callexpr', found2);
+        return wrap(file, target, 'js:export-variable', found2);
+      }
     }
     if (target === 'default' && node.type === 'ExportDefaultDeclaration') {
       if (node.declaration && node.declaration.type === 'ObjectExpression') {
@@ -116,6 +122,13 @@ function tryExtractFromDeclarations(declarations, target) {
     var decl = declarations[i];
     if (decl.id && decl.id.type === 'Identifier' && decl.id.name === target) {
       if (!decl.init) return null;
+      // Dynamically-derived (migrated) consumer: the target is built from a
+      // function call, not a literal. Return a sentinel instead of crashing —
+      // the Python driver will verify the file imports profiles.json and
+      // treat it as in-sync by construction.
+      if (decl.init.type === 'CallExpression' || decl.init.type === 'NewExpression') {
+        return { __dynamic: true, reason: 'init is ' + decl.init.type + ' — consumer derives from runtime source' };
+      }
       return astToJs(decl.init);
     }
   }

--- a/scripts/play-gate.js
+++ b/scripts/play-gate.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * play-gate.js — CLI entry point for the Play-Gate architecture spike.
+ *
+ * Usage:
+ *   node scripts/play-gate.js --route /sparkle --child jj --mode fixture
+ *   node scripts/play-gate.js --route /homework --child buggsy --mode fixture
+ *
+ * Spawns Playwright against tests/tbm/play-gate/play-gate.spec.js with env
+ * PLAY_GATE_ROUTE / PLAY_GATE_CHILD / PLAY_GATE_MODE and PLAY_GATE_OUT.
+ * The spec runs the 12 PR-1 criteria measurements, synthesizes a verdict
+ * per ops/play-gate-verdict.schema.json, and writes it to:
+ *
+ *   ops/evidence/play-gate/<route>/<child>/<yyyy-mm-dd>/verdict.json
+ *
+ * Exit codes:
+ *   0 = verdict emitted (any ship_decision — even do-not-ship is a "run success")
+ *   1 = usage error
+ *   2 = tooling error (Playwright crash, verdict not written, etc.)
+ */
+
+var fs = require('fs');
+var path = require('path');
+var spawnSync = require('child_process').spawnSync;
+
+var REPO_ROOT = path.resolve(__dirname, '..');
+var RUBRIC_PATH = path.join(REPO_ROOT, 'ops', 'play-gate-rubric.v1.json');
+
+function die(code, msg) {
+  process.stderr.write('play-gate: ' + msg + '\n');
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  var out = { route: null, child: null, mode: 'fixture' };
+  for (var i = 2; i < argv.length; i++) {
+    var arg = argv[i];
+    if (arg === '--route' && argv[i + 1]) { out.route = argv[++i]; continue; }
+    if (arg === '--child' && argv[i + 1]) { out.child = argv[++i]; continue; }
+    if (arg === '--mode' && argv[i + 1]) { out.mode = argv[++i]; continue; }
+    if (arg === '-h' || arg === '--help') {
+      process.stdout.write('Usage: play-gate.js --route <path> --child <jj|buggsy> --mode <fixture|live>\n');
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+function validateArgs(args) {
+  if (!args.route) die(1, 'missing --route');
+  if (!args.child) die(1, 'missing --child');
+  if (args.child !== 'jj' && args.child !== 'buggsy') die(1, 'invalid --child (must be jj or buggsy)');
+  if (args.mode !== 'fixture' && args.mode !== 'live') die(1, 'invalid --mode (must be fixture or live)');
+  if (args.mode === 'live') die(1, 'live mode not available in PR 1 (PR 3 dependency per v8 plan)');
+  if (args.route.charAt(0) !== '/') die(1, 'route must start with /');
+}
+
+function resolveDevice(route, child) {
+  var profiles = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'ops', 'play-gate-profiles.json'), 'utf8'));
+  var routeVp = profiles.routeViewports[route];
+  if (routeVp) {
+    return { viewport: { width: routeVp.width, height: routeVp.height }, label: routeVp.device };
+  }
+  // Fallback by child — JJ uses S10 FE, Buggsy uses Surface Pro 5
+  if (child === 'jj') return { viewport: profiles.devices['samsung-s10-fe'].viewport, label: 'S10 FE (portrait)' };
+  return { viewport: profiles.devices['surface-pro-5'].viewport, label: 'Surface Pro 5' };
+}
+
+function todayIso() {
+  var d = new Date();
+  var mm = String(d.getMonth() + 1);
+  if (mm.length < 2) mm = '0' + mm;
+  var dd = String(d.getDate());
+  if (dd.length < 2) dd = '0' + dd;
+  return d.getFullYear() + '-' + mm + '-' + dd;
+}
+
+function sanitizeRouteForPath(route) {
+  // /daily-missions?child=jj → daily-missions__child-jj
+  return route.replace(/^\//, '').replace(/\?/g, '__').replace(/=/g, '-').replace(/&/g, '__');
+}
+
+function main() {
+  var args = parseArgs(process.argv);
+  validateArgs(args);
+
+  var evidenceDir = path.join(
+    REPO_ROOT,
+    'ops', 'evidence', 'play-gate',
+    sanitizeRouteForPath(args.route),
+    args.child,
+    todayIso()
+  );
+  fs.mkdirSync(evidenceDir, { recursive: true });
+
+  var outPath = path.join(evidenceDir, 'verdict.json');
+
+  var playwrightEnv = Object.assign({}, process.env, {
+    PLAY_GATE_ROUTE: args.route,
+    PLAY_GATE_CHILD: args.child,
+    PLAY_GATE_MODE: args.mode,
+    PLAY_GATE_OUT: outPath,
+    PLAY_GATE_RUBRIC: RUBRIC_PATH,
+    PLAY_GATE_EVIDENCE_DIR: evidenceDir
+  });
+
+  // Pin --project=chromium so the spec runs once, not across the full browser matrix.
+  // Play-gate.spec.js lives under tests/tbm/, which the chromium/firefox/webkit projects
+  // all pick up by default. Playwright uses forward slashes in its path regexes, so
+  // force forward slashes on Windows (spawn otherwise passes \\ which doesn't match).
+  var specPath = 'tests/tbm/play-gate/play-gate.spec.js';
+  var playwrightArgs = [
+    'playwright', 'test',
+    specPath,
+    '--project=chromium',
+    '--reporter=line'
+  ];
+
+  process.stdout.write('play-gate: running ' + args.route + ' for ' + args.child + ' (mode=' + args.mode + ')\n');
+  process.stdout.write('play-gate: evidence dir = ' + path.relative(REPO_ROOT, evidenceDir) + '\n');
+
+  var result = spawnSync('npx', playwrightArgs, {
+    cwd: REPO_ROOT,
+    env: playwrightEnv,
+    stdio: 'inherit',
+    shell: process.platform === 'win32'
+  });
+
+  if (result.error) die(2, 'failed to spawn Playwright: ' + result.error.message);
+
+  if (!fs.existsSync(outPath)) {
+    die(2, 'Playwright finished but verdict.json was not written at ' + outPath);
+  }
+
+  var verdict;
+  try {
+    verdict = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+  } catch (e) {
+    die(2, 'verdict.json is not valid JSON: ' + e.message);
+  }
+
+  process.stdout.write('\nplay-gate: ship_decision = ' + verdict.ship_decision + '\n');
+  process.stdout.write('play-gate: verdict written to ' + path.relative(REPO_ROOT, outPath) + '\n');
+
+  // Exit 0 regardless of ship_decision — emitting a verdict IS the success signal.
+  // Failure_state preconditions_not_met / config_drift are still exit 0 because
+  // the run produced a structured judgment. Callers inspect ship_decision for gating.
+  process.exit(0);
+}
+
+main();

--- a/tests/ci/play-gate-regression.test.js
+++ b/tests/ci/play-gate-regression.test.js
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+/**
+ * play-gate-regression.test.js — PR-1 drift regression suite for Play-Gate.
+ *
+ * Runs outside Playwright (plain Node) because these assertions are about the
+ * static shape of the skill/schema/registry, not runtime page behavior.
+ *
+ * Covers:
+ *   D1 — ship_decision is the decision field; legacy `verdict` field rejected by schema
+ *   D3 — stub skills (play-jj, play-buggsy) both delegate to the same play-gate CLI
+ *   D5 — SKILL.md files contain no line-anchored cross-references (file:line → file)
+ *   Registry coverage — every PR-1 criterion (12) has a matching measurements/<ID>.js
+ *   Determinism    — canonical-verdict.js in diff mode yields MATCH on two copies of one verdict
+ *
+ * D2 (profile sync) and D6 (fixture imports) are Python CI scripts and run separately.
+ * D4 (rubric measurement_method append-only) and D7 (post-PR-2 inline map) are PR-2 scope.
+ *
+ * Usage:
+ *   node tests/ci/play-gate-regression.test.js
+ *
+ * Exit codes:
+ *   0 — all checks pass
+ *   1 — at least one check failed (details on stderr)
+ */
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var spawnSync = require('child_process').spawnSync;
+var os = require('os');
+
+var REPO_ROOT = path.resolve(__dirname, '..', '..');
+var SCHEMA_PATH = path.join(REPO_ROOT, 'ops', 'play-gate-verdict.schema.json');
+var CANONICAL_JS = path.join(REPO_ROOT, 'scripts', 'canonical-verdict.js');
+var REGISTRY_JS = path.join(REPO_ROOT, 'tests', 'tbm', 'play-gate', 'measurements', 'index.js');
+var SKILL_PLAY_GATE = path.join(REPO_ROOT, '.claude', 'skills', 'play-gate', 'SKILL.md');
+var SKILL_PLAY_JJ = path.join(REPO_ROOT, '.claude', 'skills', 'play-jj', 'SKILL.md');
+var SKILL_PLAY_BUGGSY = path.join(REPO_ROOT, '.claude', 'skills', 'play-buggsy', 'SKILL.md');
+
+var PR1_CRITERIA = ['PRE-2', 'PRE-4', 'U1', 'U2', 'U3', 'U7', 'U11', 'U12', 'U13', 'U14', 'J1', 'B1'];
+
+var results = [];
+
+function pass(name) { results.push({ name: name, ok: true }); process.stdout.write('  ✓ ' + name + '\n'); }
+function fail(name, msg) { results.push({ name: name, ok: false, msg: msg }); process.stderr.write('  ✗ ' + name + '\n    ' + msg + '\n'); }
+
+function sampleVerdict(overrides) {
+  var base = {
+    schemaVersion: 1,
+    rubricVersion: '2026-04-15-play-gate-v1',
+    ship_decision: 'ship',
+    route: '/sparkle',
+    child: 'jj',
+    profile: 'S10 FE (portrait)',
+    mode: 'fixture',
+    timestamp: '2026-04-17T12:00:00Z',
+    commitSha: 'deadbeefcafe',
+    preconditions: [
+      { id: 'PRE-2', status: 'pass' },
+      { id: 'PRE-4', status: 'pass' }
+    ],
+    criteria: [
+      { id: 'U1', status: 'pass' }
+    ],
+    failure_state: null,
+    evidence: { screenshots: [], consoleLog: 'console.txt' },
+    notes: ['fixture']
+  };
+  if (overrides) {
+    for (var k in overrides) { if (overrides.hasOwnProperty(k)) base[k] = overrides[k]; }
+  }
+  return base;
+}
+
+// ── Minimal JSON Schema checker ──────────────────────────────────────────────
+// This covers the draft-07 subset actually used in play-gate-verdict.schema.json:
+// type, required, enum, const, pattern, additionalProperties:false, items, $ref
+// via #/definitions. Full ajv dep isn't pulled in for this — it's scoped to the
+// one schema we own. If the schema grows beyond this subset, swap to ajv.
+function loadSchema() {
+  return JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+}
+
+function validate(instance, schema, defs, path) {
+  path = path || '$';
+  defs = defs || schema.definitions || {};
+  var errors = [];
+
+  if (schema.$ref) {
+    var m = schema.$ref.match(/^#\/definitions\/(.+)$/);
+    if (!m || !defs[m[1]]) return [{ path: path, msg: 'unresolved $ref ' + schema.$ref }];
+    return validate(instance, defs[m[1]], defs, path);
+  }
+
+  if (schema.type) {
+    var types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    var actual = instance === null ? 'null' : (Array.isArray(instance) ? 'array' : typeof instance);
+    if (actual === 'number' && Math.floor(instance) === instance && types.indexOf('integer') !== -1) actual = 'integer';
+    var ok = types.some(function(t) {
+      if (t === 'integer') return typeof instance === 'number' && Math.floor(instance) === instance;
+      return actual === t || (t === 'number' && actual === 'integer');
+    });
+    if (!ok) errors.push({ path: path, msg: 'expected type ' + types.join('|') + ', got ' + actual });
+  }
+
+  if (schema.const !== undefined && instance !== schema.const) {
+    errors.push({ path: path, msg: 'expected const ' + JSON.stringify(schema.const) + ', got ' + JSON.stringify(instance) });
+  }
+
+  if (schema.enum && schema.enum.indexOf(instance) === -1) {
+    errors.push({ path: path, msg: 'expected one of ' + JSON.stringify(schema.enum) + ', got ' + JSON.stringify(instance) });
+  }
+
+  if (schema.pattern && typeof instance === 'string' && !new RegExp(schema.pattern).test(instance)) {
+    errors.push({ path: path, msg: 'pattern mismatch: ' + schema.pattern + ' vs ' + JSON.stringify(instance) });
+  }
+
+  if (schema.type === 'object' && instance && typeof instance === 'object' && !Array.isArray(instance)) {
+    if (schema.required) {
+      for (var i = 0; i < schema.required.length; i++) {
+        if (!instance.hasOwnProperty(schema.required[i])) {
+          errors.push({ path: path, msg: 'missing required ' + schema.required[i] });
+        }
+      }
+    }
+    if (schema.additionalProperties === false && schema.properties) {
+      var allowed = schema.properties;
+      Object.keys(instance).forEach(function(k) {
+        if (!allowed.hasOwnProperty(k)) {
+          errors.push({ path: path + '.' + k, msg: 'additional property not allowed' });
+        }
+      });
+    }
+    if (schema.properties) {
+      Object.keys(schema.properties).forEach(function(k) {
+        if (instance.hasOwnProperty(k)) {
+          errors = errors.concat(validate(instance[k], schema.properties[k], defs, path + '.' + k));
+        }
+      });
+    }
+  }
+
+  if (schema.type === 'array' && Array.isArray(instance) && schema.items) {
+    for (var j = 0; j < instance.length; j++) {
+      errors = errors.concat(validate(instance[j], schema.items, defs, path + '[' + j + ']'));
+    }
+  }
+
+  return errors;
+}
+
+// ── D1 ───────────────────────────────────────────────────────────────────────
+function testD1() {
+  process.stdout.write('[D1] ship_decision is the decision field\n');
+  var schema = loadSchema();
+
+  var good = sampleVerdict();
+  var goodErrs = validate(good, schema);
+  if (goodErrs.length === 0) pass('D1a: canonical verdict with ship_decision validates');
+  else fail('D1a: canonical verdict with ship_decision validates', 'errors: ' + JSON.stringify(goodErrs));
+
+  var legacy = sampleVerdict();
+  delete legacy.ship_decision;
+  legacy.verdict = 'ship';
+  var legacyErrs = validate(legacy, schema);
+  var rejected = legacyErrs.some(function(e) { return /missing required ship_decision/.test(e.msg); })
+              && legacyErrs.some(function(e) { return /additional property/.test(e.msg) && /\.verdict$/.test(e.path); });
+  if (rejected) pass('D1b: legacy verdict field rejected (missing ship_decision + additional property)');
+  else fail('D1b: legacy verdict field rejected', 'validator did not catch verdict field: ' + JSON.stringify(legacyErrs));
+
+  var both = sampleVerdict();
+  both.verdict = 'ship';
+  var bothErrs = validate(both, schema);
+  var caught = bothErrs.some(function(e) { return /additional property/.test(e.msg) && /\.verdict$/.test(e.path); });
+  if (caught) pass('D1c: adding verdict alongside ship_decision still rejected');
+  else fail('D1c: adding verdict alongside ship_decision still rejected', 'validator allowed both: ' + JSON.stringify(bothErrs));
+}
+
+// ── D3 ───────────────────────────────────────────────────────────────────────
+function testD3() {
+  process.stdout.write('[D3] stub skills delegate to the play-gate CLI\n');
+
+  var jj = fs.readFileSync(SKILL_PLAY_JJ, 'utf8');
+  var buggsy = fs.readFileSync(SKILL_PLAY_BUGGSY, 'utf8');
+
+  var cliRef = /node\s+scripts\/play-gate\.js/;
+  if (cliRef.test(jj)) pass('D3a: play-jj stub invokes scripts/play-gate.js');
+  else fail('D3a: play-jj stub invokes scripts/play-gate.js', 'no scripts/play-gate.js reference found');
+
+  if (cliRef.test(buggsy)) pass('D3b: play-buggsy stub invokes scripts/play-gate.js');
+  else fail('D3b: play-buggsy stub invokes scripts/play-gate.js', 'no scripts/play-gate.js reference found');
+
+  if (/--child\s+jj/.test(jj)) pass('D3c: play-jj stub pins --child jj');
+  else fail('D3c: play-jj stub pins --child jj', 'no --child jj in play-jj stub');
+
+  if (/--child\s+buggsy/.test(buggsy)) pass('D3d: play-buggsy stub pins --child buggsy');
+  else fail('D3d: play-buggsy stub pins --child buggsy', 'no --child buggsy in play-buggsy stub');
+
+  // Both stubs must point to the same verdict-producing pipeline — i.e. the main
+  // skill file must exist and contain the same CLI invocation so callers see one
+  // source of truth. (This is the schema-identical claim.)
+  var gate = fs.readFileSync(SKILL_PLAY_GATE, 'utf8');
+  if (cliRef.test(gate)) pass('D3e: play-gate authoritative skill invokes scripts/play-gate.js');
+  else fail('D3e: play-gate authoritative skill invokes scripts/play-gate.js', 'authoritative skill missing CLI reference');
+}
+
+// ── D5 ───────────────────────────────────────────────────────────────────────
+function testD5() {
+  process.stdout.write('[D5] SKILL.md files contain no line-anchored cross-references\n');
+
+  // Line anchors are patterns like `foo.js:123` — they rot when source files
+  // grow. Skill docs reference files by path only.
+  var files = [SKILL_PLAY_GATE, SKILL_PLAY_JJ, SKILL_PLAY_BUGGSY];
+  // Permit "Issue #N" and markdown link :N suffixes inside parens; block
+  // `<file>.<ext>:<digit>` in plain prose.
+  var anchorPattern = /[A-Za-z0-9_\-./]+\.(js|ts|html|gs|py|md|json|yml|yaml|sh)\s*:\s*\d+/;
+
+  files.forEach(function(fp) {
+    var text = fs.readFileSync(fp, 'utf8');
+    // Strip fenced code blocks — CLI examples inside ``` may legitimately contain
+    // file.js invocations that look similar. Only check prose.
+    var prose = text.replace(/```[\s\S]*?```/g, '');
+    var m = prose.match(anchorPattern);
+    var rel = path.relative(REPO_ROOT, fp).replace(/\\/g, '/');
+    if (m) fail('D5: ' + rel + ' is anchor-free', 'found line anchor: ' + m[0]);
+    else pass('D5: ' + rel + ' is anchor-free');
+  });
+}
+
+// ── Registry coverage ────────────────────────────────────────────────────────
+function testRegistryCoverage() {
+  process.stdout.write('[Registry] each PR-1 criterion has a matching measurements/<ID>.js\n');
+
+  // Sanity: the registry module exports an ordered list covering all 12.
+  var registry = require(REGISTRY_JS);
+  var registered = {};
+  registry.REGISTRY.forEach(function(entry) { registered[entry.id] = true; });
+
+  PR1_CRITERIA.forEach(function(id) {
+    if (!registered[id]) fail('Registry covers ' + id, 'not present in REGISTRY array');
+    else pass('Registry covers ' + id);
+    var implPath = path.join(REPO_ROOT, 'tests', 'tbm', 'play-gate', 'measurements', id + '.js');
+    if (!fs.existsSync(implPath)) fail('Impl file exists for ' + id, 'missing ' + path.relative(REPO_ROOT, implPath));
+    else pass('Impl file exists for ' + id);
+  });
+
+  // Registry length matches PR-1 scope — catches accidental drop of a criterion.
+  if (registry.REGISTRY.length === PR1_CRITERIA.length) pass('Registry length = ' + PR1_CRITERIA.length);
+  else fail('Registry length = ' + PR1_CRITERIA.length, 'got ' + registry.REGISTRY.length);
+}
+
+// ── Determinism ──────────────────────────────────────────────────────────────
+function testDeterminism() {
+  process.stdout.write('[Determinism] canonical-verdict.js diff mode matches two identical verdicts\n');
+
+  var v = sampleVerdict();
+  var tmp = os.tmpdir();
+  var a = path.join(tmp, 'play-gate-determinism-a.json');
+  var b = path.join(tmp, 'play-gate-determinism-b.json');
+  // Write both with DIFFERENT key ordering to prove the canonicalizer sorts.
+  fs.writeFileSync(a, JSON.stringify(v, null, 2));
+  var reordered = {};
+  Object.keys(v).reverse().forEach(function(k) { reordered[k] = v[k]; });
+  fs.writeFileSync(b, JSON.stringify(reordered, null, 2));
+
+  var r = spawnSync('node', [CANONICAL_JS, a, b], { encoding: 'utf8' });
+  if (r.status === 0) pass('canonical-verdict MATCH on key-reordered copy');
+  else fail('canonical-verdict MATCH on key-reordered copy', 'exit ' + r.status + ' stderr: ' + r.stderr);
+
+  // Also prove the canonicalizer strips volatile fields (timestamp).
+  var v2 = sampleVerdict();
+  v2.timestamp = '2026-04-17T23:59:59Z';  // different time
+  var c = path.join(tmp, 'play-gate-determinism-c.json');
+  fs.writeFileSync(c, JSON.stringify(v2, null, 2));
+  var r2 = spawnSync('node', [CANONICAL_JS, a, c], { encoding: 'utf8' });
+  if (r2.status === 0) pass('canonical-verdict MATCH despite different timestamp');
+  else fail('canonical-verdict MATCH despite different timestamp', 'exit ' + r2.status + ' stderr: ' + r2.stderr);
+
+  // And the canonicalizer rejects actually-divergent verdicts (fence check so
+  // the determinism test doesn't silently pass on a broken normalizer).
+  var v3 = sampleVerdict({ ship_decision: 'do-not-ship' });
+  var d = path.join(tmp, 'play-gate-determinism-d.json');
+  fs.writeFileSync(d, JSON.stringify(v3, null, 2));
+  var r3 = spawnSync('node', [CANONICAL_JS, a, d], { encoding: 'utf8' });
+  if (r3.status === 3) pass('canonical-verdict MISMATCH detected on ship_decision drift');
+  else fail('canonical-verdict MISMATCH detected on ship_decision drift', 'expected exit 3, got ' + r3.status);
+
+  // Clean up
+  [a, b, c, d].forEach(function(p) { try { fs.unlinkSync(p); } catch (e) {} });
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+function main() {
+  process.stdout.write('Play-Gate regression suite (PR-1 scope)\n');
+  process.stdout.write('=======================================\n\n');
+
+  testD1();
+  process.stdout.write('\n');
+  testD3();
+  process.stdout.write('\n');
+  testD5();
+  process.stdout.write('\n');
+  testRegistryCoverage();
+  process.stdout.write('\n');
+  testDeterminism();
+  process.stdout.write('\n');
+
+  var failed = results.filter(function(r) { return !r.ok; });
+  process.stdout.write('---\n');
+  process.stdout.write('Total: ' + results.length + ', passed: ' + (results.length - failed.length) + ', failed: ' + failed.length + '\n');
+  process.exit(failed.length === 0 ? 0 : 1);
+}
+
+main();

--- a/tests/ci/play-gate-regression.test.js
+++ b/tests/ci/play-gate-regression.test.js
@@ -264,27 +264,27 @@ function testDeterminism() {
   Object.keys(v).reverse().forEach(function(k) { reordered[k] = v[k]; });
   fs.writeFileSync(b, JSON.stringify(reordered, null, 2));
 
-  var r = spawnSync('node', [CANONICAL_JS, a, b], { encoding: 'utf8' });
+  var r = spawnSync(process.execPath, [CANONICAL_JS, a, b], { encoding: 'utf8' });
   if (r.status === 0) pass('canonical-verdict MATCH on key-reordered copy');
-  else fail('canonical-verdict MATCH on key-reordered copy', 'exit ' + r.status + ' stderr: ' + r.stderr);
+  else fail('canonical-verdict MATCH on key-reordered copy', 'exit ' + r.status + ' stderr: ' + r.stderr + (r.error ? ' spawn-error: ' + r.error.message : ''));
 
   // Also prove the canonicalizer strips volatile fields (timestamp).
   var v2 = sampleVerdict();
   v2.timestamp = '2026-04-17T23:59:59Z';  // different time
   var c = path.join(tmp, 'play-gate-determinism-c.json');
   fs.writeFileSync(c, JSON.stringify(v2, null, 2));
-  var r2 = spawnSync('node', [CANONICAL_JS, a, c], { encoding: 'utf8' });
+  var r2 = spawnSync(process.execPath, [CANONICAL_JS, a, c], { encoding: 'utf8' });
   if (r2.status === 0) pass('canonical-verdict MATCH despite different timestamp');
-  else fail('canonical-verdict MATCH despite different timestamp', 'exit ' + r2.status + ' stderr: ' + r2.stderr);
+  else fail('canonical-verdict MATCH despite different timestamp', 'exit ' + r2.status + ' stderr: ' + r2.stderr + (r2.error ? ' spawn-error: ' + r2.error.message : ''));
 
   // And the canonicalizer rejects actually-divergent verdicts (fence check so
   // the determinism test doesn't silently pass on a broken normalizer).
   var v3 = sampleVerdict({ ship_decision: 'do-not-ship' });
   var d = path.join(tmp, 'play-gate-determinism-d.json');
   fs.writeFileSync(d, JSON.stringify(v3, null, 2));
-  var r3 = spawnSync('node', [CANONICAL_JS, a, d], { encoding: 'utf8' });
+  var r3 = spawnSync(process.execPath, [CANONICAL_JS, a, d], { encoding: 'utf8' });
   if (r3.status === 3) pass('canonical-verdict MISMATCH detected on ship_decision drift');
-  else fail('canonical-verdict MISMATCH detected on ship_decision drift', 'expected exit 3, got ' + r3.status);
+  else fail('canonical-verdict MISMATCH detected on ship_decision drift', 'expected exit 3, got ' + r3.status + (r3.error ? ' spawn-error: ' + r3.error.message : ''));
 
   // Clean up
   [a, b, c, d].forEach(function(p) { try { fs.unlinkSync(p); } catch (e) {} });

--- a/tests/shared/helpers.js
+++ b/tests/shared/helpers.js
@@ -1,16 +1,26 @@
 /**
  * Shared test helpers for TBM + MLS Playwright suites
+ *
+ * DEVICES viewport map is derived from ops/play-gate-profiles.json (canonical source per EPIC #439).
+ * The per-device `aliases["tests/shared/helpers.js:DEVICES"]` field names the key used here, so when
+ * profiles.json changes the viewport, this map picks it up automatically. CI script
+ * .github/scripts/check_profile_sync.py enforces no drift.
  */
+const path = require('path');
+const PROFILES = require(path.join(__dirname, '..', '..', 'ops', 'play-gate-profiles.json'));
 
-// Device viewport presets matching actual TBM target devices
-const DEVICES = {
-  S25:        { width: 390, height: 844 },   // Galaxy S25 (JT ThePulse)
-  iPadAir:    { width: 800, height: 1280 },  // iPad Air (kid tablets)
-  FireStick:  { width: 1920, height: 1080 }, // Fire Stick (Soul/Spine)
-  Omnibook:   { width: 1920, height: 1200 }, // HP Omnibook (LT TheVein)
-  SurfacePro: { width: 1368, height: 912 },  // Surface Pro 5 (Buggsy homework)
-  S10FE:      { width: 400, height: 800 },   // Galaxy S10 FE (JJ SparkleLearn)
-};
+const DEVICES = (function buildDevices() {
+  const out = {};
+  const deviceKeys = Object.keys(PROFILES.devices);
+  for (let i = 0; i < deviceKeys.length; i++) {
+    const device = PROFILES.devices[deviceKeys[i]];
+    const alias = device.aliases && device.aliases['tests/shared/helpers.js:DEVICES'];
+    if (alias) {
+      out[alias] = { width: device.viewport.width, height: device.viewport.height };
+    }
+  }
+  return out;
+})();
 
 // GAS pages can be slow — use this instead of default waitUntil
 const GAS_TIMEOUT = 25000;

--- a/tests/tbm/education-workflows.spec.js
+++ b/tests/tbm/education-workflows.spec.js
@@ -17,12 +17,23 @@ var FIXTURES = gasShim.EDUCATION_FIXTURES;
 
 var BASE_URL = process.env.TBM_BASE_URL || '';
 
-var DEVICES = {
-  s25: { width: 390, height: 844 },
-  a9: { width: 800, height: 1280 },
-  surface_pro: { width: 1368, height: 912 },
-  s10fe: { width: 1200, height: 1920 }
-};
+// DEVICES derived from ops/play-gate-profiles.json (canonical per EPIC #439).
+// Aliases map names the key each consumer uses. CI script
+// .github/scripts/check_profile_sync.py enforces no drift.
+var path = require('path');
+var PROFILES = require(path.join(__dirname, '..', '..', 'ops', 'play-gate-profiles.json'));
+var DEVICES = (function buildDevices() {
+  var out = {};
+  var deviceKeys = Object.keys(PROFILES.devices);
+  for (var i = 0; i < deviceKeys.length; i++) {
+    var device = PROFILES.devices[deviceKeys[i]];
+    var alias = device.aliases && device.aliases['tests/tbm/education-workflows.spec.js:DEVICES'];
+    if (alias) {
+      out[alias] = { width: device.viewport.width, height: device.viewport.height };
+    }
+  }
+  return out;
+})();
 
 // Screenshot helper — saves to test-results/screenshots/education/ so the
 // existing CI upload-artifact step picks them up automatically.

--- a/tests/tbm/play-gate/measurements/B1.js
+++ b/tests/tbm/play-gate/measurements/B1.js
@@ -1,0 +1,49 @@
+/**
+ * B1 — mission-clarity (Buggsy)
+ * Primary mission/task instruction ≤30 words.
+ */
+
+module.exports = async function B1(ctx) {
+  if (ctx.child !== 'buggsy') {
+    return { id: 'B1', status: 'skip', measurement: 'not Buggsy route' };
+  }
+  var candidates = [
+    '#hw-lcp-skeleton',
+    '.mission-title',
+    '.task-title',
+    '.today-title',
+    '.module-title',
+    'h1',
+    'h2'
+  ];
+  for (var i = 0; i < candidates.length; i++) {
+    var sel = candidates[i];
+    var count = await ctx.page.locator(sel).count();
+    if (count > 0) {
+      var text = await ctx.page.locator(sel).first().innerText().catch(function() { return ''; });
+      var trimmed = text.replace(/\s+/g, ' ').trim();
+      if (trimmed.length === 0) continue;
+      var words = trimmed.split(' ').filter(function(w) { return w.length > 0; });
+      if (words.length <= 30) {
+        return {
+          id: 'B1',
+          status: 'pass',
+          measurement: sel + ' text (' + words.length + ' words): "' + trimmed.slice(0, 60) + '"',
+          expected: '≤30 words for initial goal statement'
+        };
+      }
+      return {
+        id: 'B1',
+        status: 'fail',
+        measurement: sel + ' text has ' + words.length + ' words (>30)',
+        expected: '≤30 words'
+      };
+    }
+  }
+  return {
+    id: 'B1',
+    status: 'fail',
+    measurement: 'no mission-title-like element found on ' + ctx.route,
+    expected: 'visible mission/task title ≤30 words'
+  };
+};

--- a/tests/tbm/play-gate/measurements/J1.js
+++ b/tests/tbm/play-gate/measurements/J1.js
@@ -1,0 +1,46 @@
+/**
+ * J1 — theme-integrity (JJ / Sparkle Kingdom)
+ * Sparkle Kingdom background + palette present. Not a generic worksheet.
+ */
+
+module.exports = async function J1(ctx) {
+  if (ctx.child !== 'jj') {
+    return { id: 'J1', status: 'skip', measurement: 'not JJ route' };
+  }
+  var bodyBg = await ctx.page.evaluate(function() {
+    var body = document.querySelector('body');
+    if (!body) return null;
+    var cs = getComputedStyle(body);
+    return {
+      bg: cs.backgroundColor,
+      color: cs.color,
+      classes: body.className || ''
+    };
+  });
+  if (!bodyBg) {
+    return { id: 'J1', status: 'fail', measurement: 'body element not found' };
+  }
+  var hasThemeClass = /sparkle/i.test(bodyBg.classes);
+  // Deep purple per ops/themes/palettes.md Sparkle Kingdom set.
+  // rgb(45, 27, 105) = #2D1B69 (canonical); also accept variants near deep purple.
+  var m = bodyBg.bg.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  var isDeepPurple = false;
+  if (m) {
+    var r = parseInt(m[1], 10), g = parseInt(m[2], 10), b = parseInt(m[3], 10);
+    isDeepPurple = r < 120 && b > r && b >= 90 && g < 100;
+  }
+  if (hasThemeClass || isDeepPurple) {
+    return {
+      id: 'J1',
+      status: 'pass',
+      measurement: 'bg=' + bodyBg.bg + ' classes=' + bodyBg.classes.slice(0, 60),
+      expected: 'sparkle-body class OR deep-purple bg per palettes.md'
+    };
+  }
+  return {
+    id: 'J1',
+    status: 'fail',
+    measurement: 'bg=' + bodyBg.bg + ' classes=' + bodyBg.classes.slice(0, 60),
+    expected: 'sparkle-body class OR deep-purple bg per palettes.md'
+  };
+};

--- a/tests/tbm/play-gate/measurements/PRE-2.js
+++ b/tests/tbm/play-gate/measurements/PRE-2.js
@@ -1,0 +1,48 @@
+/**
+ * PRE-2 — failure-handler-coverage
+ * Every google.script.run.<fn>Safe() call must have a matching non-empty .withFailureHandler().
+ *
+ * Static grep against surface HTML (runs before page load — this is a precondition).
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var ROUTE_TO_HTML = {
+  '/sparkle': 'SparkleLearning.html',
+  '/homework': 'HomeworkModule.html'
+};
+
+module.exports = async function PRE_2(ctx) {
+  var htmlFile = ROUTE_TO_HTML[ctx.route];
+  if (!htmlFile) {
+    return {
+      id: 'PRE-2',
+      status: 'skip',
+      measurement: 'no HTML mapping for route ' + ctx.route
+    };
+  }
+  var abs = path.join(ctx.repoRoot, htmlFile);
+  if (!fs.existsSync(abs)) {
+    return { id: 'PRE-2', status: 'fail', measurement: 'html file not found: ' + htmlFile };
+  }
+  var src = fs.readFileSync(abs, 'utf8');
+  var empty1 = src.match(/withFailureHandler\(function\(\)\s*\{\s*\}\)/g);
+  var empty2 = src.match(/withFailureHandler\(\(\)\s*=>\s*\{\s*\}\)/g);
+  var emptyCount = (empty1 ? empty1.length : 0) + (empty2 ? empty2.length : 0);
+  if (emptyCount > 0) {
+    return {
+      id: 'PRE-2',
+      status: 'fail',
+      measurement: emptyCount + ' empty withFailureHandler in ' + htmlFile,
+      expected: '0 empty handlers'
+    };
+  }
+  var withHandlerCount = (src.match(/withFailureHandler/g) || []).length;
+  return {
+    id: 'PRE-2',
+    status: 'pass',
+    measurement: withHandlerCount + ' non-empty withFailureHandler calls in ' + htmlFile,
+    expected: 'no empty handlers'
+  };
+};

--- a/tests/tbm/play-gate/measurements/PRE-4.js
+++ b/tests/tbm/play-gate/measurements/PRE-4.js
@@ -1,0 +1,115 @@
+/**
+ * PRE-4 — safe-wrapper-chain-intact
+ * Every google.script.run.<fn>() call must use a Safe wrapper (name ends in "Safe").
+ *
+ * Parsing strategy: locate each `google.script.run` anchor, then walk the chain
+ * `.methodName(args)` using balanced-paren argument scanning (so method calls
+ * inside handler callbacks like `withFailureHandler(function(e){ console.log(e); })`
+ * don't leak into the chain walk). Handler method names (withSuccessHandler,
+ * withFailureHandler, withUserObject) are filtered out — the remaining method
+ * names in the chain are the server callees that must end in "Safe".
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var ROUTE_TO_HTML = {
+  '/sparkle': 'SparkleLearning.html',
+  '/homework': 'HomeworkModule.html'
+};
+
+var HANDLER_METHODS = { withSuccessHandler: 1, withFailureHandler: 1, withUserObject: 1 };
+
+function extractChainMethods(src, startIdx) {
+  var methods = [];
+  var i = startIdx;
+  var n = src.length;
+
+  function skipWs() { while (i < n && /\s/.test(src[i])) i++; }
+
+  while (i < n) {
+    skipWs();
+    if (src[i] !== '.') break;
+    i++;
+    skipWs();
+    var nameStart = i;
+    while (i < n && /[A-Za-z0-9_$]/.test(src[i])) i++;
+    if (i === nameStart) break;
+    var name = src.slice(nameStart, i);
+    skipWs();
+    if (src[i] !== '(') break;
+    // Consume balanced parens (respect string / line-comment content)
+    var depth = 1;
+    i++;
+    while (i < n && depth > 0) {
+      var c = src[i];
+      if (c === '"' || c === "'" || c === '`') {
+        var quote = c;
+        i++;
+        while (i < n && src[i] !== quote) {
+          if (src[i] === '\\' && i + 1 < n) i++;
+          i++;
+        }
+        if (i < n) i++;
+        continue;
+      }
+      if (c === '/' && src[i + 1] === '/') {
+        while (i < n && src[i] !== '\n') i++;
+        continue;
+      }
+      if (c === '/' && src[i + 1] === '*') {
+        i += 2;
+        while (i < n && !(src[i] === '*' && src[i + 1] === '/')) i++;
+        if (i < n) i += 2;
+        continue;
+      }
+      if (c === '(') depth++;
+      else if (c === ')') depth--;
+      i++;
+    }
+    methods.push(name);
+  }
+  return methods;
+}
+
+module.exports = async function PRE_4(ctx) {
+  var htmlFile = ROUTE_TO_HTML[ctx.route];
+  if (!htmlFile) {
+    return { id: 'PRE-4', status: 'skip', measurement: 'no HTML mapping for route ' + ctx.route };
+  }
+  var abs = path.join(ctx.repoRoot, htmlFile);
+  if (!fs.existsSync(abs)) {
+    return { id: 'PRE-4', status: 'fail', measurement: 'html file not found: ' + htmlFile };
+  }
+  var src = fs.readFileSync(abs, 'utf8');
+  var anchor = 'google.script.run';
+  var searchFrom = 0;
+  var nonSafe = [];
+  var total = 0;
+  while (true) {
+    var idx = src.indexOf(anchor, searchFrom);
+    if (idx < 0) break;
+    var methods = extractChainMethods(src, idx + anchor.length);
+    for (var k = 0; k < methods.length; k++) {
+      var name = methods[k];
+      if (HANDLER_METHODS[name]) continue;
+      total++;
+      if (name.slice(-4) !== 'Safe') nonSafe.push(name);
+    }
+    searchFrom = idx + anchor.length;
+  }
+  if (nonSafe.length > 0) {
+    return {
+      id: 'PRE-4',
+      status: 'fail',
+      measurement: nonSafe.length + ' non-Safe callees: ' + nonSafe.slice(0, 5).join(', '),
+      expected: 'all google.script.run callees end in "Safe"'
+    };
+  }
+  return {
+    id: 'PRE-4',
+    status: 'pass',
+    measurement: total + ' google.script.run callees — all end in "Safe"',
+    expected: 'all Safe-wrapped'
+  };
+};

--- a/tests/tbm/play-gate/measurements/U1.js
+++ b/tests/tbm/play-gate/measurements/U1.js
@@ -1,0 +1,16 @@
+/**
+ * U1 — correct-device
+ * Playwright viewport matches the device profile from ops/play-gate-profiles.json.
+ */
+
+module.exports = async function U1(ctx) {
+  var actual = ctx.page.viewportSize();
+  var expected = ctx.device.viewport;
+  var match = actual && actual.width === expected.width && actual.height === expected.height;
+  return {
+    id: 'U1',
+    status: match ? 'pass' : 'fail',
+    measurement: 'viewport ' + (actual ? actual.width + 'x' + actual.height : 'null'),
+    expected: expected.width + 'x' + expected.height + ' (' + ctx.device.label + ')'
+  };
+};

--- a/tests/tbm/play-gate/measurements/U11.js
+++ b/tests/tbm/play-gate/measurements/U11.js
@@ -1,0 +1,31 @@
+/**
+ * U11 — truthful-promise
+ * UI does not claim a save/reward/unlock the backend does not honor.
+ *
+ * PR-1 spike: verify that fixtures are wired (shimGAS interception active) by
+ * checking that at least one fixture fn was called during page load. Full
+ * parity test (submit action → backend state diff) is PR 2+ with live-smoke.
+ */
+
+module.exports = async function U11(ctx) {
+  if (ctx.mode !== 'fixture') {
+    return { id: 'U11', status: 'skip', measurement: 'non-fixture mode handled in PR 3 live-smoke' };
+  }
+  var interceptedFns = ctx.interceptedApiCalls || [];
+  if (interceptedFns.length === 0) {
+    return {
+      id: 'U11',
+      status: 'surrogate',
+      surrogateNote: 'no /api calls observed — surface may not exercise backend or shim not engaged',
+      measurement: '0 intercepted fixture calls',
+      expected: 'at least 1 shimmed /api call (PR-1 spike uses call-count proxy for PR-2 parity check)'
+    };
+  }
+  return {
+    id: 'U11',
+    status: 'surrogate',
+    surrogateNote: 'shim interception proxy — full backend parity test deferred to PR 2+ (needs live-smoke infra from PR 3)',
+    measurement: interceptedFns.length + ' fixture calls intercepted: ' + interceptedFns.slice(0, 3).join(', '),
+    expected: 'backend write matches UI claim (PR 3 live-smoke)'
+  };
+};

--- a/tests/tbm/play-gate/measurements/U12.js
+++ b/tests/tbm/play-gate/measurements/U12.js
@@ -1,0 +1,28 @@
+/**
+ * U12 — written-judgment
+ * Run produces a named decision: ship / ship-with-backlog / do-not-ship.
+ *
+ * This measurement is self-referential — the verdict emission IS the pass.
+ * The spec validates schema after synthesis; here we just assert that the
+ * criterion list is non-empty and evidence dir is configured.
+ */
+
+var fs = require('fs');
+
+module.exports = async function U12(ctx) {
+  if (!ctx.evidenceDir) {
+    return { id: 'U12', status: 'fail', measurement: 'no evidence directory configured' };
+  }
+  if (!fs.existsSync(ctx.evidenceDir)) {
+    return { id: 'U12', status: 'fail', measurement: 'evidence directory missing: ' + ctx.evidenceDir };
+  }
+  if (!ctx.outPath) {
+    return { id: 'U12', status: 'fail', measurement: 'no verdict output path configured' };
+  }
+  return {
+    id: 'U12',
+    status: 'pass',
+    measurement: 'verdict output will be written to ' + ctx.outPath,
+    expected: 'ship_decision field present with valid enum value'
+  };
+};

--- a/tests/tbm/play-gate/measurements/U13.js
+++ b/tests/tbm/play-gate/measurements/U13.js
@@ -1,0 +1,53 @@
+/**
+ * U13 — empty-state-defined
+ * Surface declares a specific empty state with a CTA (no blank screen, no bare error).
+ *
+ * PR-1 spike: static grep of surface HTML for empty-state markers
+ * ("no-content", "all-done", "empty-state", "come back", "no homework").
+ * Full behavioral test (inject empty payload via shim, assert empty-state
+ * element renders) is PR 2 work.
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var ROUTE_TO_HTML = {
+  '/sparkle': 'SparkleLearning.html',
+  '/homework': 'HomeworkModule.html'
+};
+
+var EMPTY_STATE_MARKERS = [
+  /empty-state/i,
+  /no-content/i,
+  /all-done/i,
+  /come\s+back/i,
+  /no\s+homework/i,
+  /nothing\s+to\s+do/i,
+  /all\s+caught\s+up/i
+];
+
+module.exports = async function U13(ctx) {
+  var htmlFile = ROUTE_TO_HTML[ctx.route];
+  if (!htmlFile) return { id: 'U13', status: 'skip', measurement: 'no HTML mapping' };
+  var abs = path.join(ctx.repoRoot, htmlFile);
+  var src = fs.readFileSync(abs, 'utf8');
+  var matched = [];
+  for (var i = 0; i < EMPTY_STATE_MARKERS.length; i++) {
+    if (EMPTY_STATE_MARKERS[i].test(src)) matched.push(EMPTY_STATE_MARKERS[i].toString());
+  }
+  if (matched.length === 0) {
+    return {
+      id: 'U13',
+      status: 'fail',
+      measurement: 'no empty-state marker found in ' + htmlFile,
+      expected: 'at least one of: empty-state / no-content / all-done / come back / no homework'
+    };
+  }
+  return {
+    id: 'U13',
+    status: 'surrogate',
+    surrogateNote: 'static grep proxy — behavioral assertion (inject empty payload, render empty-state) deferred to PR 2',
+    measurement: matched.length + ' empty-state marker(s) found',
+    expected: 'empty-state element renders when primary data empty (PR 2 behavioral test)'
+  };
+};

--- a/tests/tbm/play-gate/measurements/U14.js
+++ b/tests/tbm/play-gate/measurements/U14.js
@@ -1,0 +1,48 @@
+/**
+ * U14 — error-has-retry-path
+ * No native alert() as primary error UX, no empty withFailureHandler, no gate-check bypass.
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var ROUTE_TO_HTML = {
+  '/sparkle': 'SparkleLearning.html',
+  '/homework': 'HomeworkModule.html'
+};
+
+module.exports = async function U14(ctx) {
+  var htmlFile = ROUTE_TO_HTML[ctx.route];
+  if (!htmlFile) return { id: 'U14', status: 'skip', measurement: 'no HTML mapping' };
+  var abs = path.join(ctx.repoRoot, htmlFile);
+  var src = fs.readFileSync(abs, 'utf8');
+
+  var alertMatches = src.match(/\balert\s*\(/g);
+  var alertCount = alertMatches ? alertMatches.length : 0;
+
+  var emptyHandler = /withFailureHandler\(function\(\)\s*\{\s*\}\)/.test(src)
+    || /withFailureHandler\(\(\)\s*=>\s*\{\s*\}\)/.test(src);
+
+  if (alertCount > 0 && !/\/\/\s*ok-alert/i.test(src)) {
+    return {
+      id: 'U14',
+      status: 'fail',
+      measurement: alertCount + ' alert() call(s) in ' + htmlFile,
+      expected: 'no native alert() for primary errors (use in-surface UI)'
+    };
+  }
+  if (emptyHandler) {
+    return {
+      id: 'U14',
+      status: 'fail',
+      measurement: 'empty withFailureHandler detected in ' + htmlFile,
+      expected: 'non-empty handlers that surface error to user'
+    };
+  }
+  return {
+    id: 'U14',
+    status: 'pass',
+    measurement: 'no alert() and no empty withFailureHandler',
+    expected: 'in-surface error UI'
+  };
+};

--- a/tests/tbm/play-gate/measurements/U2.js
+++ b/tests/tbm/play-gate/measurements/U2.js
@@ -1,0 +1,38 @@
+/**
+ * U2 — loads-cleanly
+ * HTTP 200, no blocking console errors, no text "undefined"/"null" in visible DOM.
+ *
+ * ctx.httpStatus is the status from the initial navigation captured by the spec.
+ * ctx.consoleErrors is the running list of error-level console messages.
+ */
+
+module.exports = async function U2(ctx) {
+  if (ctx.httpStatus !== 200) {
+    return {
+      id: 'U2',
+      status: 'fail',
+      measurement: 'http status ' + ctx.httpStatus,
+      expected: '200'
+    };
+  }
+  var blocking = ctx.consoleErrors.filter(function(e) {
+    if (e.indexOf('favicon') !== -1) return false;
+    if (e.indexOf('net::ERR') !== -1) return false;
+    if (e.indexOf('404') !== -1) return false;
+    return true;
+  });
+  if (blocking.length > 0) {
+    return {
+      id: 'U2',
+      status: 'fail',
+      measurement: blocking.length + ' blocking console errors: ' + blocking.slice(0, 2).join(' | '),
+      expected: '0 blocking console errors'
+    };
+  }
+  return {
+    id: 'U2',
+    status: 'pass',
+    measurement: 'HTTP 200, 0 blocking console errors',
+    expected: 'clean load'
+  };
+};

--- a/tests/tbm/play-gate/measurements/U3.js
+++ b/tests/tbm/play-gate/measurements/U3.js
@@ -1,0 +1,44 @@
+/**
+ * U3 — correct-child-context
+ * Asserts child-specific CSS class is present in DOM: sparkle-body for JJ, or
+ * wolfdome-body / wolfdome-bg for Buggsy. Fall-back: child name text visible.
+ */
+
+var CHILD_SELECTORS = {
+  jj: ['.sparkle-body', '[data-child="jj"]', '.sparkle-bg', '.sparkle-kingdom'],
+  buggsy: ['.wolfdome-body', '[data-child="buggsy"]', '.wolfdome-bg', '.wolfdome']
+};
+
+module.exports = async function U3(ctx) {
+  var selectors = CHILD_SELECTORS[ctx.child];
+  var foundSelector = null;
+  for (var i = 0; i < selectors.length; i++) {
+    var n = await ctx.page.locator(selectors[i]).count();
+    if (n > 0) { foundSelector = selectors[i]; break; }
+  }
+  if (foundSelector) {
+    return {
+      id: 'U3',
+      status: 'pass',
+      measurement: 'child theme selector present: ' + foundSelector,
+      expected: 'child-specific CSS class on body or descendant'
+    };
+  }
+  // Fallback: look for the child name in the rendered DOM text
+  var bodyText = await ctx.page.locator('body').innerText().catch(function() { return ''; });
+  var nameLower = ctx.child === 'jj' ? 'jj' : 'buggsy';
+  if (bodyText.toLowerCase().indexOf(nameLower) !== -1) {
+    return {
+      id: 'U3',
+      status: 'pass',
+      measurement: 'child name "' + nameLower + '" present in body text (selector fallback)',
+      expected: 'child context visible'
+    };
+  }
+  return {
+    id: 'U3',
+    status: 'fail',
+    measurement: 'no child theme selector or name text found',
+    expected: 'sparkle-body / wolfdome-body class OR child name in DOM'
+  };
+};

--- a/tests/tbm/play-gate/measurements/U7.js
+++ b/tests/tbm/play-gate/measurements/U7.js
@@ -1,0 +1,42 @@
+/**
+ * U7 — no-silent-failure
+ * For PR 1 spike: grep withFailureHandler wiring density as a static proxy.
+ * Full behavioral test (inject API error, assert fallback element) is PR 2 work.
+ * Marked `surrogate` when the surrogate is used.
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var ROUTE_TO_HTML = {
+  '/sparkle': 'SparkleLearning.html',
+  '/homework': 'HomeworkModule.html'
+};
+
+module.exports = async function U7(ctx) {
+  var htmlFile = ROUTE_TO_HTML[ctx.route];
+  if (!htmlFile) return { id: 'U7', status: 'skip', measurement: 'no HTML mapping' };
+  var abs = path.join(ctx.repoRoot, htmlFile);
+  var src = fs.readFileSync(abs, 'utf8');
+  var runCalls = (src.match(/google\.script\.run/g) || []).length;
+  var handlers = (src.match(/withFailureHandler/g) || []).length;
+  // Rough density check: at least one handler per run call chain.
+  // Chains typically: google.script.run.withFailureHandler(...).withSuccessHandler(...).fnSafe()
+  // So handlers >= runCalls is the expected ratio.
+  if (handlers < runCalls) {
+    return {
+      id: 'U7',
+      status: 'surrogate',
+      surrogateNote: 'static grep ratio (handlers < run calls) — full behavioral test is PR 2 work',
+      measurement: handlers + ' handlers vs ' + runCalls + ' run calls',
+      expected: 'handlers >= run calls (PR-2 will assert fallback element render)'
+    };
+  }
+  return {
+    id: 'U7',
+    status: 'surrogate',
+    surrogateNote: 'static grep proxy — handler density acceptable; behavioral assertion deferred to PR 2',
+    measurement: handlers + ' handlers, ' + runCalls + ' run calls',
+    expected: 'fallback element rendered on API error (PR 2 behavioral test)'
+  };
+};

--- a/tests/tbm/play-gate/measurements/index.js
+++ b/tests/tbm/play-gate/measurements/index.js
@@ -1,0 +1,49 @@
+/**
+ * measurements/index.js — Code registry for the 12 PR-1 criteria.
+ *
+ * The registry IS the single dispatch authority (v8 plan: "code registry only;
+ * rubric prose is description"). rubric.measurement_method prose documents
+ * intent; the impl here is what actually runs.
+ *
+ * Each entry: { id, tier, impl }. impl is an async function (ctx) → checkResult
+ * per the schema's checkResult definition.
+ */
+
+var path = require('path');
+
+var PRE_2 = require(path.join(__dirname, 'PRE-2.js'));
+var PRE_4 = require(path.join(__dirname, 'PRE-4.js'));
+var U1 = require(path.join(__dirname, 'U1.js'));
+var U2 = require(path.join(__dirname, 'U2.js'));
+var U3 = require(path.join(__dirname, 'U3.js'));
+var U7 = require(path.join(__dirname, 'U7.js'));
+var U11 = require(path.join(__dirname, 'U11.js'));
+var U12 = require(path.join(__dirname, 'U12.js'));
+var U13 = require(path.join(__dirname, 'U13.js'));
+var U14 = require(path.join(__dirname, 'U14.js'));
+var J1 = require(path.join(__dirname, 'J1.js'));
+var B1 = require(path.join(__dirname, 'B1.js'));
+
+var REGISTRY = [
+  { id: 'PRE-2', tier: 'precondition', impl: PRE_2 },
+  { id: 'PRE-4', tier: 'precondition', impl: PRE_4 },
+  { id: 'U1', tier: 'universal', impl: U1 },
+  { id: 'U2', tier: 'universal', impl: U2 },
+  { id: 'U3', tier: 'universal', impl: U3 },
+  { id: 'U7', tier: 'universal', impl: U7 },
+  { id: 'U11', tier: 'universal', impl: U11 },
+  { id: 'U12', tier: 'universal', impl: U12 },
+  { id: 'U13', tier: 'universal', impl: U13 },
+  { id: 'U14', tier: 'universal', impl: U14 },
+  { id: 'J1', tier: 'jj-family', impl: J1, familyOnly: 'jj' },
+  { id: 'B1', tier: 'buggsy-family', impl: B1, familyOnly: 'buggsy' }
+];
+
+function selectForChild(child) {
+  return REGISTRY.filter(function(entry) {
+    if (!entry.familyOnly) return true;
+    return entry.familyOnly === child;
+  });
+}
+
+module.exports = { REGISTRY: REGISTRY, selectForChild: selectForChild };

--- a/tests/tbm/play-gate/play-gate.spec.js
+++ b/tests/tbm/play-gate/play-gate.spec.js
@@ -1,0 +1,230 @@
+/**
+ * play-gate.spec.js — parameterized Play-Gate runner (PR-1 architecture spike).
+ *
+ * Invoked by scripts/play-gate.js with env:
+ *   PLAY_GATE_ROUTE   e.g. /sparkle or /homework
+ *   PLAY_GATE_CHILD   jj or buggsy
+ *   PLAY_GATE_MODE    fixture | live (PR-1: fixture only)
+ *   PLAY_GATE_OUT     absolute path to write verdict.json
+ *   PLAY_GATE_RUBRIC  absolute path to ops/play-gate-rubric.v1.json
+ *   PLAY_GATE_EVIDENCE_DIR  absolute evidence directory
+ *
+ * Runs the 12 PR-1 criteria from ./measurements/index.js and synthesizes a
+ * verdict conforming to ops/play-gate-verdict.schema.json.
+ */
+
+var test = require('@playwright/test').test;
+var expect = require('@playwright/test').expect;
+var fs = require('fs');
+var path = require('path');
+var crypto = require('crypto');
+
+var shim = require('../fixtures/gas-shim');
+var PROFILES = require('../../../ops/play-gate-profiles.json');
+var registry = require('./measurements');
+
+var REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+var ROUTE = process.env.PLAY_GATE_ROUTE || '/sparkle';
+var CHILD = process.env.PLAY_GATE_CHILD || 'jj';
+var MODE = process.env.PLAY_GATE_MODE || 'fixture';
+var OUT = process.env.PLAY_GATE_OUT;
+var RUBRIC_PATH = process.env.PLAY_GATE_RUBRIC;
+var EVIDENCE_DIR = process.env.PLAY_GATE_EVIDENCE_DIR;
+var BASE_URL = process.env.PLAY_GATE_BASE_URL || 'http://localhost:8080';
+
+function resolveDevice(route, child) {
+  var rv = PROFILES.routeViewports[route];
+  if (rv) {
+    return { viewport: { width: rv.width, height: rv.height }, label: rv.device };
+  }
+  if (child === 'jj') {
+    return { viewport: PROFILES.devices['samsung-s10-fe'].viewport, label: 'S10 FE (portrait)' };
+  }
+  return { viewport: PROFILES.devices['surface-pro-5'].viewport, label: 'Surface Pro 5' };
+}
+
+function readCommitSha() {
+  var spawnSync = require('child_process').spawnSync;
+  var r = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: REPO_ROOT });
+  if (r.status === 0) return r.stdout.toString().trim().slice(0, 40);
+  return '0000000';
+}
+
+function readRubricVersion() {
+  try {
+    var rub = JSON.parse(fs.readFileSync(RUBRIC_PATH, 'utf8'));
+    return rub.version;
+  } catch (e) {
+    return '2026-04-15-play-gate-v1';
+  }
+}
+
+function synthesizeDecision(results) {
+  // Decision rules (PR-1 spike):
+  //   any precondition fail → preconditions_not_met
+  //   any universal/family `fail` with failure_mode critical → do-not-ship
+  //   any `surrogate` → ship-with-backlog (surrogate notes required)
+  //   all pass → ship
+  var hasPrecondFail = false;
+  var hasCriticalFail = false;
+  var hasSurrogate = false;
+  for (var i = 0; i < results.length; i++) {
+    var r = results[i];
+    if (r.status === 'fail') {
+      if (r.id.indexOf('PRE-') === 0) hasPrecondFail = true;
+      else hasCriticalFail = true;
+    }
+    if (r.status === 'surrogate') hasSurrogate = true;
+  }
+  if (hasPrecondFail) return { ship_decision: 'do-not-ship', failure_state: 'preconditions_not_met' };
+  if (hasCriticalFail) return { ship_decision: 'do-not-ship', failure_state: null };
+  if (hasSurrogate) return { ship_decision: 'ship-with-backlog', failure_state: null };
+  return { ship_decision: 'ship', failure_state: null };
+}
+
+// Skip the spec entirely when invoked outside scripts/play-gate.js (e.g. ad-hoc
+// `npx playwright test --project=chromium`) — env hand-off is the only supported
+// entry. This prevents accidental pollution of local dev test runs.
+test.skip(!OUT, 'play-gate spec only runs when PLAY_GATE_OUT env is set by scripts/play-gate.js');
+
+test('play-gate: ' + ROUTE + ' (' + CHILD + ', ' + MODE + ')', async function({ page, request }) {
+  test.setTimeout(60000);
+
+  var device = resolveDevice(ROUTE, CHILD);
+  await page.setViewportSize(device.viewport);
+
+  // Shim GAS API for fixture mode
+  var interceptedApiCalls = [];
+  if (MODE === 'fixture') {
+    await shim.shimGAS(page, shim.EDUCATION_FIXTURES);
+    page.on('request', function(req) {
+      var url = req.url();
+      var m = url.match(/[?&]fn=([^&]+)/);
+      if (m) interceptedApiCalls.push(decodeURIComponent(m[1]));
+    });
+  }
+
+  // Collect console errors
+  var consoleErrors = [];
+  page.on('console', function(msg) {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  // Navigate (BASE_URL is the local http-server of the repo root; the route
+  // resolves via Cloudflare-worker-equivalent routing on the dev server, or
+  // directly to the HTML file for static preview).
+  //
+  // For PR-1 architecture-spike scope we tolerate navigation failure — raw .html
+  // files in the repo contain GAS scriptlets (`<?!= ... ?>`) which a file:// load
+  // can't process, and the dev server may not be running. When nav fails, we
+  // record httpStatus=0 and continue so the criteria machinery still emits a
+  // verdict. U2 (http-200) will correctly fail, producing a do-not-ship signal
+  // that matches reality (the surface didn't render).
+  var url = BASE_URL + ROUTE;
+  var response = null;
+  var navError = null;
+  try {
+    response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 10000 });
+  } catch (e) {
+    navError = e;
+    var routeToHtml = { '/sparkle': 'SparkleLearning.html', '/homework': 'HomeworkModule.html' };
+    var html = routeToHtml[ROUTE];
+    if (html) {
+      var fileUrl = 'file://' + path.join(REPO_ROOT, html).replace(/\\/g, '/');
+      try {
+        response = await page.goto(fileUrl, { waitUntil: 'domcontentloaded', timeout: 10000 });
+        navError = null;
+      } catch (e2) {
+        navError = e2;
+      }
+    }
+  }
+
+  var httpStatus = 0;
+  if (response) {
+    httpStatus = response.status();
+    // file:// URLs return status 0 — treat as 200 for a static load that resolved
+    if (httpStatus === 0 && response.url().indexOf('file://') === 0) httpStatus = 200;
+  }
+
+  // Let the page settle briefly so first-paint content + initial script execution land
+  try { await page.waitForTimeout(500); } catch (e) {}
+
+  var ctx = {
+    repoRoot: REPO_ROOT,
+    route: ROUTE,
+    child: CHILD,
+    mode: MODE,
+    device: device,
+    page: page,
+    httpStatus: httpStatus,
+    consoleErrors: consoleErrors,
+    interceptedApiCalls: interceptedApiCalls,
+    outPath: OUT,
+    evidenceDir: EVIDENCE_DIR,
+    profiles: PROFILES
+  };
+
+  // Run all criteria in registry order
+  var selected = registry.selectForChild(CHILD);
+  var results = [];
+  for (var i = 0; i < selected.length; i++) {
+    var entry = selected[i];
+    var r;
+    try {
+      r = await entry.impl(ctx);
+    } catch (e) {
+      r = { id: entry.id, status: 'fail', measurement: 'impl threw: ' + e.message };
+    }
+    // Normalize: drop undefined fields so canonical serialization is stable
+    var clean = { id: r.id, status: r.status };
+    if (r.measurement !== undefined) clean.measurement = r.measurement;
+    if (r.expected !== undefined) clean.expected = r.expected;
+    if (r.surrogateNote !== undefined) clean.surrogateNote = r.surrogateNote;
+    if (r.reducedMotionInheritsFrom !== undefined) clean.reducedMotionInheritsFrom = r.reducedMotionInheritsFrom;
+    if (r.evidence !== undefined) clean.evidence = r.evidence;
+    results.push(clean);
+  }
+
+  // Capture a screenshot as evidence
+  var screenshotPath = path.join(EVIDENCE_DIR, 'screenshot.png');
+  try { await page.screenshot({ path: screenshotPath, fullPage: true }); } catch (e) {}
+  var consoleLogPath = path.join(EVIDENCE_DIR, 'console.txt');
+  try { fs.writeFileSync(consoleLogPath, consoleErrors.join('\n')); } catch (e) {}
+
+  // Determine ship_decision and failure_state
+  var decision = synthesizeDecision(results);
+
+  // Preconditions block (per schema: array of checkResult — at minimum PRE-2 and PRE-4)
+  var preconditions = results.filter(function(r) { return r.id.indexOf('PRE-') === 0; });
+  var criteria = results.filter(function(r) { return r.id.indexOf('PRE-') !== 0; });
+
+  var verdict = {
+    schemaVersion: 1,
+    rubricVersion: readRubricVersion(),
+    ship_decision: decision.ship_decision,
+    route: ROUTE,
+    child: CHILD,
+    profile: device.label,
+    mode: MODE,
+    timestamp: new Date().toISOString(),
+    commitSha: readCommitSha(),
+    preconditions: preconditions,
+    criteria: criteria,
+    failure_state: decision.failure_state,
+    evidence: {
+      screenshots: [path.relative(REPO_ROOT, screenshotPath).replace(/\\/g, '/')],
+      consoleLog: path.relative(REPO_ROOT, consoleLogPath).replace(/\\/g, '/')
+    },
+    notes: ['PR-1 architecture spike — see v8 plan B1 for non-goals']
+  };
+
+  fs.writeFileSync(OUT, JSON.stringify(verdict, null, 2) + '\n');
+
+  // The test itself does not fail on do-not-ship — the verdict IS the result.
+  // Integrity assertion: ship_decision enum, criteria non-empty, schema fields set.
+  expect(['ship', 'ship-with-backlog', 'do-not-ship']).toContain(verdict.ship_decision);
+  expect(verdict.criteria.length).toBeGreaterThan(0);
+  expect(verdict.schemaVersion).toBe(1);
+});


### PR DESCRIPTION
**Architecture spike, not competitive-standard adoption.**

This PR proves the Play-Gate execution engine runs end-to-end on two routes (`/sparkle` for JJ, `/homework` for Buggsy) under 12 PR-1 criteria. It does NOT claim any route meets the minimum competitive surface standard — that claim is earned route-by-route across PRs 2-7 per the v8 plan roadmap (B2).

Closes #442
Parent EPIC: #439
Prototype: #440

## Already in (commit 6bf93c7 — P1/P2/P3 prototype)

- `ops/play-gate-profiles.json` — canonical device/viewport/voice/theme source (replaces 5 inline device maps)
- `scripts/parse-profile-consumer.js` — Babel-AST parser (parses all 5 current consumer locations)
- `.github/scripts/check_profile_sync.py` — drift check (currently exits 1 on 3 known drifts; will exit 0 after helpers.js + education-workflows migrations)
- `.github/scripts/check_fixture_imports.py` — blocks new imports from `tests/shared/gas-shim.js` with 3-entry `SUPERSEDED_IMPORT_ALLOWLIST`
- `ops/play-gate/consumer-inventory.md` — P3 consumer-class inventory (writers / uploaders / readers / docs / temp / unknown-unknowns)
- `package.json` — adds `@babel/parser ^7.29.2`

## Follow-up commits on this branch (see #442 checklist)

1. `ops/play-gate-verdict.schema.json` + `scripts/canonical-verdict.js`
2. Migrate `tests/shared/helpers.js` + `tests/tbm/education-workflows.spec.js` to read profiles.json (removes drift)
3. `scripts/play-gate.js` CLI + `tests/tbm/play-gate/play-gate.spec.js` + 12 criterion `measurements/`
4. `.claude/skills/play-gate/SKILL.md` + stubs for `play-jj` / `play-buggsy`
5. GitHub Actions `workflow_dispatch` + determinism test + registry coverage test
6. Drift regression tests D1-D7

## Success bar (asserted before merge)

- `node scripts/play-gate.js --route /sparkle --child jj --mode fixture` → exit 0, valid verdict.json
- Same for `/homework buggsy`
- `ship_decision` field enforced (ajv fails on `verdict`) — D1
- `check_profile_sync.py` exits 0 after migrations — D2
- Legacy stubs return schema-identical verdict — D3
- `check_fixture_imports.py` passes with 3-entry allowlist — D6
- Determinism test: canonicalized verdict diff = 0 bytes
- Registry coverage: each of 12 criteria has matching `measurements/<ID>.js`

## Explicit non-goals

- NOT WCAG compliance claim
- NOT proof standard holds across families
- NOT live save/progress/reporting proof
- NOT `screenshots.spec.js` migration (→ PR 2)
- NOT shared-shim consumer migration (→ PR 2)
- NOT evidence-root rename (→ dedicated migration PR)
- NOT visual-hierarchy or creation-flow usability standards (→ spec PRs in PR 2 / PR 7 cycles)

## Reviewer guidance

This PR is intentionally large-scope because it establishes the execution engine + its regression fence in one atomic unit. Reviewers should look for:
- The PR description's leading line matching v8 requirement ("architecture spike, not competitive-standard adoption") ✅
- `ops/play-gate-profiles.json` treated as ground truth (not consumers)
- All 12 criteria traceable registry → spec → measurement impl
- No ES5 violations in any HTML touched (none expected)
- `check_profile_sync.py` validates both migratable consumers AND permanent-exception files