### PR TITLE
feat(#454): nightly grinder — selector + runbook + canary plan

### DIFF
--- a/.github/scripts/grinder_select_issue.py
+++ b/.github/scripts/grinder_select_issue.py
@@ -14,8 +14,9 @@ Eligibility (Issue #454 acceptance criteria):
     - state:open
     - label:model:opus AND label:needs:implementation
       (override via GRINDER_LABEL_FILTER — see env vars)
-    - body contains a '## Build Skills' section (filed issues without skills
-      are silently ignored — enforces the per-Issue skill-tagging rule)
+    - body OR first comment contains a '## Build Skills' section
+      (filed issues without skills anywhere are silently ignored —
+      enforces the per-Issue skill-tagging rule from CLAUDE.md)
   MUST NOT have:
     - label:needs:lt-decision
     - label:status:draft
@@ -115,25 +116,66 @@ def _gh(args: list[str]) -> str:
 
 
 def list_candidate_issues(repo: str, required_labels: tuple[str, ...]) -> list[dict]:
-    """Fetch open issues matching ALL required labels. Returns list of dicts
-    with number, title, body, labels[], createdAt. Empty list on no match."""
+    """Fetch ALL open issues matching ALL required labels via REST pagination.
+
+    Uses `gh api --paginate /repos/{repo}/issues` instead of `gh issue list
+    --limit N` so the queue depth has no silent ceiling. The REST endpoint
+    returns issues + PRs combined; we drop entries with a `pull_request` key.
+    Output is normalized to the same shape `gh issue list --json` produces:
+        {number, title, body, labels:[{name}], createdAt}
+    """
+    label_param = ','.join(required_labels)
     args = [
-        'issue', 'list',
-        '-R', repo,
-        '--state', 'open',
-        '--limit', '200',
-        '--json', 'number,title,body,labels,createdAt',
+        'api', '--paginate', '-X', 'GET',
+        '/repos/' + repo + '/issues',
+        '-f', 'state=open',
+        '-f', 'labels=' + label_param,
+        '-f', 'per_page=100',
     ]
-    for label in required_labels:
-        args.extend(['--label', label])
     raw = _gh(args)
+    # --paginate concatenates JSON arrays back-to-back as `][` between pages.
+    # Normalize into a single list by splitting on the join seam.
     try:
-        data = json.loads(raw or '[]')
+        if not raw.strip():
+            data: list = []
+        else:
+            normalized = '[' + raw.strip().lstrip('[').rstrip(']').replace('][', ',') + ']'
+            data = json.loads(normalized)
     except json.JSONDecodeError as exc:
-        raise RuntimeError('gh issue list returned non-JSON: ' + str(exc))
+        raise RuntimeError('gh api --paginate returned non-JSON: ' + str(exc))
     if not isinstance(data, list):
-        raise RuntimeError('gh issue list returned non-list payload')
-    return data
+        raise RuntimeError('gh api returned non-list payload')
+    out = []
+    for item in data:
+        # REST `/issues` includes PRs; filter them out.
+        if 'pull_request' in item:
+            continue
+        out.append({
+            'number': item.get('number'),
+            'title': item.get('title'),
+            'body': item.get('body'),
+            'labels': item.get('labels') or [],
+            'createdAt': item.get('created_at'),
+        })
+    return out
+
+
+def fetch_first_comment_body(repo: str, issue_number: int) -> str | None:
+    """Return the body of the first comment on the Issue (oldest), or None."""
+    raw = _gh([
+        'api', '-X', 'GET',
+        '/repos/' + repo + '/issues/' + str(issue_number) + '/comments',
+        '-f', 'per_page=1',
+        '-f', 'sort=created',
+        '-f', 'direction=asc',
+    ])
+    try:
+        comments = json.loads(raw or '[]')
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(comments, list) or not comments:
+        return None
+    return comments[0].get('body')
 
 
 def has_open_closing_pr(repo: str, issue_number: int) -> bool:
@@ -206,8 +248,12 @@ def select(repo: str,
             log('skip_excluded', issue=number, reason=hit)
             continue
         if require_build_skills and not has_build_skills_section(issue.get('body')):
-            log('skip_no_build_skills', issue=number)
-            continue
+            # Per CLAUDE.md: section may live in body OR first comment.
+            first_comment = fetch_first_comment_body(repo, number)
+            if not has_build_skills_section(first_comment):
+                log('skip_no_build_skills', issue=number)
+                continue
+            log('build_skills_in_first_comment', issue=number)
         if has_open_closing_pr(repo, number):
             log('skip_has_closing_pr', issue=number)
             continue

--- a/.github/scripts/grinder_select_issue.py
+++ b/.github/scripts/grinder_select_issue.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""grinder_select_issue.py
+Purpose:   Pick exactly ONE eligible open Issue for the nightly Claude Code
+           grinder to implement, or return 0 if the queue is idle. Deterministic
+           filter + sort — same inputs produce the same pick.
+
+Called by: ops/grinder-runbook.md (the prompt fired by the scheduled task).
+           Also runnable standalone for dry-run inspection:
+               python3 .github/scripts/grinder_select_issue.py
+           Shells out to `gh` for issue + PR listing; exit 2 if gh missing.
+
+Eligibility (Issue #454 acceptance criteria):
+  MUST have:
+    - state:open
+    - label:model:opus AND label:needs:implementation
+      (override via GRINDER_LABEL_FILTER — see env vars)
+    - body contains a '## Build Skills' section (filed issues without skills
+      are silently ignored — enforces the per-Issue skill-tagging rule)
+  MUST NOT have:
+    - label:needs:lt-decision
+    - label:status:draft
+    - label:status:broken
+    - label:kind:decision
+    - an open PR closing the issue (gh pr list --search "closes #N")
+
+Sort order: severity priority DESC (blocker > critical > major > minor),
+            then created_at ASC (oldest first). First match wins.
+
+Env vars:
+  Required:
+    GITHUB_TOKEN / GH_TOKEN       auth for gh CLI
+    REPO                          owner/repo (e.g. blucsigma05/tbm-apps-script)
+  Optional:
+    GRINDER_LABEL_FILTER          comma-separated required labels. Default:
+                                    'model:opus,needs:implementation'
+                                    Narrow to 'grinder-canary' during canary.
+    GRINDER_EXCLUDE_LABELS        comma-separated excluded labels. Default:
+                                    'needs:lt-decision,status:draft,status:broken,kind:decision'
+    GRINDER_REQUIRE_BUILD_SKILLS  'false' to disable the body skill-check.
+                                    Default 'true'. Do not disable in prod —
+                                    it's load-bearing for agent handoff.
+
+Output:
+  stdout: exactly one line, either the selected issue number or '0'.
+          The runbook parses this literally (int(line.strip())).
+  stderr: one JSON-line log per major step. Fields: ts, level, event,
+          issue (optional), reason (optional), count (optional).
+
+Exit codes:
+  0  success (including idle = no eligible issues — stdout is '0')
+  1  validation error (missing REPO, unparseable gh output, etc.)
+  2  gh CLI not installed / not on PATH
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from typing import Iterable
+
+SEVERITY_PRIORITY = {
+    'severity:blocker': 0,
+    'severity:critical': 1,
+    'severity:major': 2,
+    'severity:minor': 3,
+}
+DEFAULT_SEVERITY_RANK = 99  # unlabeled goes last
+
+DEFAULT_LABEL_FILTER = ('model:opus', 'needs:implementation')
+DEFAULT_EXCLUDE_LABELS = (
+    'needs:lt-decision',
+    'status:draft',
+    'status:broken',
+    'kind:decision',
+)
+
+BUILD_SKILLS_RE = re.compile(r'(?mi)^##\s*build\s*skills\s*$')
+
+
+def log(event: str, level: str = 'info', **fields) -> None:
+    rec = {
+        'ts': _dt.datetime.now(_dt.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'level': level,
+        'event': event,
+    }
+    rec.update(fields)
+    sys.stderr.write(json.dumps(rec, sort_keys=True) + '\n')
+    sys.stderr.flush()
+
+
+def _split_csv(raw: str | None, default: Iterable[str]) -> tuple[str, ...]:
+    if raw is None or raw.strip() == '':
+        return tuple(default)
+    return tuple(p.strip() for p in raw.split(',') if p.strip())
+
+
+def _gh(args: list[str]) -> str:
+    """Run gh with the given args, return stdout. Raises on nonzero."""
+    proc = subprocess.run(
+        ['gh', *args],
+        capture_output=True, text=True, encoding='utf-8',
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            'gh failed (rc={rc}): {cmd}\nstderr: {err}'.format(
+                rc=proc.returncode, cmd=' '.join(args), err=proc.stderr.strip(),
+            )
+        )
+    return proc.stdout
+
+
+def list_candidate_issues(repo: str, required_labels: tuple[str, ...]) -> list[dict]:
+    """Fetch open issues matching ALL required labels. Returns list of dicts
+    with number, title, body, labels[], createdAt. Empty list on no match."""
+    args = [
+        'issue', 'list',
+        '-R', repo,
+        '--state', 'open',
+        '--limit', '200',
+        '--json', 'number,title,body,labels,createdAt',
+    ]
+    for label in required_labels:
+        args.extend(['--label', label])
+    raw = _gh(args)
+    try:
+        data = json.loads(raw or '[]')
+    except json.JSONDecodeError as exc:
+        raise RuntimeError('gh issue list returned non-JSON: ' + str(exc))
+    if not isinstance(data, list):
+        raise RuntimeError('gh issue list returned non-list payload')
+    return data
+
+
+def has_open_closing_pr(repo: str, issue_number: int) -> bool:
+    """True if any open PR already closes this issue. Uses gh pr list with a
+    `closes #N` search; we then verify the body / closingIssuesReferences to
+    avoid matching PRs that merely mention the number in prose."""
+    raw = _gh([
+        'pr', 'list',
+        '-R', repo,
+        '--state', 'open',
+        '--search', 'closes #{n} in:body'.format(n=issue_number),
+        '--json', 'number,body,closingIssuesReferences',
+        '--limit', '50',
+    ])
+    try:
+        prs = json.loads(raw or '[]')
+    except json.JSONDecodeError:
+        return False
+    for pr in prs:
+        refs = pr.get('closingIssuesReferences') or []
+        for ref in refs:
+            if ref.get('number') == issue_number:
+                return True
+        # Fallback: body contains "closes #N" (case-insensitive, word-boundary)
+        body = (pr.get('body') or '').lower()
+        if re.search(r'\bcloses\s+#' + str(issue_number) + r'\b', body):
+            return True
+    return False
+
+
+def severity_rank(labels: list[dict]) -> int:
+    best = DEFAULT_SEVERITY_RANK
+    for lbl in labels:
+        name = (lbl.get('name') or '').lower()
+        rank = SEVERITY_PRIORITY.get(name)
+        if rank is not None and rank < best:
+            best = rank
+    return best
+
+
+def has_build_skills_section(body: str | None) -> bool:
+    if not body:
+        return False
+    return bool(BUILD_SKILLS_RE.search(body))
+
+
+def is_excluded(labels: list[dict], excludes: tuple[str, ...]) -> str | None:
+    """Return the first exclusion label hit, or None."""
+    names = {(lbl.get('name') or '').lower() for lbl in labels}
+    for ex in excludes:
+        if ex.lower() in names:
+            return ex
+    return None
+
+
+def select(repo: str,
+           required_labels: tuple[str, ...],
+           excluded_labels: tuple[str, ...],
+           require_build_skills: bool = True) -> int:
+    candidates = list_candidate_issues(repo, required_labels)
+    log('candidates_listed', count=len(candidates))
+    eligible: list[dict] = []
+    for issue in candidates:
+        number = issue.get('number')
+        if not isinstance(number, int):
+            continue
+        labels = issue.get('labels') or []
+        hit = is_excluded(labels, excluded_labels)
+        if hit:
+            log('skip_excluded', issue=number, reason=hit)
+            continue
+        if require_build_skills and not has_build_skills_section(issue.get('body')):
+            log('skip_no_build_skills', issue=number)
+            continue
+        if has_open_closing_pr(repo, number):
+            log('skip_has_closing_pr', issue=number)
+            continue
+        eligible.append(issue)
+    if not eligible:
+        log('idle_no_eligible')
+        return 0
+    # Sort: severity asc (lower rank = higher priority), then createdAt asc.
+    eligible.sort(key=lambda i: (severity_rank(i.get('labels') or []),
+                                  i.get('createdAt') or ''))
+    pick = eligible[0]
+    log('picked',
+        issue=pick['number'],
+        severity_rank=severity_rank(pick.get('labels') or []),
+        created_at=pick.get('createdAt'))
+    return int(pick['number'])
+
+
+def main(argv: list[str]) -> int:
+    if shutil.which('gh') is None:
+        log('gh_missing', level='error')
+        return 2
+    repo = os.environ.get('REPO') or os.environ.get('GITHUB_REPOSITORY')
+    if not repo:
+        log('missing_repo', level='error')
+        return 1
+    required = _split_csv(os.environ.get('GRINDER_LABEL_FILTER'),
+                         DEFAULT_LABEL_FILTER)
+    excluded = _split_csv(os.environ.get('GRINDER_EXCLUDE_LABELS'),
+                         DEFAULT_EXCLUDE_LABELS)
+    require_skills = os.environ.get('GRINDER_REQUIRE_BUILD_SKILLS',
+                                    'true').lower() != 'false'
+    log('start',
+        repo=repo,
+        required=list(required),
+        excluded=list(excluded),
+        require_build_skills=require_skills)
+    try:
+        picked = select(repo, required, excluded, require_skills)
+    except RuntimeError as exc:
+        log('runtime_error', level='error', reason=str(exc))
+        return 1
+    sys.stdout.write(str(picked) + '\n')
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv))

--- a/.github/scripts/tests/test_grinder_select.py
+++ b/.github/scripts/tests/test_grinder_select.py
@@ -80,7 +80,7 @@ def test_not_excluded_when_no_overlap():
 
 @pytest.fixture
 def fake_gh(monkeypatch):
-    state = {'issues': [], 'prs': {}}
+    state = {'issues': [], 'prs': {}, 'first_comments': {}}
 
     def _fake_list(repo, required_labels):
         # Return issues that carry ALL required labels (case-insensitive)
@@ -95,8 +95,12 @@ def fake_gh(monkeypatch):
     def _fake_has_pr(repo, n):
         return state['prs'].get(n, False)
 
+    def _fake_first_comment(repo, n):
+        return state['first_comments'].get(n)
+
     monkeypatch.setattr(gsi, 'list_candidate_issues', _fake_list)
     monkeypatch.setattr(gsi, 'has_open_closing_pr', _fake_has_pr)
+    monkeypatch.setattr(gsi, 'fetch_first_comment_body', _fake_first_comment)
     return state
 
 
@@ -172,3 +176,45 @@ def test_select_require_build_skills_false_bypasses_body_check(fake_gh):
                       ('model:opus', 'needs:implementation'),
                       gsi.DEFAULT_EXCLUDE_LABELS,
                       require_build_skills=False) == 601
+
+
+# ---------- Codex P1: Build Skills in first comment ----------
+
+def test_select_accepts_build_skills_in_first_comment(fake_gh):
+    """CLAUDE.md: section may live in body OR first comment."""
+    fake_gh['issues'] = [
+        _issue(701, ['model:opus', 'needs:implementation', 'severity:major'],
+               body='Body has no skills section.'),
+    ]
+    fake_gh['first_comments'][701] = '## Build Skills\n- thompson-engineer'
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS) == 701
+
+
+def test_select_skips_when_neither_body_nor_first_comment_has_skills(fake_gh):
+    fake_gh['issues'] = [
+        _issue(801, ['model:opus', 'needs:implementation', 'severity:blocker'],
+               body='no skills here'),
+        _issue(802, ['model:opus', 'needs:implementation', 'severity:minor']),
+    ]
+    fake_gh['first_comments'][801] = 'just a follow-up comment, no skills'
+    # 801 fails both checks; 802 has skills in body (default _issue body)
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS) == 802
+
+
+def test_select_body_skills_short_circuits_no_comment_fetch(fake_gh, monkeypatch):
+    """If body already has the section, the first-comment fetch must not
+    be called — keeps the API budget tight when the common case wins."""
+    fake_gh['issues'] = [
+        _issue(901, ['model:opus', 'needs:implementation', 'severity:major']),
+    ]
+    calls = []
+    monkeypatch.setattr(gsi, 'fetch_first_comment_body',
+                        lambda r, n: calls.append(n) or None)
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS) == 901
+    assert calls == [], 'must not fetch comments when body already has skills'

