### PR TITLE
feat(#450): Codex review → claude:inbox event router (Phase 1)

### DIFF
--- a/.github/scripts/file_codex_review_findings.py
+++ b/.github/scripts/file_codex_review_findings.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""file_codex_review_findings.py
+Purpose:   Convert automated Codex PR review findings into durable claude:inbox
+           Issues. Parses the structured JSON block embedded in the bot's review
+           comment (<!-- codex-review-report -->) and shells out to
+           file_hygiene_issue.py for each actionable finding.
+
+           Phase 1 of the Codex-to-Claude event router. Complements (does not
+           replace) the manual-audit path in parse_finding_comment.py which
+           handles human-authored finding markers via a separate trust domain
+           and separate dedup mechanism (_finding_dedup.py comment-ID markers).
+
+Called by: .github/workflows/codex-review-filer.yml
+Trust:     github-actions[bot] author only. Human-authored findings are NOT
+           handled here — they stay on the manual listener path.
+
+Env vars:
+  Required:
+    GITHUB_TOKEN / GH_TOKEN           auth (auto in Actions)
+    GITHUB_REPOSITORY                 owner/repo (auto in Actions)
+    REPO                              owner/repo (workflow-supplied mirror)
+    COMMENT_BODY                      full bot comment body (contains the JSON block)
+    COMMENT_AUTHOR                    expected: 'github-actions[bot]'
+    COMMENT_ID                        the bot comment ID (used for source URL)
+    PR_NUMBER                         the PR the comment is on
+  Kill switches (our own):
+    AUTOMATION_ENABLED                'false' short-circuits (default true)
+    CODEX_REVIEW_FILER_ENABLED        'false' short-circuits this filer only (default true)
+    CLAUDE_INBOX_MAJOR_ENABLED        'true' opts severity:major into inbox (default false)
+  Forwarded to file_hygiene_issue.py subprocess (per its contract):
+    STATUS_ISSUE_NUMBER               pinned filer-status Issue
+    AUTOMATION_MAX_DAILY_ISSUES       integer cap (default 5 on helper side)
+  Intentionally NOT forwarded:
+    HYGIENE_ISSUE_CREATION_ENABLED    belongs to the paused hygiene-filer.yml
+                                      wrapper. This filer is adjacent, not
+                                      identical — it bypasses that wrapper.
+
+Behavior:
+  1. Gate on AUTOMATION_ENABLED AND CODEX_REVIEW_FILER_ENABLED. Silent exit on false.
+  2. Gate on COMMENT_AUTHOR == 'github-actions[bot]'. Silent exit otherwise.
+  3. Locate <!-- codex-review-report --> ... <!-- /codex-review-report --> block.
+     Extract JSON. Silent exit if absent or unparseable.
+  4. Gate on verdict == 'FAIL'. PASS and INCONCLUSIVE exit silently —
+     INCONCLUSIVE is handled by review-watcher.js as PR-check state, not a
+     work-queue item.
+  5. For each finding in findings[]:
+       - severity in {'blocker','critical'}: always file
+       - severity == 'major': file iff CLAUDE_INBOX_MAJOR_ENABLED=true
+       - severity == 'minor': skip
+  6. Build identity dict via build_identity(): evidence_hash primary,
+     title_hash fallback when evidence is empty.
+  7. Derive area:* label via AREA_PREFIX_MAP (first match wins; JJ/Buggsy
+     before generic area:education).
+  8. Derive model:* label: model:sonnet by default (fix work per
+     ops/WORKFLOW.md:65). model:codex when finding.file matches a
+     review-pipeline path.
+  9. Invoke file_hygiene_issue.py per finding with the constructed finding-JSON.
+ 10. Structured JSON-line logging to stdout.
+
+Exit: 0 success (one or more findings processed, or intentional skip).
+      1 validation error (bad input, unexpected shape).
+      2 unexpected error (subprocess failure).
+"""
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+AUTHOR_REQUIRED = 'github-actions[bot]'
+PR_COMMENT_MARKER = '<!-- codex-pr-review -->'
+REPORT_START = '<!-- codex-review-report -->'
+REPORT_END = '<!-- /codex-review-report -->'
+
+DEFAULT_SEVERITIES = {'blocker', 'critical'}
+OPTIONAL_SEVERITIES = {'major'}  # gated by CLAUDE_INBOX_MAJOR_ENABLED
+
+# finding.type -> repo label (pre-existing repo labels only)
+TYPE_LABEL_MAP = {
+    'wiring': 'type:wiring',
+    'persistence': 'type:persistence',
+    'schema': 'type:schema',
+    'ui': 'type:ui',
+    'logic': 'type:logic',
+    'deploy': 'type:deploy',
+}
+
+# file-path prefix -> area:* label. ORDER MATTERS. First match wins.
+# JJ/Buggsy specific before generic area:education, so SparkleLearning.html
+# routes to area:jj and HomeworkModule.html routes to area:buggsy.
+# Finance surfaces (ThePulse/Vein/Spine/Soul/DataEngine) before shared GAS infra.
+# Code.gs lives in shared (router/Safe-wrappers/CacheService per CLAUDE.md).
+AREA_PREFIX_MAP = [
+    # Infra / QA
+    ('.github/', 'area:infra'),
+    ('tests/', 'area:qa'),
+    ('playwright', 'area:qa'),
+    # JJ-specific
+    ('SparkleLearning', 'area:jj'),
+    ('JJHome', 'area:jj'),
+    ('sparkle-kingdom', 'area:jj'),
+    ('jj-', 'area:jj'),
+    # Buggsy-specific
+    ('HomeworkModule', 'area:buggsy'),
+    ('Wolfkid', 'area:buggsy'),
+    ('wolfkid-', 'area:buggsy'),
+    ('wolfdome', 'area:buggsy'),
+    # Shared education (after JJ/Buggsy so child-specific wins)
+    ('reading-module', 'area:education'),
+    ('writing-module', 'area:education'),
+    ('fact-sprint', 'area:education'),
+    ('investigation-module', 'area:education'),
+    ('daily-missions', 'area:education'),
+    ('BaselineDiagnostic', 'area:education'),
+    ('ComicStudio', 'area:education'),
+    ('StoryLibrary', 'area:education'),
+    ('StoryReader', 'area:education'),
+    ('ProgressReport', 'area:education'),
+    ('executive-skills', 'area:education'),
+    # Finance
+    ('ThePulse', 'area:finance'),
+    ('TheVein', 'area:finance'),
+    ('TheSpine', 'area:finance'),
+    ('TheSoul', 'area:finance'),
+    ('DataEngine', 'area:finance'),
+    # Shared GAS infra (includes Code.gs — router, NOT finance)
+    ('Code.gs', 'area:shared'),
+    ('GASHardening', 'area:shared'),
+    ('MonitorEngine', 'area:shared'),
+    ('AlertEngine', 'area:shared'),
+    ('Utility', 'area:shared'),
+]
+AREA_DEFAULT = 'area:infra'
+
+# Review-pipeline code — findings in these paths route to model:codex
+# (the review lane owns its own infrastructure) per ops/WORKFLOW.md:66.
+REVIEW_PIPELINE_PREFIXES = (
+    '.github/workflows/codex-',
+    '.github/scripts/codex_review',
+    '.github/scripts/triage_review',
+    '.github/scripts/review-fixer',
+    '.github/scripts/review-watcher',
+    '.github/scripts/parse_finding_comment',
+    '.github/scripts/_finding_dedup',
+    '.github/scripts/file_hygiene_issue',
+    '.github/scripts/file_codex_review_findings',
+)
+
+
+def log(event, **fields):
+    """Structured JSON-line logging to stdout (grep-able in workflow logs)."""
+    fields['event'] = event
+    sys.stdout.write(json.dumps(fields, sort_keys=True) + '\n')
+    sys.stdout.flush()
+
+
+def env_flag(name, default=True):
+    raw = os.environ.get(name, '').strip().lower()
+    if raw == '':
+        return default
+    return raw not in ('false', '0', 'no', 'off')
+
+
+def normalize(text):
+    """Lowercase + collapse whitespace + strip trailing punctuation."""
+    if not text:
+        return ''
+    s = str(text).lower()
+    s = re.sub(r'\s+', ' ', s).strip()
+    s = s.rstrip('.,;:!?')
+    return s
+
+
+def short_hash(text):
+    """First 12 hex chars of SHA256 over normalized text."""
+    return hashlib.sha256(normalize(text).encode('utf-8')).hexdigest()[:12]
+
+
+def build_identity(pr_number, finding):
+    """Identity dict for file_hygiene_issue.py signature computation.
+
+    Primary anchor: evidence_hash (code snippet — stable across reruns).
+    Fallback: title_hash (model prose — drifts; used only when evidence empty).
+
+    Excludes finding.id (model ordinal F001/F002, unstable), line (shifts when
+    surrounding code edits), and commit_sha (re-reviews should dedup to same
+    Issue, not stack new ones).
+    """
+    evidence = (finding.get('evidence') or '').strip()
+    if evidence:
+        anchor_key = 'evidence_hash'
+        anchor_val = short_hash(evidence)
+    else:
+        anchor_key = 'title_hash'
+        anchor_val = short_hash(finding.get('title') or '')
+    return {
+        'check': 'codex-review-finding',
+        'pr_number': str(pr_number),
+        'rule': (finding.get('rule') or '').strip(),
+        'file': (finding.get('file') or '').strip(),
+        anchor_key: anchor_val,
+    }
+
+
+def derive_area_label(file_path):
+    """First-match-wins prefix/substring lookup. Defaults to area:infra."""
+    if not file_path:
+        return AREA_DEFAULT
+    for prefix, label in AREA_PREFIX_MAP:
+        if prefix in file_path:
+            return label
+    return AREA_DEFAULT
+
+
+def derive_model_label(file_path):
+    """model:codex when the finding is in review-pipeline code (the review
+    lane's own infrastructure). model:sonnet otherwise (implementation/fixes).
+    """
+    if not file_path:
+        return 'model:sonnet'
+    for p in REVIEW_PIPELINE_PREFIXES:
+        if file_path.startswith(p):
+            return 'model:codex'
+    return 'model:sonnet'
+
+
+def derive_type_label(finding_type):
+    """Map finding.type to an existing repo label. Returns None if unmapped
+    (caller will skip rather than creating a new label)."""
+    if not finding_type:
+        return None
+    return TYPE_LABEL_MAP.get(finding_type.strip().lower())
+
+
+def extract_json_block(body):
+    """Find the embedded JSON between <!-- codex-review-report --> markers.
+    Returns parsed dict, or None if absent / unparseable.
+    """
+    if PR_COMMENT_MARKER not in body:
+        return None
+    start = body.find(REPORT_START)
+    end = body.find(REPORT_END)
+    if start < 0 or end < 0 or end <= start:
+        return None
+    block = body[start + len(REPORT_START):end]
+    # The helper in review-watcher.js handles the same block shape: find the
+    # first { and last } inside. That's robust against a surrounding markdown
+    # ```json fence.
+    j_start = block.find('{')
+    j_end = block.rfind('}')
+    if j_start < 0 or j_end < 0 or j_end <= j_start:
+        return None
+    try:
+        return json.loads(block[j_start:j_end + 1])
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def should_file(severity, major_enabled):
+    """Severity+verdict policy. verdict is already gated to FAIL before this."""
+    sev = (severity or '').strip().lower()
+    if sev in DEFAULT_SEVERITIES:
+        return True
+    if sev in OPTIONAL_SEVERITIES and major_enabled:
+        return True
+    return False
+
+
+def render_issue_details(finding, pr_number, repo, comment_id, confidence):
+    """The 'details' field goes verbatim into the Issue body (after the filer's
+    auto-generated Check/Evidence prefix). Includes source comment URL and the
+    mandatory ## Build Skills section per CLAUDE.md workflow rules.
+    """
+    file_path = finding.get('file') or 'unknown'
+    line = finding.get('line') or '?'
+    snippet = (finding.get('evidence') or '(no snippet)').strip()
+    fix_hint = (finding.get('fix_hint') or '(none provided)').strip()
+    comment_url = 'https://github.com/{0}/pull/{1}#issuecomment-{2}'.format(
+        repo, pr_number, comment_id
+    )
+    pr_url = 'https://github.com/{0}/pull/{1}'.format(repo, pr_number)
+    return (
+        '### From Codex PR Review\n\n'
+        '- **PR:** [#{pr}]({pr_url})\n'
+        '- **Source comment:** [Codex review on #{pr}]({comment_url})\n'
+        '- **File:** `{file}` (line {line})\n'
+        '- **Verdict:** FAIL (confidence: {conf})\n\n'
+        '### Snippet\n\n'
+        '```\n{snippet}\n```\n\n'
+        '### Fix hint\n\n'
+        '{fix}\n\n'
+        '### Build Skills\n\n'
+        '- `thompson-engineer` — auto-filed Codex findings typically need '
+        'repo-wide architecture + GAS pattern awareness to resolve.\n'
+        '- `deploy-pipeline` — any fix landing via PR must pass audit-source.sh '
+        '+ CI before deploy.\n\n'
+        '(Minimum skills per `CLAUDE.md § Workflow — Build Skills (MANDATORY '
+        'on every Issue)`. The picking Claude session may add more skills '
+        'based on the specific file / module involved.)'
+    ).format(
+        pr=pr_number, pr_url=pr_url, comment_url=comment_url,
+        file=file_path, line=line, conf=(confidence or 'unknown'),
+        snippet=snippet, fix=fix_hint,
+    )
+
+
+def build_finding_payload(finding, pr_number, repo, comment_id, confidence):
+    """Construct the finding JSON to pipe into file_hygiene_issue.py stdin."""
+    severity = (finding.get('severity') or '').strip().lower()
+    ftype = (finding.get('type') or '').strip().lower()
+    file_path = (finding.get('file') or '').strip()
+
+    title = (finding.get('title') or 'Codex finding').strip()
+    identity = build_identity(pr_number, finding)
+    area_label = derive_area_label(file_path)
+    model_label = derive_model_label(file_path)
+    type_label = derive_type_label(ftype)
+
+    extra_labels = [
+        'claude:inbox',
+        'kind:bug',
+        model_label,
+        'severity:' + severity,
+    ]
+    if type_label:
+        extra_labels.append(type_label)
+    extra_labels.append(area_label)
+
+    return {
+        'check': 'codex-review-finding',
+        'check_title': 'Codex',
+        'title': '{0} (PR #{1})'.format(title, pr_number),
+        'identity': identity,
+        'evidence': {
+            'severity': severity,
+            'type': ftype,
+            'file': file_path,
+            'line': str(finding.get('line') or '?'),
+            'rule': (finding.get('rule') or '').strip(),
+            'confidence': confidence or 'unknown',
+        },
+        'details': render_issue_details(finding, pr_number, repo, comment_id, confidence),
+        'extra_labels': extra_labels,
+    }
+
+
+def invoke_filer(payload):
+    """Pipe payload JSON into file_hygiene_issue.py. Returns (exit_code, stdout, stderr)."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    script = os.path.join(here, 'file_hygiene_issue.py')
+    proc = subprocess.run(
+        ['python3', script],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        encoding='utf-8',
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def main():
+    # 1. Master kill switches.
+    if not env_flag('AUTOMATION_ENABLED', default=True):
+        log('skip', reason='AUTOMATION_ENABLED=false')
+        return 0
+    if not env_flag('CODEX_REVIEW_FILER_ENABLED', default=True):
+        log('skip', reason='CODEX_REVIEW_FILER_ENABLED=false')
+        return 0
+
+    # 2. Author gate — bot-only trust domain.
+    author = os.environ.get('COMMENT_AUTHOR', '').strip()
+    if author != AUTHOR_REQUIRED:
+        log('skip', reason='author-not-bot', author=author)
+        return 0
+
+    # 3. Parse the JSON block.
+    body = os.environ.get('COMMENT_BODY', '')
+    report = extract_json_block(body)
+    if report is None:
+        log('skip', reason='no-report-block')
+        return 0
+
+    # 4. Verdict gate.
+    verdict = str(report.get('verdict') or '').strip().upper()
+    if verdict != 'FAIL':
+        log('skip', reason='verdict-not-fail', verdict=verdict)
+        return 0
+
+    findings = report.get('findings') or []
+    if not isinstance(findings, list) or not findings:
+        log('skip', reason='no-findings', verdict=verdict)
+        return 0
+
+    # Required inputs for constructing payloads.
+    repo = os.environ.get('REPO') or os.environ.get('GITHUB_REPOSITORY') or ''
+    pr_number = os.environ.get('PR_NUMBER', '').strip()
+    comment_id = os.environ.get('COMMENT_ID', '').strip() or '0'
+    confidence = str(report.get('confidence') or '').strip().lower() or None
+
+    if not repo or not pr_number:
+        log('error', reason='missing-required-env', repo=bool(repo), pr=bool(pr_number))
+        return 1
+
+    # 5. Severity policy + per-finding file.
+    major_enabled = env_flag('CLAUDE_INBOX_MAJOR_ENABLED', default=False)
+    filed = 0
+    skipped = 0
+    errors = 0
+
+    for idx, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            log('skip-finding', reason='non-dict', index=idx)
+            skipped += 1
+            continue
+
+        severity = (finding.get('severity') or '').strip().lower()
+        if not should_file(severity, major_enabled):
+            log('skip-finding', reason='severity-policy', index=idx,
+                severity=severity, major_enabled=major_enabled)
+            skipped += 1
+            continue
+
+        payload = build_finding_payload(
+            finding, pr_number, repo, comment_id, confidence,
+        )
+        code, stdout, stderr = invoke_filer(payload)
+        if code == 0:
+            filed += 1
+            log('filed', index=idx, severity=severity,
+                rule=payload['identity'].get('rule'),
+                file=payload['identity'].get('file'),
+                labels=payload['extra_labels'])
+        else:
+            errors += 1
+            log('filer-error', index=idx, code=code,
+                stderr=(stderr or '').strip()[:500])
+
+    log('done', pr=pr_number, verdict=verdict,
+        findings_total=len(findings), filed=filed, skipped=skipped, errors=errors,
+        major_enabled=major_enabled)
+    return 2 if errors else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/codex-review-filer.yml
+++ b/.github/workflows/codex-review-filer.yml
@@ -1,0 +1,71 @@
+# .github/workflows/codex-review-filer.yml
+# Codex Review Filer — convert automated Codex PR review findings (the bot
+# comment with embedded <!-- codex-review-report --> JSON) into durable
+# claude:inbox Issues for blocker/critical findings.
+#
+# Adjacent to .github/workflows/codex-finding-listener.yml, not a replacement:
+#   - codex-finding-listener: MANUAL path, whitelisted humans, comment-ID dedup
+#   - codex-review-filer:     AUTOMATED path, github-actions[bot] only,
+#                             signature dedup via file_hygiene_issue.py
+# The two trust domains must stay separate (parse_finding_comment.py:40-43
+# explicitly skips github-actions[bot] to prevent loops).
+#
+# Logic lives in .github/scripts/file_codex_review_findings.py (no heredocs).
+# Phase 1: issues only. No auto-close, no handoff comments, no Notion sync.
+# Sacrificial test PR required before relying on this filer — new workflow
+# files can't review their own introduction (see CLAUDE.md workflow-safety).
+
+name: Codex Review Filer
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: codex-review-filer-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  file-findings:
+    name: File Codex review findings
+    # Cheap first-gate in the YAML itself — avoids spinning up a runner for
+    # every comment event. The script re-gates these too (defense in depth).
+    if: >
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.login == 'github-actions[bot]' &&
+      contains(github.event.comment.body, '<!-- codex-review-report -->')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: File Codex review findings
+        env:
+          # Required by this script.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          # Our kill switches.
+          AUTOMATION_ENABLED: ${{ vars.AUTOMATION_ENABLED || 'true' }}
+          CODEX_REVIEW_FILER_ENABLED: ${{ vars.CODEX_REVIEW_FILER_ENABLED || 'true' }}
+          CLAUDE_INBOX_MAJOR_ENABLED: ${{ vars.CLAUDE_INBOX_MAJOR_ENABLED || 'false' }}
+          # Forwarded to file_hygiene_issue.py subprocess per its env contract
+          # at file_hygiene_issue.py:17-22. Forwarding preserves the
+          # repo-configured status-audit trail and daily cap instead of
+          # silently using helper defaults.
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STATUS_ISSUE_NUMBER: ${{ vars.STATUS_ISSUE_NUMBER || '' }}
+          AUTOMATION_MAX_DAILY_ISSUES: ${{ vars.AUTOMATION_MAX_DAILY_ISSUES || '5' }}
+          # Intentionally NOT forwarded: HYGIENE_ISSUE_CREATION_ENABLED —
+          # that repo var belongs to the paused hygiene-filer.yml wrapper.
+          # This filer is adjacent, not identical. Leaving the wrapper
+          # paused (HYGIENE_ISSUE_CREATION_ENABLED=false live) is correct.
+        run: python3 .github/scripts/file_codex_review_findings.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ This loads `.claude/settings.local.json` (repo-scoped MCP + Bash allowances). Wi
 2. Run `clasp deployments` to confirm deployment ID
 3. Fetch PM Active Versions (Notion `2c8cea3cd9e8818eaf53df73cb5c2eee`) for current state
 4. Check the TBM Operations Project board and the "Needs Decision" column for anything blocked on LT input
-5. Do NOT begin work until steps 1–4 are complete
+5. Check `gh issue list -l claude:inbox --state open` for pending Codex findings auto-filed by `codex-review-filer.yml`. If any exist, they are the priority queue — address before starting new work.
+6. Do NOT begin work until steps 1–5 are complete
 
 ---
 
@@ -105,8 +106,10 @@ After 10+ messages in a session, re-read any file before editing it. Do not trus
 - If a decision is blocking 3 specs, the Issue has back-links in all 3 specs.
 
 **Codex findings:**
-- In-PR review comments stay in the PR (that's the evidence)
-- For any blocking finding, Claude (or LT, during audit) **manually opens** a dedicated Issue with `kind:bug` + `severity:blocker` + a link to the PR comment. Process rule, NOT automation today (Codex pipeline posts comments and `pipeline:*` labels only). The manual Issue exists so the finding survives PR close/merge. Future automation (Orchestration Loop Phase 3+, issue #111) may promote this.
+- In-PR review comments stay in the PR (that's the evidence).
+- **Automated path (bot):** For blocker/critical findings in the `<!-- codex-review-report -->` JSON emitted by `codex-pr-review.yml`, `codex-review-filer.yml` auto-files a durable Issue labeled `claude:inbox` + `kind:bug` + `severity:*` + `model:sonnet` (default) + `area:*` + `type:*`, with body including a `## Build Skills` section and the exact `#issuecomment-<id>` URL. Dedup is signature-based on `rule + file + evidence_hash + pr_number` — re-reviews on the same PR dedup to the same Issue signature: open matches no-op, recent closed matches (≤7 days) reopen, no duplicate is created. Kill switches: `AUTOMATION_ENABLED`, `CODEX_REVIEW_FILER_ENABLED`, `CLAUDE_INBOX_MAJOR_ENABLED`. `model:codex` is used instead of `model:sonnet` when the finding is in review-pipeline code itself.
+- **Manual path (human):** Codex (or LT, during a manual audit via "audit N" in ChatGPT) posts freeform PR comments with `Codex finding: FIX/HOLD/BLOCK` markers. `codex-finding-listener.yml` picks these up via `parse_finding_comment.py` under the `{blucsigma05, chatgpt-codex-connector}` author whitelist and auto-files durable Issues for `severity:blocker` via `_finding_dedup.py` (comment-ID dedup). This path is unchanged.
+- Both paths produce durable Issues; they differ in trust domain and dedup mechanism. Do not merge them.
 
 **When LT says "PR" but means "Issue" (or vice versa):**
 - Claude MUST redirect and confirm: "You said PR — did you mean the Issue, or is this actually a code change?"
@@ -444,7 +447,8 @@ Phase 1 scope: one pilot check (HYG-06 version drift). Phase 2+ is out of scope 
 | `codex_review.py` | codex-pr-review.yml | Send PR diff to OpenAI gpt-4o, format review comment |
 | `parse_test_results.py` | ci.yml | Parse GAS smoke+regression JSON into PR comment |
 | `parse_playwright_results.py` | playwright-regression.yml | Parse Playwright JSON into PR comment |
-| `parse_finding_comment.py` | codex-pr-review.yml | Parse PR comment for finding markers, apply labels |
+| `parse_finding_comment.py` | codex-finding-listener.yml | Parse PR comment for human-authored finding markers (manual path), apply labels, file blocker Issues via `_finding_dedup.py` |
+| `file_codex_review_findings.py` | codex-review-filer.yml | Parse automated Codex review JSON (bot-authored), file blocker/critical findings as durable `claude:inbox` Issues via `file_hygiene_issue.py` |
 | `triage_review.py` | codex-pr-review.yml | Classify PR into skip/light/medium/full before review |
 | `check_version_drift.py` | hygiene.yml | Compare deployed GAS versions against source constants |
 | `check_claude_md.py` | hygiene.yml | Detect CLAUDE.md bloat, dead refs, duplicate phrases |
@@ -533,6 +537,7 @@ thompsonfams.com/api/verify-pin   → PIN verification for finance surfaces
 | 2 | TBM Smoke + Regression | `ci.yml` | GAS smoke + regression tests |
 | 2 | Playwright Regression | `playwright-regression.yml` | E2E + viewport screenshots |
 | 2 | Codex PR Review | `codex-pr-review.yml` | gpt-4o code review — has `needs: lint-gate` |
+| async | Codex Review Filer | `codex-review-filer.yml` | Auto-file durable `claude:inbox` Issues for blocker/critical findings from automated Codex reviews (fires on `issue_comment` — not a PR gate) |
 
 LT applies branch protection in GitHub Settings > Branches > Branch protection rules (UI action).
 

--- a/ops/WORKFLOW.md
+++ b/ops/WORKFLOW.md
@@ -157,13 +157,39 @@ Cards move based on labels and PR state:
 
 ### Flow 4 — Codex PR audit with findings
 
+Two paths, both producing durable Issues. They differ in trust domain and dedup mechanism — do not merge them.
+
 ```
-1. Codex reviews a PR, posts findings as inline comments
-2. For each blocker finding, Codex also opens Issue with kind:bug + severity:blocker
-3. The Issue body references the PR comment URL
+1. Codex (auto or manual) reviews a PR, posts findings
+
+2a. AUTO path — bot comment with <!-- codex-review-report --> JSON:
+    codex-review-filer.yml (fires on issue_comment:created+edited)
+      -> file_codex_review_findings.py parses JSON
+      -> per blocker/critical finding, invokes file_hygiene_issue.py
+      -> claude:inbox Issue filed (signature dedup on rule+file+evidence_hash+pr)
+    Kill switches: AUTOMATION_ENABLED, CODEX_REVIEW_FILER_ENABLED,
+                   CLAUDE_INBOX_MAJOR_ENABLED.
+
+2b. MANUAL path — whitelisted human posts "Codex finding: FIX/HOLD/BLOCK":
+    codex-finding-listener.yml (fires on issue_comment / review / review_comment)
+      -> parse_finding_comment.py (authors: blucsigma05, chatgpt-codex-connector)
+      -> applies pipeline:* labels, files severity:blocker Issues via _finding_dedup.py
+         (comment-ID dedup)
+    Kill switches: AUTOMATION_ENABLED, CODEX_BLOCKER_AUTOFILE_ENABLED.
+
+3. Issue body includes exact PR-comment URL and a ## Build Skills section
 4. If the PR merges without fixing, the Issue stays open and blocks downstream work
-5. Fix comes as a follow-up PR closing the Issue
+5. Fix comes as a follow-up PR closing the Issue (builder lane = model:sonnet default)
 ```
+
+**Dedup semantics.** Re-reviews or comment edits on the same PR hitting the same
+underlying finding dedup to the same Issue signature. Open matches no-op;
+recent closed matches (≤7 days) reopen; no duplicate Issue is ever created.
+See `file_hygiene_issue.py:307–342` for the authoritative flow.
+
+**INCONCLUSIVE verdicts** (Codex CI truncated or errored) do NOT create
+Issues — they stay on the PR-check state surface handled by `review-watcher.js`.
+LT resolves them via a manual `audit N` in ChatGPT or an explicit waive.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 1 of the GitHub-native bridge that removes LT from manually relaying automated Codex review findings. When `codex-pr-review.yml` posts a review with blocker or critical findings, `codex-review-filer.yml` auto-opens a durable `claude:inbox` Issue within ~30s. Claude reads `gh issue list -l claude:inbox --state open` at session start and addresses pending findings before new work.

**Manual-audit path unchanged** — the existing `codex-finding-listener.yml` + `parse_finding_comment.py` path for whitelisted human-authored finding markers stays exactly as it was. Two trust domains, two separate workflows, two separate dedup mechanisms.

## What's new

- `.github/workflows/codex-review-filer.yml` — fires on `issue_comment:created+edited`, gated on `github-actions[bot]` + body contains `<!-- codex-review-report -->`.
- `.github/scripts/file_codex_review_findings.py` — parses the embedded JSON block, constructs finding-JSON per severity+verdict policy, shells out to `file_hygiene_issue.py`.

## What's updated

- `CLAUDE.md § Session Start` — new step 5: check `claude:inbox` before new work.
- `CLAUDE.md § Workflow — Codex findings` — "NOT automation today" block replaced with explicit AUTO + MANUAL path docs.
- `CLAUDE.md § File Map` + `§ CI Checks` — new inventory rows for the script and workflow.
- `ops/WORKFLOW.md § Flow 4` — rewritten to show both paths, documents dedup semantics and INCONCLUSIVE handling.

## What's reused (not modified)

- `.github/scripts/file_hygiene_issue.py` — called via subprocess. `STATUS_ISSUE_NUMBER` and `AUTOMATION_MAX_DAILY_ISSUES` are forwarded to preserve the repo-configured audit/cap contract. `HYGIENE_ISSUE_CREATION_ENABLED` is intentionally NOT forwarded — that belongs to the paused `hygiene-filer.yml` wrapper; this filer is adjacent to it, not identical.
- `.github/workflows/codex-finding-listener.yml` + `parse_finding_comment.py` + `_finding_dedup.py` — the manual human-audit path. Untouched.

## Severity + verdict policy

| Severity | Verdict | Behavior |
|---|---|---|
| blocker | FAIL | auto-file (always) |
| critical | FAIL | auto-file (always) |
| major | FAIL | auto-file iff `CLAUDE_INBOX_MAJOR_ENABLED=true` (default false) |
| minor | FAIL | skip (stays in PR comment as evidence) |
| any | PASS | skip all |
| any | INCONCLUSIVE | skip (handled by `review-watcher.js` as PR-check state, not a work item) |

## Filed Issue shape

- **Labels:** `claude:inbox`, `kind:bug`, `severity:<level>`, `type:<type>`, `area:<derived>`, `model:sonnet` (or `model:codex` when the finding is in review-pipeline code itself)
- **Body:** Includes the exact `#issuecomment-<id>` URL for audit chain, the finding's evidence snippet, fix hint, and a mandatory `## Build Skills` section per `CLAUDE.md § Workflow — Build Skills (MANDATORY on every Issue)`
- **Dedup:** signature-based on `{check, pr_number, rule, file, evidence_hash}` (falls back to `title_hash` when evidence is empty). Re-reviews on the same PR dedup to the same Issue signature: open matches no-op, recent closed matches (≤7 days) reopen, no duplicate is created. See `file_hygiene_issue.py:307–342`.

## Kill switches

- `AUTOMATION_ENABLED` (shared master) — flip to `false` to kill all automation
- `CODEX_REVIEW_FILER_ENABLED` (NEW, this filer only) — flip to `false` to kill just this path
- `CLAUDE_INBOX_MAJOR_ENABLED` (NEW) — flip to `true` to include `severity:major` findings

Default state: `CODEX_REVIEW_FILER_ENABLED=true`, `CLAUDE_INBOX_MAJOR_ENABLED=false`. `HYGIENE_ISSUE_CREATION_ENABLED` stays `false` (unrelated — do not flip).

## Sacrificial test PR required

Per `CLAUDE.md` workflow-safety rule, new workflow files cannot review their own introduction. After this merges:

1. Open a trivial throwaway PR with one intentional `severity:critical` finding Codex will catch.
2. Let `codex-pr-review.yml` post its review comment.
3. Confirm `claude:inbox` Issue opens within ~30s with expected labels including `model:sonnet`.
4. Push an empty commit to trigger re-review → confirm dedup (no second Issue).
5. Fix the finding → confirm no Issue-churn (Phase 1 does not auto-close; that's Phase 2).
6. Flip `CLAUDE_INBOX_MAJOR_ENABLED=true`, induce a major finding, verify; flip back, verify skip.
7. Flip `CODEX_REVIEW_FILER_ENABLED=false`, induce any finding, verify skip + workflow logs "disabled".

If any step fails: flip `CODEX_REVIEW_FILER_ENABLED=false` immediately, file a bug Issue, iterate.

## Closes

Closes #450.

## Plan reference

Plan evolved v1 → v7 across four Codex audit passes. All findings either folded or explicitly rejected with verification. Plan file stays local (not canonical) at `C:\Users\BluCs\.claude\plans\i-need-you-to-encapsulated-fountain.md`; this PR body is the canonical spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)