### PR TITLE
fix(#438): respect prefers-reduced-motion on all education surfaces

### DIFF
--- a/ComicStudio.html
+++ b/ComicStudio.html
@@ -989,6 +989,16 @@ main {
   opacity: 0;
   transition: opacity 0.25s;
 }
+
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 </style>
 </head>
 <body>

--- a/DesignDashboard.html
+++ b/DesignDashboard.html
@@ -468,6 +468,16 @@ input::placeholder { color: #64748B; }
 .dd-next-enabled { background: #3B82F6; color: #fff; }
 .dd-next-disabled { background: #1E2A4A; color: #64748B; cursor: not-allowed; }
 
+
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 </style>
 </head>
 <body>

--- a/HomeworkModule.html
+++ b/HomeworkModule.html
@@ -482,6 +482,16 @@ main {
   font-family: 'Nunito', sans-serif;
 }
 .mission-card:hover { border-color: #3B82F6; }
+
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 </style>
 </head>
 <body>

--- a/JJHome.html
+++ b/JJHome.html
@@ -200,6 +200,16 @@ body {
   color: #ff80ff;
 }
 
+
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 </style>
 </head>
 <body>

--- a/SparkleLearning.html
+++ b/SparkleLearning.html
@@ -583,7 +583,17 @@
       -webkit-animation: pulseSlot 1.2s ease-in-out infinite;
       animation: pulseSlot 1.2s ease-in-out infinite;
     }
-  </style>
+  
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+</style>
 </head>
 <body style="background:#1a0533;">
 

--- a/WolfkidCER.html
+++ b/WolfkidCER.html
@@ -650,6 +650,16 @@
     pointer-events: none;
     z-index: 0;
   }
+
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 </style>
 </head>
 <body>

--- a/daily-missions.html
+++ b/daily-missions.html
@@ -685,6 +685,16 @@ body.jj-theme #launch-overlay .ov-sub { color: rgba(255,200,240,0.55) !important
 .mf-actions{display:-webkit-flex;display:flex;gap:12px;-webkit-justify-content:center;justify-content:center;}
 .mf-submit-btn{background:#f59e0b;color:#0b0f1a;border:none;border-radius:10px;padding:12px 28px;font-size:14px;font-weight:700;cursor:pointer;font-family:'Orbitron',sans-serif;}
 .mf-skip-btn{background:transparent;border:1px solid rgba(255,255,255,0.2);color:#94a3b8;border-radius:10px;padding:12px 20px;font-size:13px;cursor:pointer;}
+
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 </style>
 </head>
 <body>

--- a/investigation-module.html
+++ b/investigation-module.html
@@ -715,6 +715,16 @@ body::after {
   z-index: 0;
 }
 /* Brain break overlay (#170) — no CSS needed beyond inline styles */
+
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 </style>
 </head>
 <body>

--- a/reading-module.html
+++ b/reading-module.html
@@ -564,6 +564,16 @@ main {
   color: #F59E0B;
   margin-top: 12px;
 }
+
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 </style>
 </head>
 <body>

--- a/writing-module.html
+++ b/writing-module.html
@@ -537,6 +537,16 @@
 /* ExecSkills plan overlay */
 #es-plan-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(11,15,26,0.97);z-index:200;display:-webkit-flex;display:flex;-webkit-align-items:center;align-items:center;-webkit-justify-content:center;justify-content:center;padding:24px;}
 #es-plan-inner{max-width:520px;width:100%;}
+
+  /* WCAG 2.1 Animation from Interactions — respect OS reduced motion (#438) */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
Closes #438

## Summary
WCAG 2.1 Animation from Interactions floor — `prefers-reduced-motion` was unrespected on every Buggsy + JJ surface. Adds the standard neutralizer block inside each surface's `<style>` block.

## What changed
Identical CSS block added to all 10 education surfaces in one sweep:

| File | Surface |
|---|---|
| HomeworkModule.html | Buggsy homework (must per Issue acceptance) |
| SparkleLearning.html | JJ learning (most-animated surface) |
| JJHome.html | JJ Sparkle Kingdom hub |
| daily-missions.html | Daily mission rotation |
| reading-module.html | Cold reading practice |
| writing-module.html | Writing practice |
| WolfkidCER.html | Wolfkid CER writing |
| investigation-module.html | Science investigation |
| ComicStudio.html | Comic Studio |
| DesignDashboard.html | Wolfdome dashboard |

## CSS block (identical in all 10 files)

```css
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

Reference template lifted verbatim from #438. Universal-selector with `!important` keeps functional transitions sub-perceptual (0.01ms) without enumerating every animated element. Safe for kid-first UI per the Issue's design discussion.

## Verification
- `grep 'prefers-reduced-motion' <each>.html` → 1 match per file ✓
- `bash audit-source.sh` → PASS (one expected WARN on deploy-freeze probe)
- ES5 enforcement: not applicable (CSS-only change, no JS touched)

## Manual verification needed (in QA, not blocking merge)
- Toggle OS setting (System > Accessibility > Reduce Motion) on a tablet
- Confirm catch-up banner slide-in (#411) becomes instant snap
- Confirm wolfkid theme transitions stop on HomeworkModule
- Confirm SparkleLearning game animations freeze appropriately

## Skills loaded
- `adhd-accommodations` — sensory-friendly defaults
- `game-design` — animation standards
- `education-qa` — verification protocol

## Non-conflicts
- #481 (grinder selector + runbook) — different files entirely, no overlap
- No hot-file edits (`.github/workflows/**`, `.github/scripts/**`, `CLAUDE.md`, `audit-source.sh`)

## Why one PR for all 10 (per Issue recommendation)
> "Recommend one PR that adds the reduced-motion block to all Buggsy + JJ surfaces in scope. Single file-list sweep, consistent implementation, MVSS v1 accessibility floor raised across the board in one commit."