### PR TITLE
fix(#486): shim logQuestionResultSafe in education test fixtures

### DIFF
--- a/tests/tbm/fixtures/gas-shim.js
+++ b/tests/tbm/fixtures/gas-shim.js
@@ -164,6 +164,12 @@ var EDUCATION_FIXTURES = {
   submitHomeworkSafe: { status: 'ok' },
   logScaffoldEventSafe: { success: true },
   getAudioBatchSafe: {},
+  // logQuestionResultSafe: added to HomeworkModule on 2026-04-11 but never
+  // shimmed. Without this entry, every per-question submission in the
+  // answer-loop tests (brain-break / Monday journal / Friday reflection)
+  // fell through route.continue() to real production GAS via Cloudflare and
+  // accumulated latency past the 90s test timeout. See #486.
+  logQuestionResultSafe: { success: true },
 
   // getWeekProgressSafe: empty completedDays so the catch-up banner renders all
   // missed days in tests (no server-side completions assumed in test fixtures).


### PR DESCRIPTION
Closes #486

## Summary
Root cause: \`logQuestionResultSafe\` was added to HomeworkModule on 2026-04-11 but never added to \`EDUCATION_FIXTURES\` in \`tests/tbm/fixtures/gas-shim.js\`. With the call missing from the fixture map, \`gas-shim.js\` falls through \`route.continue()\` to the real backend — so each per-question answer in the answer-loop tests hit production GAS via Cloudflare. Cumulative latency from 7-9 real submissions exceeded the 90s test timeout.

## Fix
Single line added to the stubs block:
\`\`\`js
logQuestionResultSafe: { success: true },
\`\`\`

Same pattern as \`submitHomeworkSafe\`, \`logScaffoldEventSafe\`, \`getAudioBatchSafe\` — calls that need to succeed but don't need real data shape.

## What this unblocks
The 3 failing education tests on every PR:
- \`Homework: brain break fires after 4 answers > brain-break overlay appears after answering 4 questions\`
- \`Homework: Monday Error Journal appears > error journal renders when clock is set to Monday\`
- \`Homework: Friday Reflection appears > reflection panel renders when clock is set to Friday\`

The \`Plan Your Attack → answer flow\` test was passing because it submitted only ONE answer.

## Why this is the right fix
- Production /homework is **not** broken — answer submission is fast in real use
- The bug is in test isolation: a new server call wasn't added to the fixture allowlist
- Fix is at the right layer (test fixture, not production code, not test logic)
- Pattern-consistent: matches existing stub style in the same file

## Investigation evidence
The diagnostic agent traced the path:
1. \`gas-shim.js\` lines 10-180 = EDUCATION_FIXTURES — \`logQuestionResultSafe\` absent
2. \`gas-shim.js\` line 269 = \`route.continue()\` for unmatched calls (= passes to prod backend)
3. HomeworkModule lines 1783-1829 = \`submitAnswer\` calls \`logQuestionResultSafe\` per question
4. Tests await per-question feedback → cumulative latency on real backend → 90s timeout

## Acceptance
- [ ] All 3 currently-failing education tests pass on this PR's Playwright run
- [ ] Plan Your Attack test still passes (regression check)
- [ ] No production code touched

## Non-conflicts
- Single new-line addition in fixtures, not hot-file
- #487 (#321 Amazon enrichment) — different files