### PR TITLE
CHORE: group redirects in inline filer step — shellcheck SC2129

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -402,10 +402,13 @@ jobs:
           fi
           # Wrap the structured report in the marker envelope the filer script
           # expects, so it can reuse its extract_json_block() logic unchanged.
-          printf '%s\n' '<!-- codex-pr-review -->' > /tmp/synthetic_comment_body.md
-          printf '%s\n' '<!-- codex-review-report -->' >> /tmp/synthetic_comment_body.md
-          cat review-report.json >> /tmp/synthetic_comment_body.md
-          printf '\n%s\n' '<!-- /codex-review-report -->' >> /tmp/synthetic_comment_body.md
+          # Grouped redirect satisfies shellcheck SC2129 (one open/close vs 4).
+          {
+            printf '%s\n' '<!-- codex-pr-review -->'
+            printf '%s\n' '<!-- codex-review-report -->'
+            cat review-report.json
+            printf '\n%s\n' '<!-- /codex-review-report -->'
+          } > /tmp/synthetic_comment_body.md
           COMMENT_BODY="$(cat /tmp/synthetic_comment_body.md)" \
             python3 .github/scripts/file_codex_review_findings.py
 


### PR DESCRIPTION
Follow-up to #457. Inline filer step's synthetic-body construction had 4 separate `>>` redirects that shellcheck flags as SC2129. One-line refactor to a `{ ... } >` group. Functionally identical. Fails its own lint-gate (main has the issue being fixed); merging via `--admin` per the chicken-and-egg pattern.