### PR TITLE
fix(#428): race-then-dismiss catch-up banner in education spec

### DIFF
--- a/tests/tbm/education-workflows.spec.js
+++ b/tests/tbm/education-workflows.spec.js
@@ -74,15 +74,24 @@ function filterRealErrors(errors) {
   });
 }
 
-// Dismiss the catch-up banner (added in #411) if present, then wait for the
-// Plan Your Attack overlay. The banner renders when the server returns fullWeek
-// data with missed days — dismiss before asserting plan overlay visibility.
+// Wait for the Plan Your Attack overlay, dismissing the catch-up banner if it
+// renders first. The banner (#411) and plan-attack overlay race — the banner
+// renders after getFridayMakeupQueueSafe returns, the overlay after
+// getTodayContentSafe; either may win. Old code checked banner.count() once
+// immediately, which fired before the banner had a chance to render at all.
+//
+// Pattern: wait for *either* element to appear (CSS comma selector resolves
+// to whichever renders first), then dismiss the banner if that's what showed
+// up, then wait for the plan-attack overlay proper.
 async function waitForPlanAttack(page) {
-  var dismissBtn = page.locator('[data-testid="catchup-banner-dismiss"]');
-  if (await dismissBtn.count() > 0) {
-    await dismissBtn.click();
+  var bannerSel = '[data-testid="catchup-banner-dismiss"]';
+  var planSel = '.es-plan-attack';
+  await page.locator(bannerSel + ', ' + planSel).first()
+    .waitFor({ state: 'visible', timeout: 20000 });
+  if (await page.locator(bannerSel).isVisible()) {
+    await page.locator(bannerSel).click();
   }
-  await page.locator('.es-plan-attack').waitFor({ state: 'visible', timeout: 20000 });
+  await page.locator(planSel).waitFor({ state: 'visible', timeout: 20000 });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #428

## Summary
The Playwright \`waitForPlanAttack\` helper checked \`dismissBtn.count()\` immediately after page navigation. Banner renders asynchronously after \`getFridayMakeupQueueSafe()\` — so the check fired before the banner existed, dismissal was skipped, banner appeared after, blocked plan-attack render, 20s timeout.

## Fix
Race the banner and plan-attack selectors via CSS comma selector — whichever renders first wins the wait. If banner won, dismiss it, then wait for the plan-attack overlay proper.

## What changed
\`tests/tbm/education-workflows.spec.js\` — \`waitForPlanAttack()\` helper only. No production code edits, no HomeworkModule.html touch.

## Behavior
| Scenario | Outcome |
|---|---|
| Banner renders first (Friday, makeup queue) | Wait resolves on banner → dismiss → plan-attack appears → second wait passes |
| Plan-attack renders first (Mon–Thu, no makeup) | Wait resolves on plan-attack → banner.isVisible()=false → second wait passes immediately |
| Neither renders within 20s | Original timeout error |

## Tests affected
- \`Homework: Plan Your Attack → answer flow → completion\` / \`loads plan-attack screen, starts session, answers a question\`
- \`Homework: Friday Reflection appears\` / \`reflection panel renders when clock is set to Friday\`

Both call \`waitForPlanAttack()\`.

## Why Option A (test-only) and not Option B/C
Issue body offered three options. Option A keeps the fix in the test layer — no HomeworkModule.html edit (which would conflict with #482 \`prefers-reduced-motion\` PR currently in flight on that file). Production behavior is unchanged.

## Non-conflicts
- #481 (grinder selector) — different files
- #482 (reduced-motion across education surfaces) — touches HomeworkModule.html but not the test spec; no overlap

## Evidence
- \`bash audit-source.sh\` → PASS (one expected WARN on deploy-freeze probe)
- ES5 enforcement: not applicable (Playwright spec runs in Node, not Fully Kiosk)