### PR TITLE
feat(#321): Amazon item-detail enrichment in TheVein recent-tx feed

### DIFF
--- a/Dataengine.js
+++ b/Dataengine.js
@@ -1,10 +1,10 @@
 // ════════════════════════════════════════════════════════════════════
-// DATA ENGINE v96 — Dynamic KPI Computation from Raw Tiller Data
+// DATA ENGINE v97 — Dynamic KPI Computation from Raw Tiller Data
 // WRITES TO: 💻🧮 Dashboard_Export, 💻🧮 Debt_Export, 💻🧮 DebtModel, 💻🧮 Cascade Proof, 💻🧮 Cascade Month-by-Month, 💻🧮 Cascade Payoff Schedule, 📋 Board_Config
 // READS FROM: 🔒 Transactions, 🔒 Balance History, 🔒 Categories, 💻🧮 Budget_Data, 💻🧮 Helpers, 💻🧮 DebtModel, 💻🧮 BankRec, 💻🧮 Budget_Rules, 💻 MealPlan
 // ════════════════════════════════════════════════════════════════════
 
-function getDataEngineVersion() { return 96; }
+function getDataEngineVersion() { return 97; }
 
 // ════════════════════════════════════════════════════════════════════
 //
@@ -3541,6 +3541,37 @@ function de_buildSoulMoment_(boardPayload, kidsPayload) {
  * @param {number} [days=5] Number of days to look back.
  * @returns {Object} { transactions: [], summary: {} }
  */
+/**
+ * Build a map of tillerRow → [items] from the Amazon_Detail tab. Each item is
+ * { qty, desc, price }. Used to enrich the recent-tx feed (#321 — Amazon
+ * charges show item detail when matched to a Tiller transaction).
+ *
+ * Amazon_Detail schema (matchAmazonToTiller in Utility.js):
+ *   col A=OrderID, B=Date, C=Qty, D=ItemDesc(≤60), E=Price/unit,
+ *   col H=tillerRow (write target after match), I=neg amount, J=category.
+ *
+ * Returns {} if the tab is missing — caller treats absence as "no enrichment."
+ */
+function _buildAmazonItemMap_() {
+  var ss = SpreadsheetApp.openById(SSID);
+  var sheet = ss.getSheetByName('Amazon_Detail');
+  if (!sheet) return {};
+  var data = sheet.getDataRange().getValues();
+  if (!data || data.length < 2) return {};
+  var map = {};
+  for (var i = 1; i < data.length; i++) {
+    var tillerRow = parseInt(data[i][7], 10);
+    if (!tillerRow) continue;
+    if (!map[tillerRow]) map[tillerRow] = [];
+    map[tillerRow].push({
+      qty: parseInt(data[i][2], 10) || 1,
+      desc: String(data[i][3] || ''),
+      price: Math.round((parseFloat(data[i][4]) || 0) * 100) / 100
+    });
+  }
+  return map;
+}
+
 function getRecentTransactions_(days) {
   days = days || 5;
   var ss = SpreadsheetApp.openById(SSID);
@@ -3553,6 +3584,9 @@ function getRecentTransactions_(days) {
   var tz = Session.getScriptTimeZone();
   var now = new Date();
   var cutoff = new Date(now.getTime() - (days * 86400000));
+
+  // Amazon enrichment map (#321) — best-effort; absence is silent.
+  var amazonItems = _buildAmazonItemMap_();
 
   var txList = [];
   var totalIn = 0;
@@ -3570,16 +3604,21 @@ function getRecentTransactions_(days) {
     var cat = String(data[i][3] || 'Uncategorized').trim();
     var desc = String(data[i][2] || '').trim();
     var acct = String(data[i][5] || '').trim();
+    var rowNum = i + 1;
 
-    txList.push({
+    var entry = {
       date: Utilities.formatDate(txDate, tz, 'yyyy-MM-dd'),
       dateDisplay: Utilities.formatDate(txDate, tz, 'EEE MMM d'),
       description: desc.length > 80 ? desc.substring(0, 77) + '...' : desc,
       amount: amt,
       category: cat,
       account: acct,
-      row: i + 1
-    });
+      row: rowNum
+    };
+    if (amazonItems[rowNum] && amazonItems[rowNum].length > 0) {
+      entry.amazonItems = amazonItems[rowNum];
+    }
+    txList.push(entry);
 
     if (amt > 0) totalIn += amt;
     if (amt < 0) totalOut += Math.abs(amt);
@@ -3858,4 +3897,4 @@ function getCloseProofSafe(monthLabel) {
   });
 }
 
-// END OF FILE — DataEngine v96
+// END OF FILE — DataEngine v97

--- a/TheVein.html
+++ b/TheVein.html
@@ -2409,6 +2409,25 @@ function renderTxFeed(data) {
     html += '<td style="padding:3px 6px;white-space:nowrap;">' + (badges || '<span style="color:var(--text-dim);font-size:9px;">\u2014</span>') + '</td>';
     html += '<td style="padding:3px 6px;text-align:center;"><button id="txBtn_' + tx.row + '" onclick="toggleTxReview(' + tx.row + ')" style="background:none;border:none;cursor:pointer;font-size:13px;padding:0 2px;color:' + (reviewed ? '#22c55e' : 'var(--text-muted)') + ';" title="' + (reviewed ? 'Mark unreviewed' : 'Mark reviewed') + '">' + (reviewed ? '\u2713' : '\u25cb') + '</button></td>';
     html += '</tr>';
+
+    // Amazon item detail (#321) — render as a sub-row when matchAmazonToTiller
+    // has joined this Tiller transaction back to Amazon_Detail entries.
+    if (tx.amazonItems && tx.amazonItems.length > 0) {
+      var itemsHtml = '';
+      for (var ai = 0; ai < tx.amazonItems.length; ai++) {
+        var it = tx.amazonItems[ai];
+        var qtyPart = it.qty > 1 ? (it.qty + '\u00d7 ') : '';
+        itemsHtml += '<div style="padding:1px 0;color:var(--text-muted);">' +
+          '<span style="color:var(--text-dim);">\u2937 </span>' +
+          escapeHtml(qtyPart) + escapeHtml(it.desc) +
+          '<span style="float:right;color:var(--text-dim);">$' + fmt(it.price) + '</span>' +
+          '</div>';
+      }
+      html += '<tr' + (reviewed ? ' style="opacity:0.55;"' : '') + '>';
+      html += '<td></td>';
+      html += '<td colspan="6" style="padding:2px 6px 6px 18px;font-size:10px;background:rgba(99,102,241,0.04);">' + itemsHtml + '</td>';
+      html += '</tr>';
+    }
   }
   html += '</table>';
 


### PR DESCRIPTION
Closes #321 (final acceptance item — Amazon item detail from Amazon_Detail tab).

## Summary
Last open acceptance criterion on #321: when a Tiller AMAZON/AMZN/PRIME charge has been matched to Amazon_Detail entries by \`matchAmazonToTiller\`, surface the matched items inline in the recent-tx feed on TheVein. LT can verify charges item-by-item without leaving the dashboard.

## What changed

**Server — \`Dataengine.js\` (v96 → v97):**
- New \`_buildAmazonItemMap_()\` helper reads Amazon_Detail and returns a \`tillerRow → [{qty, desc, price}]\` map. Silent on missing tab (best-effort enrichment).
- \`getRecentTransactions_\` calls the helper and attaches \`amazonItems\` to each tx whose row matches.

**UI — \`TheVein.html\` \`renderTxFeed\`:**
- After each tx row, if \`tx.amazonItems\` is non-empty, render a sub-row with one indented line per item: \`↷ <qty>× <desc> ... \$<price>\`.
- Sub-row uses subtle indigo tint + 10px font for visual hierarchy.
- Inherits parent row's reviewed opacity.

## Acceptance — full status

| # | Criterion | State | Evidence |
|---|---|---|---|
| 1 | Last 5 days transactions, sorted desc | ✅ | already shipped |
| 2 | Amount, description, category, account visible | ✅ | already shipped |
| 3 | Uncategorized / General Shopping highlighted | ✅ | already shipped (UNCAT badge) |
| 4 | **Amazon items from Amazon_Detail when matched** | ✅ | this PR |

## Version bump
- \`Dataengine.js\` line 2 header: \`v96\` → \`v97\`
- \`getDataEngineVersion()\` line 7: \`return 96\` → \`return 97\`
- EOF marker: \`v96\` → \`v97\`

## ES5 compliance
- ✓ No arrow / let / const / template literals / spread / destructuring
- ✓ \`audit-source.sh\` PASS (one expected WARN on deploy-freeze probe — local jq/clasp not installed)

## Manual verification needed (in QA, not blocking merge)
- Visit \`/vein\`, expand Recent Transactions
- An Amazon charge matched by \`matchAmazonToTiller\` should show its items underneath, indented with \`↷\`
- Unmatched Amazon charges (no Amazon_Detail entries) display as before — no sub-row

## Non-conflicts
- All 4 PRs from earlier this session merged
- No hot-file edits
- Touches \`Dataengine.js\` (calculator file — kept change scoped to feed-enrichment helper, no changes to existing financial logic)

## Note on the prod-regression we surfaced earlier
The 3 failing education Playwright tests (#486) won't be impacted by this PR — they're missing-fixture issues on a different code path. Filing the fix for those next.