### PR TITLE
docs(#460): codify autonomous merge authority tiers in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,8 +577,13 @@ Distinct from "Auto-merge policy" above (which concerns GitHub's CI-triggered au
 
 **Evidence standard for "Claude says green."** Before an autonomous merge, Claude must have VERIFIED (not assumed):
 - `gh pr checks <N>` shows all required checks passing (not just "workflow_run success")
-- `gh pr view <N>` shows a Codex comment with explicit `**Verdict:** PASS` AND `**Files Reviewed:**` section
-- `gh pr view <N>` shows no unresolved review threads from LT or other reviewers
+- `gh api repos/<owner>/<repo>/issues/<N>/comments --jq '.[] | select(.body | contains("codex-pr-review"))'` shows a Codex comment with explicit `**Verdict:** PASS` AND `**Files Reviewed:**` section
+- **Unresolved review threads = 0**, queried via GraphQL (NOT `gh pr view` — that does not expose thread-level resolution state; it only surfaces `reviewDecision` / `reviews`, which summarize differently):
+  ```bash
+  gh api graphql -f query='{ repository(owner:"<owner>",name:"<repo>") { pullRequest(number:<N>) { reviewThreads(first:50) { nodes { isResolved } } } } }' \
+    --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+  ```
+  Output must be `0`. Any other number blocks autonomous merge.
 
 "Looks green in the UI" is not evidence. Read the API response.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,6 +542,46 @@ LT applies branch protection in GitHub Settings > Branches > Branch protection r
 
 **Auto-merge policy:** Currently **manual review required**. Auto-merge can be enabled when the pipeline runs cleanly on 5 consecutive PRs without false negatives. Status: not yet enabled.
 
+### Autonomous Merge Authority
+
+Distinct from "Auto-merge policy" above (which concerns GitHub's CI-triggered auto-merge feature). This section governs when Claude Code may run `gh pr merge` directly during an interactive session.
+
+**Merge autonomously (green = go).** All of the following must hold:
+- Both CI AND Codex have explicit PASS verdicts on the PR
+- The PR matches one of these shapes:
+  - `CHORE:` / `DOCS:` / `CONFIG:` non-sensitive prefixed changes
+  - `severity:minor` feature work with no mutation-path changes
+  - Review-fix commits on a PR LT already saw the diff of
+  - Any PR where LT said "ship it" / "merge" / "let's go" in the same session
+- The PR does NOT touch any file in the "always confirm" list below
+- No active deploy freeze
+
+**Always confirm merge first (non-negotiable, no override).**
+- Hot files: `.github/workflows/**`, `.github/scripts/**`, `CLAUDE.md`, `audit-source.sh`, `cloudflare-worker.js`
+- Freeze-critical paths (enumerated in `ops/mutation-paths.md`)
+- Schema migrations or `TAB_MAP` changes
+- Financial model changes (DataEngine calculators, debt cascade, close logic)
+- Any PR with `severity:blocker` or `severity:critical`
+- Any PR where CI is yellow/red or Codex verdict is FAIL / INCONCLUSIVE
+- Kid-visible UI changes without a visual diff shown to LT in session
+- During an active deploy freeze (any merge)
+- PRs opened by a non-interactive agent lane (e.g. the nightly grinder — see #454)
+
+**Gray zone (ask first time, remember the call).**
+- First PR of a new pattern or area
+- New scheduled tasks / cron triggers
+- Changes to alert tier thresholds (`PUSHOVER_PRIORITY.*`)
+- First PR after a CI workflow change
+
+**Autonomous overnight work is a separate contract.** The nightly grinder (#454) and any future unsupervised automation **merges nothing**. That is a different trust tier — no interactive LT to catch subtle wrongness. Interactive session authority above does not extend to lanes LT is not watching.
+
+**Evidence standard for "Claude says green."** Before an autonomous merge, Claude must have VERIFIED (not assumed):
+- `gh pr checks <N>` shows all required checks passing (not just "workflow_run success")
+- `gh pr view <N>` shows a Codex comment with explicit `**Verdict:** PASS` AND `**Files Reviewed:**` section
+- `gh pr view <N>` shows no unresolved review threads from LT or other reviewers
+
+"Looks green in the UI" is not evidence. Read the API response.
+
 ### Cloudflare Worker Deploy Verification (issue #403)
 
 There are two separate Cloudflare integrations on this repo — do not confuse them:


### PR DESCRIPTION
## Summary
Adds an "Autonomous Merge Authority" section to CLAUDE.md that clarifies when Claude Code may run `gh pr merge` directly during interactive sessions vs when LT must confirm first. Disambiguates from the adjacent "Auto-merge policy" line (which concerns GitHub's CI-triggered auto-merge feature, unrelated to agent authority).

## Why
Policy has been implicit — led to inconsistent behavior across sessions and unnecessary confirmation friction on low-risk PRs. This decision was discussed and approved in a 2026-04-18 session with LT.

## Change
One additive section inserted between existing "Auto-merge policy" line and "Cloudflare Worker Deploy Verification" heading. No existing content modified.

Three tiers defined:
- **Merge autonomously** — CHORE/DOCS/CONFIG, `severity:minor` interactive work with no mutation-path changes, review-fix commits on previously-seen diffs, or any PR where LT said "ship it" in session. CI + Codex both green required.
- **Always confirm** — hot files (`.github/workflows/**`, `.github/scripts/**`, `CLAUDE.md`, `audit-source.sh`, `cloudflare-worker.js`), freeze-critical paths, schema/finance changes, `severity:blocker`/`critical`, yellow/red CI, Codex FAIL/INCONCLUSIVE, kid-visible UI without visual diff, active deploy freeze, PRs from non-interactive agent lanes (e.g. the nightly grinder #454).
- **Gray zone** — first PR of a new pattern, new cron triggers, alert threshold changes, first PR after a CI workflow change.

Also specifies the evidence standard for "green" (real `gh pr checks` verification + explicit Codex `Verdict: PASS` + no unresolved review threads) and explicitly carves out that autonomous overnight work (nightly grinder #454) merges nothing — separate trust contract.

## Acceptance criteria (from #460)
- [x] New section "Autonomous Merge Authority" added to CLAUDE.md after existing "Auto-merge policy" line
- [x] Three tiers clearly defined: Autonomous, Always-confirm, Gray-zone
- [x] Evidence standard for "PR is green" included (not just UI glance)
- [x] Explicit carve-out that nightly grinder (#454) merges nothing — different contract
- [x] Links to relevant existing CLAUDE.md rules (mutation-paths.md, PUSHOVER_PRIORITY, hot file list)

## Test plan
- [x] `audit-source.sh` passes (docs-only change — ES5/version/wiring gates N/A, branch staleness OK)
- [ ] Codex review confirms no contradictions with existing CLAUDE.md sections
- [ ] LT reads the new section and confirms wording matches the verbal agreement

## Not in this PR (out of scope per #460)
- Auto-merge (CI-triggered) enablement — stays at "not yet enabled" per existing policy
- Grinder merge authority — remains zero per #454

## Hot file lock
This PR touches CLAUDE.md (hot file). Verified pre-creation: no other open PR touches CLAUDE.md. Single in-flight edit to this file.

Closes #460