--- a/.github/scripts/tests/test_grinder_select.py
+++ b/.github/scripts/tests/test_grinder_select.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""test_grinder_select.py
+Purpose: Unit tests for grinder_select_issue.py — eligibility, sort order,
+         build-skills gate, exclusion labels, and idle output shape.
+         Run with:  python3 -m pytest .github/scripts/tests/ -v
+"""
+
+import pathlib
+import sys
+
+import pytest
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import grinder_select_issue as gsi  # noqa: E402
+
+
+def _issue(number, labels=(), body='## Build Skills\n- x', created='2026-04-01T00:00:00Z'):
+    return {
+        'number': number,
+        'title': 'issue ' + str(number),
+        'body': body,
+        'labels': [{'name': n} for n in labels],
+        'createdAt': created,
+    }
+
+
+# ---------- build skills section ----------
+
+def test_build_skills_accepts_standard_heading():
+    assert gsi.has_build_skills_section('# Top\n\n## Build Skills\n- x')
+
+
+def test_build_skills_case_insensitive():
+    assert gsi.has_build_skills_section('## build skills')
+    assert gsi.has_build_skills_section('## BUILD SKILLS')
+
+
+def test_build_skills_requires_h2_heading():
+    # bare text mention doesn't count — must be a heading
+    assert not gsi.has_build_skills_section('we should add Build Skills here')
+
+
+def test_build_skills_empty_body():
+    assert not gsi.has_build_skills_section('')
+    assert not gsi.has_build_skills_section(None)
+
+
+# ---------- severity ranking ----------
+
+def test_severity_blocker_wins():
+    rank = gsi.severity_rank([{'name': 'severity:blocker'}, {'name': 'severity:major'}])
+    assert rank == 0
+
+
+def test_severity_case_insensitive():
+    assert gsi.severity_rank([{'name': 'SEVERITY:CRITICAL'}]) == 1
+
+
+def test_severity_unlabeled_goes_last():
+    assert gsi.severity_rank([{'name': 'area:infra'}]) == gsi.DEFAULT_SEVERITY_RANK
+
+
+# ---------- exclusion labels ----------
+
+def test_excluded_by_lt_decision():
+    hit = gsi.is_excluded(
+        [{'name': 'needs:lt-decision'}, {'name': 'kind:task'}],
+        ('needs:lt-decision',),
+    )
+    assert hit == 'needs:lt-decision'
+
+
+def test_not_excluded_when_no_overlap():
+    assert gsi.is_excluded([{'name': 'kind:task'}], ('status:draft',)) is None
+
+
+# ---------- select() — integration with stubbed gh ----------
+
+@pytest.fixture
+def fake_gh(monkeypatch):
+    state = {'issues': [], 'prs': {}}
+
+    def _fake_list(repo, required_labels):
+        # Return issues that carry ALL required labels (case-insensitive)
+        required_lower = {r.lower() for r in required_labels}
+        out = []
+        for i in state['issues']:
+            names = {(lbl.get('name') or '').lower() for lbl in i.get('labels', [])}
+            if required_lower.issubset(names):
+                out.append(i)
+        return out
+
+    def _fake_has_pr(repo, n):
+        return state['prs'].get(n, False)
+
+    monkeypatch.setattr(gsi, 'list_candidate_issues', _fake_list)
+    monkeypatch.setattr(gsi, 'has_open_closing_pr', _fake_has_pr)
+    return state
+
+
+def test_select_idle_when_no_candidates(fake_gh):
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS) == 0
+
+
+def test_select_prefers_blocker_over_major(fake_gh):
+    fake_gh['issues'] = [
+        _issue(101, ['model:opus', 'needs:implementation', 'severity:major'],
+               created='2026-04-01T00:00:00Z'),
+        _issue(102, ['model:opus', 'needs:implementation', 'severity:blocker'],
+               created='2026-04-10T00:00:00Z'),  # newer, but higher priority
+    ]
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS) == 102
+
+
+def test_select_ties_broken_by_oldest(fake_gh):
+    fake_gh['issues'] = [
+        _issue(201, ['model:opus', 'needs:implementation', 'severity:major'],
+               created='2026-04-10T00:00:00Z'),
+        _issue(202, ['model:opus', 'needs:implementation', 'severity:major'],
+               created='2026-04-01T00:00:00Z'),
+    ]
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS) == 202
+
+
+def test_select_skips_excluded_label(fake_gh):
+    fake_gh['issues'] = [
+        _issue(301, ['model:opus', 'needs:implementation',
+                     'needs:lt-decision', 'severity:blocker']),
+        _issue(302, ['model:opus', 'needs:implementation', 'severity:major']),
+    ]
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS) == 302
+
+
+def test_select_skips_missing_build_skills(fake_gh):
+    fake_gh['issues'] = [
+        _issue(401, ['model:opus', 'needs:implementation', 'severity:blocker'],
+               body='No skills section here.'),
+        _issue(402, ['model:opus', 'needs:implementation', 'severity:minor']),
+    ]
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS) == 402
+
+
+def test_select_skips_issue_with_open_closing_pr(fake_gh):
+    fake_gh['issues'] = [
+        _issue(501, ['model:opus', 'needs:implementation', 'severity:blocker']),
+        _issue(502, ['model:opus', 'needs:implementation', 'severity:major']),
+    ]
+    fake_gh['prs'][501] = True
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS) == 502
+
+
+def test_select_require_build_skills_false_bypasses_body_check(fake_gh):
+    fake_gh['issues'] = [
+        _issue(601, ['model:opus', 'needs:implementation', 'severity:major'],
+               body='no skills'),
+    ]
+    assert gsi.select('owner/repo',
+                      ('model:opus', 'needs:implementation'),
+                      gsi.DEFAULT_EXCLUDE_LABELS,
+                      require_build_skills=False) == 601

--- a/ops/grinder-canary-plan.md
+++ b/ops/grinder-canary-plan.md
@@ -1,0 +1,123 @@
+# Nightly Grinder — Canary Plan
+
+Before the grinder consumes the broad `model:opus` + `needs:implementation`
+queue, it must prove stop-discipline and correctness on a narrowed label
+filter. This file is the rollout checklist.
+
+**Parent Issue.** #454
+**Runbook.** `ops/grinder-runbook.md`
+
+---
+
+## Stage 1 — Narrow to `grinder-canary`
+
+**Goal.** 5–10 supervised fires against Issues explicitly tagged for canary
+use. Every fire is reviewed cold next morning before the next fire.
+
+### Setup
+
+1. Keep `NIGHTLY_GRINDER_ENABLED=false` until the canary Issues exist.
+2. Hand-pick 5–10 well-scoped, low-blast-radius Issues from backlog and
+   add the `grinder-canary` label. Criteria for a canary Issue:
+   - Single-file or single-module change
+   - No schema or `TAB_MAP` edits
+   - No financial calculator changes
+   - No kid-visible UI changes
+   - Has a clear, measurable acceptance checklist
+   - Has a `## Build Skills` section
+3. Register the scheduled task with the label filter narrowed:
+   - Env var passed at fire time: `GRINDER_LABEL_FILTER=grinder-canary`
+   - (Can still require `needs:implementation` by passing
+     `grinder-canary,needs:implementation` — recommended.)
+4. Flip `NIGHTLY_GRINDER_ENABLED=true`.
+
+### Observe (per fire)
+
+For each morning after a fire, before the next fire:
+
+- [ ] Pushover delivered exactly one terminal notification
+- [ ] Notion Scheduled Tasks DB has the row for the fire
+- [ ] If shipped: PR exists, branch named `grinder/<N>-<slug>`, CI green,
+  Codex review explicit PASS, `## Build Skills` section present in PR body
+- [ ] If shipped: diff stays inside the Issue's stated scope — no
+  unrelated refactors, no hot-file edits
+- [ ] If parked: Issue has the correct label (`status:broken` or
+  `needs:lt-decision`), comment explains the reason, no state leaked
+  into main
+- [ ] Lock file removed (`/tmp/grinder.lock` absent)
+- [ ] Stop discipline held — no retries, no override flags used
+
+### Gate to Stage 2
+
+All of the below must be true before broadening the filter:
+
+- [ ] 5 consecutive clean fires (shipped or parked-correctly — either is fine)
+- [ ] Zero bad fires (wrong scope, wrong stop reason, override flag used,
+  hot file touched, merge attempted)
+- [ ] Codex has reviewed at least 3 of the canary PRs with explicit PASS
+- [ ] LT has reviewed every canary PR in the morning — no surprise diffs
+
+If ANY fire is bad → go back to start of Stage 1, fix the runbook or
+selector, rerun 5 clean fires from zero.
+
+---
+
+## Stage 2 — Broaden to `model:opus` + `needs:implementation`
+
+**Goal.** First week on the broad filter runs with LT reviewing every
+morning before coffee. Two-strike rule on regressions.
+
+### Setup
+
+1. Flip the filter env var: drop `grinder-canary`, keep
+   `model:opus,needs:implementation` (the selector default).
+2. Leave `NIGHTLY_GRINDER_ENABLED=true`.
+3. Continue morning cold-reviews for the first week.
+
+### Two-strike rule
+
+If TWO consecutive fires are "bad" by the canary criteria above:
+
+1. Flip `NIGHTLY_GRINDER_ENABLED=false` immediately.
+2. Open a post-mortem Issue with `kind:decision` + `needs:lt-decision`.
+   Body: the two bad fires, their PRs/comments, root cause hypothesis.
+3. Do NOT re-enable until the post-mortem closes with a fix landed.
+
+### Gate to steady-state
+
+After one clean week on the broad filter:
+
+- [ ] Zero bad fires across 5+ broad-filter fires
+- [ ] LT morning review ≤5 minutes per PR on average
+- [ ] No post-mortem Issues opened
+
+At that point the morning-review burden can relax. The grinder is now
+normal infrastructure.
+
+---
+
+## Out of scope (explicitly deferred)
+
+- **Auto-merge.** Separate Issue, gated on 30+ clean grinder fires with
+  zero false-positive Codex reviews. Not this canary.
+- **Multi-issue fires.** Never. Violates bounded-blast-radius.
+- **Spec-picking.** `kind:spec` stays human-driven.
+- **Parallel grinders.** The lock file enforces one at a time; do not
+  lift that.
+
+---
+
+## Rollback procedure
+
+If canary reveals a systemic issue:
+
+1. `gh variable set NIGHTLY_GRINDER_ENABLED --body false` — stops all
+   future fires in ≤60s.
+2. If a bad PR was opened, close it without merging; comment links the
+   fire and the issue that should be re-opened.
+3. Label affected Issues with `status:broken` so they won't re-enter the
+   queue until the root cause is fixed.
+4. Open a post-mortem Issue (see Stage 2 two-strike rule).
+5. Fix, re-run Stage 1 from zero before re-enabling.
+
+No "just one more fire to see if it works." Stage 1 restarts from zero.

--- a/ops/grinder-runbook.md
+++ b/ops/grinder-runbook.md
@@ -1,0 +1,295 @@
+# Nightly Grinder — Claude Code Runbook
+
+**Purpose.** Every fire, convert idle overnight hours into exactly one
+shipped PR awaiting human review. Fresh context. Hardcoded gates. LT reviews
+PRs in the morning.
+
+**Parent Issue.** #454
+**Parent epic.** #340 (Issue-to-PR automation)
+**Kill switches.** See bottom of this file.
+
+This file IS the prompt. The scheduled task fires a fresh Claude Code
+session with these instructions loaded. Follow every step as written.
+
+---
+
+## 0. Pre-flight (fail closed)
+
+Run these checks before anything else. If any fails → EXIT with the matching
+Pushover tier. Never retry, never escalate override flags.
+
+| Check | Command | On fail |
+|---|---|---|
+| Kill switch master | `gh variable get AUTOMATION_ENABLED` | EXIT silent |
+| Kill switch grinder | `gh variable get NIGHTLY_GRINDER_ENABLED` | EXIT silent |
+| Lock file | `[ -f /tmp/grinder.lock ]` — if present, read PID and check `kill -0 <pid>` | EXIT silent (overlapping fire) |
+| Deploy freeze | `bash audit-source.sh` check 6 equivalent (read script-prop `DEPLOY_FREEZE_ACTIVE` via `clasp run getFreezeState_` or equivalent probe) | EXIT silent |
+| Repo clean | `git status --porcelain` empty | EXIT + `SYSTEM_ERROR` Pushover |
+| Main CI green | `gh run list --branch main --limit 1 --json conclusion` → `success` | EXIT + `SYSTEM_ERROR` |
+
+On pass: write lock — `echo $$ > /tmp/grinder.lock` — and register a trap to
+remove it on any exit path. Never leave a stale lock.
+
+Any kill switch flipped to `false` must take effect on the next fire in
+≤60 seconds. Do not cache. Read fresh every fire.
+
+---
+
+## 1. Sync to fresh main
+
+```bash
+git fetch origin main
+git checkout main
+git pull --ff-only
+```
+
+If `--ff-only` fails → EXIT + `SYSTEM_ERROR` Pushover. Don't rebase, don't
+merge — main is source of truth. A non-fast-forward state means something
+happened that needs human attention.
+
+---
+
+## 2. Select exactly one Issue
+
+```bash
+PICKED=$(REPO=blucsigma05/tbm-apps-script \
+  python3 .github/scripts/grinder_select_issue.py)
+```
+
+- `$PICKED == 0` → idle. Send `HYGIENE_REPORT_LOW` Pushover
+  "Grinder idle, no eligible issues." and EXIT clean.
+- `$PICKED > 0` → the one Issue for this fire.
+
+**Never pick a second Issue in the same fire.** Even if the first fails.
+Failures stop the fire; they don't advance to the next candidate.
+
+### Eligibility (enforced by the selector, here for transparency)
+
+Selected Issue MUST have: `state:open`, `model:opus`, `needs:implementation`,
+a `## Build Skills` section in the body, no open PR closing it.
+
+Selected Issue MUST NOT have: `needs:lt-decision`, `status:draft`,
+`status:broken`, `kind:decision`.
+
+Sort: `severity:blocker` → `critical` → `major` → `minor`, then oldest
+`createdAt` first.
+
+During canary, narrow the label filter:
+```bash
+GRINDER_LABEL_FILTER='grinder-canary' python3 ...
+```
+
+---
+
+## 3. Read the Issue end to end
+
+```bash
+gh issue view $PICKED --comments
+```
+
+Read the entire body and every comment. No skimming. Extract:
+- Acceptance criteria (the checklist)
+- Build Skills list
+- Any attached spec files referenced by path
+- Files / surfaces named explicitly
+
+If anything is ambiguous — stop and escalate per §7.
+
+---
+
+## 4. Load declared skills
+
+Parse the `## Build Skills` section from the Issue body. For each skill
+name, invoke the Skill tool with that exact name. If a declared skill
+doesn't exist in the environment → EXIT per §7 (skill-missing path).
+
+---
+
+## 5. Branch + implement
+
+```bash
+SLUG=$(gh issue view $PICKED --json title --jq '.title' \
+  | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | cut -c1-50)
+BRANCH="grinder/${PICKED}-${SLUG}"
+git checkout -b "$BRANCH"
+```
+
+Implement per the Issue spec. Stay within the listed scope. Do not expand
+to adjacent refactors. Do not touch files outside what the Issue describes.
+
+**Forbidden files (non-negotiable, no override).** If the work touches ANY
+of these, EXIT per §7 with the reason `hot file, requires LT`:
+
+- `.github/workflows/**`
+- `.github/scripts/**` (exception: adding pure test files under
+  `.github/scripts/tests/` is allowed; modifying existing helpers is not)
+- `CLAUDE.md`
+- `audit-source.sh`
+- `cloudflare-worker.js`
+- Anything in `ops/operating-memos/**` already merged (they're frozen
+  records — you may add a NEW memo only if the Issue explicitly asks for one)
+
+---
+
+## 6. Run the full deploy pipeline — all 11 steps
+
+Reference: `CLAUDE.md` § "Deploy Pipeline (MANDATORY — every deploy)".
+
+No shortcuts. Each step is a gate:
+
+1. EDIT (done in §5)
+2. VERSION bump in all 3 locations per changed `.gs` file
+3. `bash audit-source.sh` — any FAIL blocks; any WARN must be reviewed
+4. `clasp push`
+5. `diagPreQA()` via `clasp run diagPreQA` — all categories PASS
+6. `clasp deploy -i <deploymentId>`
+7. Hit `?action=runTests` on production `/exec` URL — JSON assert
+   `overall == "PASS"` AND `smoke.overall == "PASS"`; scan ErrorLog for
+   new rows in last 5 min
+8. Git: `git add <specific files>` → commit with `#${PICKED}` → push branch
+9. Notion PM Active Versions DB row + Thread Handoff row
+10. curl all Cloudflare proxy endpoints — expect 200 on every one
+11. `gh release create v<version> --notes "..."`
+
+**Never stop at step 4.** Any failure in steps 3–7 → EXIT per §7 with
+`status:broken` on the Issue.
+
+---
+
+## 7. Stop conditions (EXIT immediately, never retry)
+
+| Condition | Label Issue | Pushover | Post to Issue |
+|---|---|---|---|
+| `audit-source.sh` FAIL | `status:broken` | `DEPLOY_FAIL` | `Grinder blocked on #${PICKED} — audit failed: <captured stderr>` |
+| `diagPreQA()` FAIL | `status:broken` | `DEPLOY_FAIL` | `Grinder blocked on #${PICKED} — diagPreQA: <failing category>` |
+| `runTests` smoke ≠ PASS | `status:broken` | `DEPLOY_FAIL` | `Grinder blocked on #${PICKED} — smoke: <failing test>` |
+| Merge conflict needing judgment | `needs:lt-decision` | `BACKLOG_STALE` | `Grinder parked — conflict requires human resolution. Files: ...` |
+| Spec ambiguous | `needs:lt-decision` | `BACKLOG_STALE` | `Grinder parked — spec ambiguity: <the question>` |
+| Deploy freeze active | _(no label change)_ | _(silent)_ | _(no comment — freeze is expected downtime)_ |
+| Hot file touched | `needs:lt-decision` | `BACKLOG_STALE` | `Grinder parked — touches hot file <path>; requires LT implementation` |
+| Declared skill not in env | `needs:lt-decision` | `BACKLOG_STALE` | `Grinder parked — declared skill '<name>' not installed` |
+| `clasp` auth expired | _(no label change)_ | `SYSTEM_ERROR` | `Grinder infra failure — clasp auth broken, run clasp login` |
+| Any hook refuses operation | `needs:lt-decision` | `BACKLOG_STALE` | `Grinder parked — hook blocked: <hook name> / <reason>` |
+| 2-hour runtime timeout | _(runtime-enforced)_ | `SYSTEM_ERROR` | _(runtime posts the timeout notice)_ |
+
+**NEVER set `EMERGENCY=1` or `HOTFIX=1` autonomously.** Those flags are LT's.
+Hitting a hook block is a stop condition, not a prompt to bypass.
+
+---
+
+## 8. Ship — open the PR
+
+```bash
+gh pr create \
+  --base main \
+  --head "$BRANCH" \
+  --title "feat(#${PICKED}): <the issue title>" \
+  --body "Closes #${PICKED}
+
+## Summary
+<one paragraph — what shipped, why>
+
+## Skills loaded
+<list from the Issue's Build Skills>
+
+## Evidence
+- audit-source.sh: PASS
+- diagPreQA: PASS
+- smoke: PASS
+- runTests overall: PASS
+- CF proxy probes: 200 on all N routes
+
+## Grinder metadata
+- Fire started: <ISO timestamp>
+- Fire finished: <ISO timestamp>
+- Runtime: <seconds>
+"
+```
+
+**NEVER merge.** LT reviews in the morning. Merging is a separate trust
+tier (see `CLAUDE.md` § Autonomous Merge Authority — the grinder is
+explicitly excluded: "PRs opened by a non-interactive agent lane ... always
+confirm merge first, no override").
+
+---
+
+## 9. Close the loop
+
+1. Comment on the Issue with the PR link:
+   `gh issue comment ${PICKED} --body "Grinder shipped → #<PR>"`
+2. Pushover `DEPLOY_OK` priority (-2, silent):
+   `Grinder shipped #${PICKED} → PR #<PR> (<url>)`
+3. Append a row to Notion "Claude Code Scheduled Tasks" DB
+   (`334cea3cd9e8812a95bdcea2786b50d6`) with: timestamp, issue, verdict,
+   PR, duration.
+4. Remove the lock file. Exit clean.
+
+---
+
+## Pushover tiers (contract)
+
+Use the named constants from `AlertEngine.gs` `PUSHOVER_PRIORITY`. Never
+bare integers. Reference: `CLAUDE.md` § "Alert Tiers (HYG-12)".
+
+| Event | Constant | Value | Body template |
+|---|---|---|---|
+| Shipped PR | `DEPLOY_OK` | -2 | `Grinder shipped #{N} → PR #{M} ({url})` |
+| Parked on decision | `BACKLOG_STALE` | 0 | `Grinder parked #{N} — {reason}` |
+| Stopped on error | `DEPLOY_FAIL` | 2 | `Grinder blocked on #{N} — {reason}` |
+| Idle, no work | `HYGIENE_REPORT_LOW` | -1 | `Grinder idle, no eligible issues` |
+| Clasp/infra break | `SYSTEM_ERROR` | 1 | `Grinder infra failure — {detail}` |
+
+---
+
+## Kill switches (three, all ≤60s)
+
+1. `gh variable set NIGHTLY_GRINDER_ENABLED --body false` — next fire
+   no-ops at §0.
+2. Disable / update the scheduled task itself. Removes the trigger entirely
+   until re-registered.
+3. Remove `model:opus` or `needs:implementation` labels from the queue —
+   the selector starves.
+
+The master `AUTOMATION_ENABLED=false` switch also short-circuits the
+grinder at §0 along with every other auto-filer.
+
+---
+
+## Observability
+
+- **Pushover** is the source of truth for "did it run, did it work." Every
+  fire emits exactly one terminal notification at one of the five tiers.
+- **ErrorLog sheet** captures any uncaught error via the normal GAS
+  `logError_` path (runtime, not this runbook's concern).
+- **Notion Scheduled Tasks DB** row per fire — written at §9 on success,
+  or by a dedicated skip-write on the stop paths that still want a record.
+- **Lock file** at `/tmp/grinder.lock` carries the PID of the active fire.
+  Stale locks (PID not alive) are treated as absent.
+
+---
+
+## Explicit non-goals
+
+The grinder does NOT:
+- Merge PRs (LT reviews — always).
+- Spec. `kind:spec` Issues are ineligible.
+- Pick more than one Issue per fire.
+- Set override flags (`EMERGENCY=1`, `HOTFIX=1`).
+- Touch hot files.
+- Escalate past stop conditions.
+- Modify `main` directly.
+- Force-push anything.
+
+---
+
+## References
+
+- Parent Issue: #454
+- Parent epic (Issue-to-PR automation): #340
+- Umbrella courier-reduction epic: #376
+- Canary plan: `ops/grinder-canary-plan.md`
+- Selector: `.github/scripts/grinder_select_issue.py`
+- Deploy pipeline spec: `CLAUDE.md` § "Deploy Pipeline (MANDATORY)"
+- Autonomous merge authority rules: `CLAUDE.md` § "Autonomous Merge Authority"
+- Alert tiers: `CLAUDE.md` § "Alert Tiers (HYG-12)"
+- Notion Scheduled Tasks DB: `334cea3cd9e8812a95bdcea2786b50d6`


### PR DESCRIPTION
Closes #454

## Summary
Code-only half of the nightly Claude Code grinder (Phase 3 of Issue-to-PR automation, epic #340). Adds the deterministic selector, the runbook prompt, the canary rollout plan, and the selector unit tests. Does NOT register the scheduled task, touch any kill-switch default, or edit hot files — those are deferred to a separate "turn it on" step after this merges.

## What's in the PR

| File | Role |
|---|---|
| `.github/scripts/grinder_select_issue.py` | Deterministic eligibility + sort (severity DESC, then oldest). Enforces the `## Build Skills` section requirement. Standalone-runnable for dry-run. |
| `.github/scripts/tests/test_grinder_select.py` | 16 unit tests — all green. Covers build-skills heading, severity rank, exclusion labels, sort ties, idle path, closing-PR filter. |
| `ops/grinder-runbook.md` | The prompt the scheduled task fires. Pre-flight gates, selection call, branch + implement, full 11-step deploy pipeline reference, stop conditions, forbidden list, Pushover tier contract, three kill switches. |
| `ops/grinder-canary-plan.md` | Stage 1 `grinder-canary` narrow filter (5–10 supervised fires), Stage 2 broaden with LT morning review, two-strike rollback rule. |

## Scope honored (per approval)
- Pure code PR — no registration, no kill-switch default, no Notion row
- No `CLAUDE.md` edits
- No `.github/workflows/**` edits
- No `audit-source.sh` edits
- No `cloudflare-worker.js` edits
- Queued behind #469 (merged at 20:37Z) per hot-file lock rule; rebased on fresh `origin/main` before opening

## Deferred to a separate step after merge
- `mcp__scheduled-tasks__create_scheduled_task` registration (nightly 11pm CT)
- Notion Claude Code Scheduled Tasks DB row (`334cea3cd9e8812a95bdcea2786b50d6`)
- `gh variable set NIGHTLY_GRINDER_ENABLED false` (default off until canary clean)
- First 5–10 `grinder-canary`-labeled Issues hand-picked for Stage 1

## Evidence
- `bash audit-source.sh` — PASS (one expected WARN on deploy-freeze probe — jq/clasp not on local env; CI will hit the real check)
- `python -m pytest .github/scripts/tests/test_grinder_select.py` — 16 passed in 0.04s
- Branch rebased on `origin/main` at `b40cd2e` (post-#469 merge, post-#477 merge)
- Pre-flight conflict check: clean (rebase applied with zero conflicts)

## Why this shape
The grinder is load-bearing automation that fires unsupervised. Splitting "code" from "turn it on" gives us:
1. A PR that is pure code, reviewable as code
2. A distinct, auditable flip of the kill switch after the runbook has been read cold
3. Zero blast radius until step 2 fires

## Non-goals (explicit in runbook)
- Grinder NEVER merges PRs — LT reviews in the morning
- Grinder NEVER sets `EMERGENCY=1` / `HOTFIX=1` override flags
- Grinder NEVER picks a second Issue in the same fire
- Grinder NEVER touches hot files (`.github/workflows/**`, `CLAUDE.md`, `audit-source.sh`, `cloudflare-worker.js`)