### PR TITLE
feat(#464): Playwright paths-ignore — skip E2E on docs-only PRs

### DIFF
--- a/.github/scripts/review-watcher.js
+++ b/.github/scripts/review-watcher.js
@@ -5,6 +5,40 @@ const ACTION_MARKER = '<!-- pipeline-action: ';
 const USER_AGENT = 'tbm-pipeline-review-watcher';
 const PIPELINE_LABEL_PREFIX = 'pipeline:';
 const MAX_FIX_CYCLES = 3;
+
+// Playwright workflow paths-ignore patterns (#464). MUST stay in sync with
+// .github/workflows/playwright-regression.yml. If all of a PR's changed
+// files match at least one pattern, the Playwright workflow is skipped by
+// design and no run record exists. Without this, the watcher would treat
+// the missing run as WAITING and the PR would never reach READY_TO_MERGE.
+const PLAYWRIGHT_PATHS_IGNORE = [
+  '**/*.md',
+  'ops/**',
+  'specs/**',
+  '.github/ISSUE_TEMPLATE/**',
+];
+
+function fileMatchesPattern(file, pattern) {
+  if (!file || !pattern) return false;
+  if (pattern === '**/*.md') return file.endsWith('.md');
+  if (pattern.endsWith('/**')) {
+    const prefix = pattern.slice(0, -3);
+    return file.startsWith(prefix + '/');
+  }
+  return file === pattern;
+}
+
+function allFilesMatchIgnore(files, patterns) {
+  if (!files || files.length === 0) return false;
+  for (const file of files) {
+    var matched = false;
+    for (var i = 0; i < patterns.length; i++) {
+      if (fileMatchesPattern(file, patterns[i])) { matched = true; break; }
+    }
+    if (!matched) return false;
+  }
+  return true;
+}
 const PIPELINE_LABELS = {
   WAITING: {
     name: 'pipeline:waiting',
@@ -479,6 +513,10 @@ async function main() {
           isDraft
           reviewDecision
           headRefOid
+          files(first: 100) {
+            nodes { path }
+            pageInfo { hasNextPage }
+          }
           reviewThreads(first: 100, after: $after) {
             nodes {
               isResolved
@@ -565,9 +603,38 @@ async function main() {
 
   // Playwright E2E must also pass for READY_TO_MERGE
   var playwrightWorkflowName = getEnv('PLAYWRIGHT_WORKFLOW_NAME', '');
-  var playwrightState = playwrightWorkflowName
-    ? formatWorkflowState(latestRunByName(playwrightWorkflowName))
-    : { label: 'N/A', pass: true, failed: false, url: '' };
+  var playwrightState;
+  if (!playwrightWorkflowName) {
+    playwrightState = { label: 'N/A', pass: true, failed: false, url: '' };
+  } else {
+    var playwrightRun = latestRunByName(playwrightWorkflowName);
+    if (!playwrightRun) {
+      // No run exists for this head SHA. Distinguish between (a) the
+      // workflow was skipped by design via paths-ignore (#464) and (b)
+      // the workflow simply has not started yet. Use the PR's changed
+      // file list: if EVERY file matches a paths-ignore pattern AND the
+      // file list is complete (not truncated at 100), treat as passing.
+      // Otherwise fall through to WAITING. (#465/#477 P1 Codex finding.)
+      var prFiles = (pr.files && pr.files.nodes)
+        ? pr.files.nodes.map(function (n) { return n.path; })
+        : [];
+      var filesTruncated = !!(pr.files && pr.files.pageInfo
+        && pr.files.pageInfo.hasNextPage);
+      if (!filesTruncated
+          && allFilesMatchIgnore(prFiles, PLAYWRIGHT_PATHS_IGNORE)) {
+        playwrightState = {
+          label: 'SKIPPED-PATH',
+          pass: true,
+          failed: false,
+          url: ''
+        };
+      } else {
+        playwrightState = formatWorkflowState(null);
+      }
+    } else {
+      playwrightState = formatWorkflowState(playwrightRun);
+    }
+  }
 
   var codexState = buildActorReviewState(reviews, isCodexSignal, pr.headRefOid, parseExplicitOutcome);
 

--- a/.github/workflows/playwright-regression.yml
+++ b/.github/workflows/playwright-regression.yml
@@ -1,6 +1,15 @@
 # .github/workflows/playwright-regression.yml
 # Playwright E2E Regression — runs Chromium tests against thompsonfams.com.
 # Result parsing lives in .github/scripts/parse_playwright_results.py.
+#
+# Path filter (#464): skip E2E on PRs that only touch docs / specs / Issue
+# templates. Doc edits cannot affect live-site rendering, so running the full
+# 30-min suite against thompsonfams.com on a CLAUDE.md-only PR is wasted time
+# AND exposes the PR to pre-existing Homework flakes that have nothing to do
+# with the change under review.
+#
+# GitHub behavior: `paths-ignore` skips the workflow iff EVERY changed file
+# matches at least one pattern. Mixed PRs (docs + code) still run the suite.
 
 name: Playwright Regression
 
@@ -8,6 +17,11 @@ on:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review]
+    paths-ignore:
+      - '**/*.md'
+      - 'ops/**'
+      - 'specs/**'
+      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Add `paths-ignore` to the `pull_request` trigger in `playwright-regression.yml` so PRs that only touch docs, specs, or Issue templates skip the 30-min E2E suite against live `thompsonfams.com`.

## Motivation (this pattern has surfaced 3 times in <24h)
A docs-only PR cannot possibly affect live-site rendering, yet the current workflow runs the full Chromium suite against production. This:
1. Wastes ~30 minutes of CI time per docs PR
2. Exposes docs PRs to pre-existing Homework test flakes ([#465](https://github.com/blucsigma05/tbm-apps-script/issues/465)) that have nothing to do with the change under review
3. Blocks merge paths on false-negative E2E fails that require explicit admin-merge workarounds

Live examples from today:
- [#461](https://github.com/blucsigma05/tbm-apps-script/pull/461) (CLAUDE.md merge authority policy) — admin-merged despite red Playwright
- [#469](https://github.com/blucsigma05/tbm-apps-script/pull/469) (Phase 3 router, `.github/` only) — admin-merged despite red Playwright
- This PR — would still require admin-merge without this fix, because the workflow itself doesn't install its own change for the current PR (GitHub uses the base-branch workflow config)

## Change
```yaml
on:
  pull_request:
    branches: [main]
    types: [opened, reopened, synchronize, ready_for_review]
    paths-ignore:
      - '**/*.md'
      - 'ops/**'
      - 'specs/**'
      - '.github/ISSUE_TEMPLATE/**'
  workflow_dispatch:
```

## GitHub behavior
`paths-ignore` skips the workflow if AND ONLY IF every changed file matches at least one pattern. Mixed PRs (docs + code) still run the suite. Any change to `.gs`, `.html`, `.js`, `.yml`, `.py`, `cloudflare-worker.js`, or anywhere outside the listed patterns triggers Playwright normally.

## What's covered
| Pattern | Catches |
|---|---|
| `**/*.md` | CLAUDE.md, READMEs, thread handoffs, operating memos, PR templates (markdown) |
| `ops/**` | operating memos, runbooks, thread handoffs |
| `specs/**` | design specs before implementation |
| `.github/ISSUE_TEMPLATE/**` | Issue templates |

## Acceptance criteria (from #464)
- [x] `paths-ignore:` added to `pull_request` trigger
- [x] Patterns covered: `**/*.md`, `ops/**`, `specs/**`, `.github/ISSUE_TEMPLATE/**`
- [x] Mixed PRs still run Playwright (behavior inherent to `paths-ignore`)
- [x] `actionlint` passes on updated YAML
- [ ] Verified by pushing a docs-only test branch (canary, post-merge — this PR itself touches `.github/workflows/**` so cannot self-test)

## Post-merge canary
Open a throwaway PR touching only a `.md` file. Confirm the Playwright workflow reports "skipped" (no run started) rather than running to completion.

## Out of scope
- Switching Playwright away from live `thompsonfams.com` (separate infra discussion)
- Fixing the pre-existing Homework test timeouts (#465)
- Per-file granularity inside `.gs` files (e.g., docstring-only changes) — start with clear directories
- Adding `paths-ignore` to the other CI workflows (`ci.yml`, `codex-pr-review.yml`, etc.) — different risk/benefit tradeoffs; each worth its own discussion

## Related
- #461, #469 — today's docs/infra PRs that burned full Playwright runs on unrelated code
- #465 — Playwright failure → Issue filer (Phase 2 complement that would capture the flakes this PR avoids)
- #340 — Issue-to-PR automation epic (parent)

Closes #464