### PR TITLE
feat(#468): Phase 3 — reverse-direction handoff router (Claude → Codex marker)

### DIFF
--- a/.github/scripts/post_tbm_handoff_marker.py
+++ b/.github/scripts/post_tbm_handoff_marker.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""post_tbm_handoff_marker.py
+Purpose:   Phase 3 of the Codex <-> Claude event router (#468). Post a
+           <!-- tbm-handoff --> marker comment on a PR that references one
+           or more open `claude:inbox` Issues via "Closes #N" / "Fixes #N" /
+           "Resolves #N" patterns in the PR body or any commit message.
+           Documents the Claude -> Codex handoff visibly on the PR so LT
+           and future automation can see which inbox findings a PR claims
+           to close. Does NOT trigger Codex re-review (that already fires
+           on `pull_request_target: synchronize`) and does NOT close any
+           Issues (Phase 2 does that when Codex re-reviews).
+
+Called by: .github/workflows/codex-rereview-handoff.yml (pull_request_target
+           opened/reopened/synchronize + workflow_dispatch).
+
+Trust:     Low-trust. This script only POSTS a single PR comment; it does
+           not close Issues, file new ones, or otherwise mutate state
+           beyond one idempotent upsert. Safe to run on fork PRs under
+           pull_request_target (base-branch YAML is authoritative).
+
+Env vars:
+  Required:
+    GITHUB_TOKEN / GH_TOKEN           auth (auto in Actions)
+    GITHUB_REPOSITORY                 owner/repo (auto in Actions)
+    REPO                              owner/repo (workflow-supplied mirror)
+    PR_NUMBER                         the PR number
+  Kill switches (both default ON):
+    AUTOMATION_ENABLED                master off for all automation
+    TBM_HANDOFF_ROUTER_ENABLED        off for this router only
+
+Behavior:
+  1. Gate on AUTOMATION_ENABLED AND TBM_HANDOFF_ROUTER_ENABLED. Silent exit
+     on either false.
+  2. Fetch PR body + all commit messages via `gh pr view --json body,commits`.
+  3. Parse `Close[sd]? | Fix(e[sd])? | Resolve[sd]? #N` patterns (case
+     insensitive). GitHub's closing-keyword set, not every mention.
+  4. For each unique referenced issue, query `gh issue view --json labels,title`.
+     Silently skip issues that do not exist or that return an error.
+  5. Keep only issues carrying the `claude:inbox` label.
+  6. If the filtered set is non-empty, build the canonical comment body and
+     upsert: search existing PR comments for the marker, PATCH if present,
+     POST if not.
+  7. If the filtered set is empty, no-op (do not post, do not delete existing
+     marker -- a past marker may still be valid even if the current push
+     removed the closing keyword temporarily).
+  8. Structured JSON-line logging to stdout for every decision.
+
+Exit: 0 success (posted / updated / no-op all count as success).
+      1 validation error (missing required env var).
+      2 unexpected error (API / subprocess failure that prevents completion).
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+MARKER = '<!-- tbm-handoff -->'
+INBOX_LABEL = 'claude:inbox'
+
+# GitHub's canonical closing-keyword grammar. Deliberately narrow -- only
+# references that will trigger Issue closure on merge count. Plain "#N"
+# mentions or "Related to #N" do NOT trigger a handoff marker.
+ISSUE_REF_RE = re.compile(
+    r'\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b',
+    re.IGNORECASE,
+)
+
+
+def log(event, **fields):
+    """Structured JSON-line logging. Mirrors file_codex_review_findings.py."""
+    fields['event'] = event
+    sys.stdout.write(json.dumps(fields, sort_keys=True) + '\n')
+    sys.stdout.flush()
+
+
+def env_flag(name, default=True):
+    raw = os.environ.get(name, '').strip().lower()
+    if raw == '':
+        return default
+    return raw not in ('false', '0', 'no', 'off')
+
+
+def env_required(name):
+    value = os.environ.get(name, '').strip()
+    if not value:
+        log('error', reason='missing-env', name=name)
+        sys.exit(1)
+    return value
+
+
+def gh(args, check=True):
+    """Run gh CLI. Return (stdout, returncode). Raise on check=True failure."""
+    proc = subprocess.run(
+        ['gh'] + list(args),
+        capture_output=True,
+        text=True,
+    )
+    if check and proc.returncode != 0:
+        log('gh-error', args=list(args), rc=proc.returncode,
+            stderr=proc.stderr.strip()[:500])
+        raise RuntimeError('gh ' + args[0] + ' failed rc=' + str(proc.returncode))
+    return proc.stdout, proc.returncode
+
+
+def fetch_pr_text(repo, pr_number):
+    """Return PR body + all commit headlines/bodies concatenated for regex scan."""
+    stdout, _ = gh([
+        'pr', 'view', str(pr_number),
+        '--repo', repo,
+        '--json', 'body,commits',
+    ])
+    data = json.loads(stdout)
+    parts = [data.get('body') or '']
+    for commit in data.get('commits') or []:
+        parts.append(commit.get('messageHeadline') or '')
+        parts.append(commit.get('messageBody') or '')
+    return '\n'.join(parts)
+
+
+def extract_closing_refs(text):
+    """Return sorted unique issue numbers from closing-keyword patterns."""
+    nums = set()
+    for match in ISSUE_REF_RE.finditer(text or ''):
+        try:
+            nums.add(int(match.group(1)))
+        except (TypeError, ValueError):
+            continue
+    return sorted(nums)
+
+
+def lookup_inbox_issue(repo, issue_number):
+    """Return (True, title) if the issue has claude:inbox, else (False, None).
+    Returns (False, None) on any lookup error (nonexistent, API failure, etc.)."""
+    try:
+        stdout, rc = gh([
+            'issue', 'view', str(issue_number),
+            '--repo', repo,
+            '--json', 'labels,title,state',
+        ], check=False)
+        if rc != 0:
+            log('issue-lookup-skip', issue=issue_number, rc=rc)
+            return (False, None)
+        data = json.loads(stdout)
+        labels = [lbl.get('name', '') for lbl in data.get('labels') or []]
+        if INBOX_LABEL in labels:
+            return (True, data.get('title') or '')
+        return (False, None)
+    except (json.JSONDecodeError, RuntimeError) as exc:
+        log('issue-lookup-error', issue=issue_number, error=str(exc)[:200])
+        return (False, None)
+
+
+def build_comment_body(inbox_refs):
+    """inbox_refs: list of (issue_number:int, title:str)."""
+    lines = [MARKER, '', '## Claude to Codex Handoff', '']
+    plural = len(inbox_refs) != 1
+    claim = (
+        'This PR claims to close the following `claude:inbox` '
+        + ('Issues' if plural else 'Issue')
+        + ' (filed by a prior Codex review):'
+    )
+    lines.append(claim)
+    lines.append('')
+    for num, title in inbox_refs:
+        title_safe = (title or '').replace('\n', ' ').strip() or '(no title)'
+        lines.append('- #{0} - {1}'.format(num, title_safe))
+    lines.extend([
+        '',
+        '**Codex:** on next review, please verify the original finding is '
+        'resolved. If verdict is PASS, Phase 2 auto-close will fire on the '
+        'linked ' + ('Issues' if plural else 'Issue') + '. If FAIL, the '
+        + ('Issues remain' if plural else 'Issue remains') + ' open.',
+        '',
+        '_Generated by Phase 3 reverse-direction handoff router (#468)._',
+        '_Last updated: '
+        + datetime.now(timezone.utc).isoformat(timespec='seconds')
+        + '_',
+    ])
+    return '\n'.join(lines)
+
+
+def find_existing_marker_comment(repo, pr_number):
+    """Return comment id for an existing tbm-handoff comment, or None."""
+    stdout, _ = gh([
+        'api', 'repos/{0}/issues/{1}/comments'.format(repo, pr_number),
+        '--paginate',
+    ])
+    try:
+        comments = json.loads(stdout)
+    except json.JSONDecodeError:
+        log('comments-parse-error')
+        return None
+    for comment in comments:
+        if MARKER in (comment.get('body') or ''):
+            return comment.get('id')
+    return None
+
+
+def upsert_marker_comment(repo, pr_number, body):
+    """Update existing tbm-handoff comment or create a new one."""
+    existing_id = find_existing_marker_comment(repo, pr_number)
+    if existing_id:
+        # PATCH via gh api. Pass body via stdin to avoid shell escaping.
+        proc = subprocess.run(
+            ['gh', 'api',
+             'repos/{0}/issues/comments/{1}'.format(repo, existing_id),
+             '--method', 'PATCH',
+             '--input', '-'],
+            input=json.dumps({'body': body}),
+            text=True,
+            capture_output=True,
+        )
+        if proc.returncode != 0:
+            log('comment-update-error', rc=proc.returncode,
+                stderr=proc.stderr.strip()[:500])
+            raise RuntimeError('failed to update handoff comment')
+        log('comment-updated', pr=pr_number, comment_id=existing_id)
+        return
+    # Create. `gh issue comment` handles the PR case too (PRs are issues).
+    proc = subprocess.run(
+        ['gh', 'issue', 'comment', str(pr_number),
+         '--repo', repo,
+         '--body-file', '-'],
+        input=body,
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        log('comment-create-error', rc=proc.returncode,
+            stderr=proc.stderr.strip()[:500])
+        raise RuntimeError('failed to create handoff comment')
+    log('comment-created', pr=pr_number)
+
+
+def main():
+    # 1. Kill switches.
+    if not env_flag('AUTOMATION_ENABLED', True):
+        log('skip', reason='AUTOMATION_ENABLED=false')
+        return 0
+    if not env_flag('TBM_HANDOFF_ROUTER_ENABLED', True):
+        log('skip', reason='TBM_HANDOFF_ROUTER_ENABLED=false')
+        return 0
+
+    repo = os.environ.get('REPO', '').strip() or env_required('GITHUB_REPOSITORY')
+    pr_number = env_required('PR_NUMBER')
+
+    # 2. Fetch PR body + commits.
+    try:
+        pr_text = fetch_pr_text(repo, pr_number)
+    except (json.JSONDecodeError, RuntimeError) as exc:
+        log('pr-fetch-failed', error=str(exc)[:200])
+        return 2
+
+    # 3. Extract closing refs.
+    refs = extract_closing_refs(pr_text)
+    log('closing-refs-found', count=len(refs), refs=refs)
+    if not refs:
+        log('no-op', reason='no-closing-refs')
+        return 0
+
+    # 4-5. Filter to claude:inbox.
+    inbox_refs = []
+    for num in refs:
+        has_inbox, title = lookup_inbox_issue(repo, num)
+        if has_inbox:
+            inbox_refs.append((num, title))
+    log('inbox-refs-matched',
+        count=len(inbox_refs),
+        refs=[r[0] for r in inbox_refs])
+    if not inbox_refs:
+        log('no-op', reason='no-inbox-refs')
+        return 0
+
+    # 6. Upsert marker comment.
+    body = build_comment_body(inbox_refs)
+    try:
+        upsert_marker_comment(repo, pr_number, body)
+    except RuntimeError as exc:
+        log('upsert-failed', error=str(exc)[:200])
+        return 2
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/post_tbm_handoff_marker.py
+++ b/.github/scripts/post_tbm_handoff_marker.py
@@ -146,7 +146,12 @@ def lookup_inbox_issue(repo, issue_number):
             return (False, None)
         data = json.loads(stdout)
         labels = [lbl.get('name', '') for lbl in data.get('labels') or []]
-        if INBOX_LABEL in labels:
+        # Require OPEN state. A closed claude:inbox Issue referenced in
+        # older commit history should not surface as a live handoff target
+        # and retrigger Codex re-review of an already-resolved finding.
+        # (Caught by Codex review on PR #469 -- P2 finding.)
+        state = (data.get('state') or '').upper()
+        if INBOX_LABEL in labels and state == 'OPEN':
             return (True, data.get('title') or '')
         return (False, None)
     except (json.JSONDecodeError, RuntimeError) as exc:
@@ -184,19 +189,30 @@ def build_comment_body(inbox_refs):
 
 
 def find_existing_marker_comment(repo, pr_number):
-    """Return comment id for an existing tbm-handoff comment, or None."""
+    """Return comment id for an existing tbm-handoff comment, or None.
+
+    Uses `gh api --paginate --slurp` so all pages arrive as a single JSON
+    array of arrays. Without --slurp, `gh api --paginate` emits each page
+    as its own top-level JSON document; `json.loads` fails on the
+    concatenated stream for any PR with >100 comments, the function
+    silently returns None, and the upsert path creates a NEW comment on
+    every run (duplicate tbm-handoff markers on busy PRs).
+    (Caught by Codex review on PR #469 -- P1 finding.)
+    """
     stdout, _ = gh([
         'api', 'repos/{0}/issues/{1}/comments'.format(repo, pr_number),
-        '--paginate',
+        '--paginate', '--slurp',
     ])
     try:
-        comments = json.loads(stdout)
+        pages = json.loads(stdout)
     except json.JSONDecodeError:
         log('comments-parse-error')
         return None
-    for comment in comments:
-        if MARKER in (comment.get('body') or ''):
-            return comment.get('id')
+    # --slurp produces [[page1_comments], [page2_comments], ...]; flatten.
+    for page in pages or []:
+        for comment in page or []:
+            if MARKER in (comment.get('body') or ''):
+                return comment.get('id')
     return None
 
 

--- a/.github/workflows/codex-rereview-handoff.yml
+++ b/.github/workflows/codex-rereview-handoff.yml
@@ -1,0 +1,53 @@
+# .github/workflows/codex-rereview-handoff.yml
+# Phase 3 of the Codex <-> Claude event router (#468).
+# When a PR's body or commit messages reference "Closes #<inbox-issue>" (or
+# Fixes / Resolves), post a <!-- tbm-handoff --> marker on the PR to
+# document the Claude -> Codex handoff and cue Codex's next re-review.
+# Complements Phase 1 (filer) and Phase 2 (auto-close) which live inline
+# in codex-pr-review.yml. This router is deliberately a SEPARATE workflow:
+# it posts only a PR comment (no downstream workflow triggers needed),
+# so the GITHUB_TOKEN recursive-run restriction does not apply.
+# Logic lives in .github/scripts/post_tbm_handoff_marker.py (no heredocs).
+
+name: Codex Re-review Handoff (Phase 3)
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to process
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+concurrency:
+  # Per-PR. Rapid pushes collapse to the final state; the marker is
+  # idempotent (update-or-create) so cancelled runs leave nothing stale.
+  group: codex-rereview-handoff-pr-${{ github.event.pull_request.number || github.event.inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  post-handoff-marker:
+    name: Post tbm-handoff marker
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Checkout base branch code
+        uses: actions/checkout@v4
+
+      - name: Post handoff marker
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr }}
+          REPO: ${{ github.repository }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTOMATION_ENABLED: ${{ vars.AUTOMATION_ENABLED || 'true' }}
+          TBM_HANDOFF_ROUTER_ENABLED: ${{ vars.TBM_HANDOFF_ROUTER_ENABLED || 'true' }}
+        run: python3 .github/scripts/post_tbm_handoff_marker.py


### PR DESCRIPTION
## Summary
Phase 3 of the Codex ↔ Claude event router. When a PR's body or commit messages reference `Closes #<inbox-issue>` (or `Fixes` / `Resolves`), post a `<!-- tbm-handoff -->` marker comment on the PR documenting the Claude → Codex handoff and cueing Codex's next re-review.

Complements Phase 1 (filer, [#451](https://github.com/blucsigma05/tbm-apps-script/pull/451) + [#457](https://github.com/blucsigma05/tbm-apps-script/pull/457)) and Phase 2 (auto-close, [#463](https://github.com/blucsigma05/tbm-apps-script/pull/463)) which both live inline in `codex-pr-review.yml`.

## Why a separate workflow instead of inline
Phase 1/2 had to be inline because they needed `issue_comment` triggers, and `GITHUB_TOKEN`-authored events do NOT trigger other workflow runs (GitHub's recursive-loop prevention — see [#456](https://github.com/blucsigma05/tbm-apps-script/issues/456)). Phase 3 only posts a PR comment — no downstream workflow needs to react to it — so a standalone workflow is fine and cleaner.

## Files added
- `.github/workflows/codex-rereview-handoff.yml` (49 lines)
  - `pull_request_target: [opened, reopened, synchronize]`
  - `workflow_dispatch` for manual retry
  - Per-PR concurrency with `cancel-in-progress: true` (rapid pushes collapse to final state; the marker is idempotent)
  - Permissions: `contents: read`, `pull-requests: write`, `issues: read`
  - 3-minute timeout
- `.github/scripts/post_tbm_handoff_marker.py` (294 lines)
  - Mirrors `file_codex_review_findings.py` patterns: structured JSON-line logging, env-var contract documented in module docstring, kill-switch gating, narrow trust domain
  - Scans PR body + all commit headlines/bodies for GitHub's canonical closing keywords (`Close[sd]? | Fix(e[sd])? | Resolve[sd]? #N`)
  - For each referenced issue, queries labels via `gh issue view`; keeps only those carrying `claude:inbox`
  - Upserts a single PR comment with `<!-- tbm-handoff -->` marker
  - Zero inbox refs → no-op (does NOT delete existing marker)

## Behavior summary
1. Gate on kill switches (silent exit)
2. Fetch PR body + all commits
3. Extract closing refs via regex
4. Filter to `claude:inbox` via per-issue API calls (skip nonexistent / errored issues silently)
5. If non-empty set, upsert comment; if empty, no-op
6. Structured JSON logging at every decision point

## Kill switches (three independent, all ≤60s)
1. `vars.AUTOMATION_ENABLED=false` → master off
2. `vars.TBM_HANDOFF_ROUTER_ENABLED=false` → this router only
3. Disable the workflow file in UI

## Pre-push audit
```
--- Workflow YAML Lint ---  OK
--- Python Script Compile Check ---  OK
--- Branch Staleness ---  OK (fresh from origin/main)
--- All other gates ---  OK or SKIP (N/A for docs-less infra change)
```

## Canary plan (manual, after merge)
1. Manually file a test `claude:inbox` issue with a throwaway title.
2. Open a PR from a throwaway branch with `Closes #<that-issue>` in the body.
3. Verify the `<!-- tbm-handoff -->` marker comment appears within ~30 seconds.
4. Push a second commit; verify the comment is UPDATED (single comment, new timestamp) — not duplicated.
5. Remove the `claude:inbox` label from the test issue, push a third commit; verify the marker is NOT removed (intentional — past marker may still reflect prior intent).
6. Close the test PR and issue. Dispose.

## Acceptance criteria (from #468)
- [x] New workflow at `.github/workflows/codex-rereview-handoff.yml`
- [x] New script at `.github/scripts/post_tbm_handoff_marker.py`
- [x] Scans PR body + commit messages for closing keywords
- [x] Queries per-issue for `claude:inbox` label
- [x] Posts/updates single marker comment
- [x] Idempotent upsert (update existing marker, not duplicate)
- [x] Zero inbox refs = no-op
- [x] Three kill switches wired
- [x] Per-PR concurrency with `cancel-in-progress`
- [x] Minimum permissions
- [x] `actionlint` passes on new YAML
- [x] `py_compile` passes on new script
- [ ] Canary proof (manual, post-merge — steps above)

## Test plan
- [x] Local `python3 -m py_compile` ✓
- [x] Local `actionlint` ✓
- [x] Local `bash audit-source.sh` ✓
- [ ] CI workflow-lint gate
- [ ] CI Codex PR review (self-review of the handoff router code)
- [ ] Canary after merge (see plan above — intentionally out of this PR's scope)

## Out of scope (deferred)
- Actively triggering Codex re-review (Codex already runs on `pull_request_target: synchronize`)
- Modifying Phase 1/2 behavior in `file_codex_review_findings.py`
- Downstream automation that parses the `<!-- tbm-handoff -->` marker (that's a Phase 4 possibility — e.g., dashboard of in-flight claude:inbox closures)
- Non-closing references (e.g., `Related to #N` or bare `#N`) — intentional: only closing keywords signal a real handoff

Closes #468