### PR TITLE
feat(#452): claude.ai automation contracts — template + prompts + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -715,6 +715,23 @@ Installed via `installAllOpsTriggersSafe()`. Health via `diagOpsTriggersSafe()`.
 
 ---
 
+## Scheduled Automations (claude.ai)
+
+claude.ai web-app Automations are separate from GAS Triggers. They run in the web app, have **no local filesystem access**, and use only connector tools (GitHub / Notion / Drive). To prevent run-to-run drift, every Automation prompt is one line that fetches a versioned `SKILL.md` from the repo and executes it exactly.
+
+- Canonical schema + the one-line prompt template: `ops/automations/AUTOMATION-TEMPLATE.md`
+- Existing automations: `.claude/scheduled-tasks/<name>/SKILL.md` (10 active)
+- One-line prompt format:
+  ```
+  Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/<name>/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+  ```
+
+When adding a new Automation: write the SKILL.md per the template, then hand LT the one-line prompt to paste in claude.ai. Do not touch claude.ai prompts directly except via this swap.
+
+Output of an Automation goes to one of four destinations: Alert (Pushover), Persistent finding (dedup'd Issue via `hygiene-filer.yml`), Digest (comment on pinned status Issue), or Archive (Notion page append). See template for the full tier table.
+
+---
+
 ## Context Management
 
 - **Step 0 cleanup:** Before any refactor on a file >300 LOC, do a cleanup-only pass first (dead functions, unused variables, stale comments, debug logs). Commit separately. Then start real work. This prevents context compaction from firing mid-task.

--- a/ops/automations/AUTOMATION-TEMPLATE.md
+++ b/ops/automations/AUTOMATION-TEMPLATE.md
@@ -1,0 +1,108 @@
+# Scheduled Automation — SKILL.md Template
+
+Canonical schema for `.claude/scheduled-tasks/<name>/SKILL.md`. All scheduled automations triggered from claude.ai must conform — the claude.ai web UI runs these as `Fetch <URL> via GitHub connector and execute it exactly`, so the SKILL.md IS the contract.
+
+## Why this exists
+
+claude.ai Automation threads have **no local filesystem access**. They run in the web app with connector-only tooling (GitHub / Notion / Drive). Without a single source of truth fetched at run time, every fire improvises from scratch and outputs drift run-to-run. Issue [#452](https://github.com/blucsigma05/tbm-apps-script/issues/452).
+
+## Required schema
+
+Every SKILL.md MUST have:
+
+### 1. Frontmatter (YAML)
+
+```yaml
+---
+name: <kebab-case-task-name>
+description: <one-sentence purpose; include cadence (daily 6am, weekly Mon, monthly 1st)>
+---
+```
+
+- `name` matches the parent folder name exactly
+- `description` includes WHEN it fires + WHAT it produces (one sentence)
+
+### 2. Opening line
+
+One-sentence summary of what the run does, restating the description in active voice. Helps the agent read past the frontmatter and orient.
+
+### 3. `## Steps` section
+
+Numbered list of concrete actions. Each step:
+- Names the tool / endpoint / file explicitly
+- Says what to do with the result
+- Avoids generic advice ("check things") in favor of named operations
+
+For multi-part automations, use `## PART A — <name>` / `## PART B — <name>` instead of `## Steps`. Each part still has a numbered Steps list inside.
+
+### 4. `## Output` section
+
+Specifies the destination + format. Must use one of the four tier categories from the **Destination Tier Table** below.
+
+### 5. `## On error` (or `## Override behavior`)
+
+What to do when a step fails or when the run should be skipped. At minimum: which Pushover priority fires on failure, what gets silently swallowed.
+
+## Destination Tier Table
+
+Every automation output goes to exactly one of these four destinations. Mixing is allowed but each output line needs its tier called out.
+
+| Tier | Destination | Use for |
+|---|---|---|
+| **Alert** | Pushover (named priority from `PUSHOVER_PRIORITY.*` in `AlertEngine.gs`) | Red/yellow operational signals — system down, gate breach, deploy fail |
+| **Persistent finding** | Dedup'd Issue via `hygiene-filer.yml` (`.github/scripts/file_hygiene_issue.py`) | Anything needing a ticket — drift, broken state, recurring pattern |
+| **Digest** | Comment on a pinned status Issue | Weekly rollups, low-priority recurring summaries |
+| **Archive** | Append to a Notion page | Historical audit trail, raw data for later analysis |
+
+For Pushover specifically, **always use the named constant**, never a bare integer. Reference `CLAUDE.md` § "Alert Tiers (HYG-12)" for the full table.
+
+## The one-line claude.ai prompt template
+
+Every Automation in the claude.ai web UI uses this exact prompt — substitute `<name>` for the folder name:
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/<name>/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+Why a single line:
+- Edit SKILL.md once → all future fires pick up the change in ≤24h (next scheduled run)
+- claude.ai UI prompts are not under version control — minimizing what lives there minimizes drift surface
+- "Do not improvise" + "stop on missing capability" is the anti-drift discipline
+
+## Validation checklist for new automations
+
+Before adding a new SKILL.md:
+
+- [ ] Frontmatter `name` matches folder name exactly
+- [ ] `description` says WHEN + WHAT in one sentence
+- [ ] Opening line restates purpose in active voice
+- [ ] `## Steps` (or `## PART A` / `## PART B`) with numbered actions
+- [ ] `## Output` names destination tier from the table above
+- [ ] `## On error` or `## Override behavior` defines failure behavior
+- [ ] Pushover calls use named constants, not bare integers
+- [ ] LT has been handed the one-line prompt to paste in claude.ai
+
+## Where to find things
+
+- Existing SKILL.md files: `.claude/scheduled-tasks/<name>/SKILL.md`
+- Pushover priority constants: `AlertEngine.gs` → `PUSHOVER_PRIORITY.*`
+- Hygiene Issue filer: `.github/scripts/file_hygiene_issue.py`
+- Pinned status Issues: managed via `vars.STATUS_ISSUE_NUMBER`
+- Notion archive root: see `CLAUDE.md` § "Notion IDs + Update Rules"
+
+## Reference: existing automations (audit snapshot 2026-04-19)
+
+| Folder | Cadence | Output tier(s) | Schema status |
+|---|---|---|---|
+| `morning-health-check` | Daily 6am | Alert (Pushover) | ✓ conforms |
+| `stale-pr-check` | Daily 8am | Alert (Pushover) | ✓ conforms |
+| `version-drift-check` | Daily 7am | Alert + Persistent finding | ✓ conforms |
+| `sheet-schema-drift` | Daily 6:30am | Alert + Persistent finding | ✓ conforms |
+| `spec-quality-gate` | Daily 8:30am | Alert | ✓ conforms |
+| `issue-pr-deploy-traceability` | Saturday 6am | Alert + Persistent finding | ✓ conforms (multi-part) |
+| `monday-drift-sweep` | Weekly Monday 6am | Digest | ✓ conforms (multi-part) |
+| `monthly-health-and-structure` | 1st of month 6am | Digest + Archive | ✓ conforms (multi-part) |
+| `weekly-notion-cleanup` | Weekly | Archive | confirms after audit |
+| `claude-md-review` | Periodic | Archive (Notion) | **drift** — uses inline numbered list instead of `## Steps`; lacks `## Output` + `## On error` headers |
+
+The one drift case (`claude-md-review`) functions correctly today — its inline list is parseable — but it doesn't match the schema and breaks the agent's pattern-matching when reading multiple SKILL.md files in one fire. Normalization is a follow-up Issue, not blocking for this template land.

--- a/ops/automations/CLAUDE-AI-PROMPTS.md
+++ b/ops/automations/CLAUDE-AI-PROMPTS.md
@@ -1,0 +1,87 @@
+# claude.ai Automation Prompts — Copy-Paste Reference
+
+LT pastes these one-liners into the claude.ai Automations UI. Each replaces whatever prompt currently lives there. Per Issue [#452](https://github.com/blucsigma05/tbm-apps-script/issues/452) — single source of truth is the SKILL.md, not the claude.ai prompt.
+
+> **How to swap.** Open the Automation in claude.ai → edit the prompt → paste the matching line below → save. The next scheduled fire (≤24h) picks up the new contract. No deploy needed; no Claude Code involvement.
+
+---
+
+## The 10 Automations
+
+### 1. morning-health-check (daily 6am)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/morning-health-check/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+### 2. stale-pr-check (daily 8am)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/stale-pr-check/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+### 3. version-drift-check (daily 7am)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/version-drift-check/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+### 4. sheet-schema-drift (daily 6:30am)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/sheet-schema-drift/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+### 5. spec-quality-gate (daily 8:30am)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/spec-quality-gate/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+### 6. issue-pr-deploy-traceability (Saturday 6am)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/issue-pr-deploy-traceability/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+### 7. monday-drift-sweep (Monday 6am)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/monday-drift-sweep/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+### 8. monthly-health-and-structure (1st of month 6am)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/monthly-health-and-structure/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+### 9. weekly-notion-cleanup (weekly)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/weekly-notion-cleanup/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+### 10. claude-md-review (periodic)
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/main/.claude/scheduled-tasks/claude-md-review/SKILL.md via the GitHub connector and execute it exactly. Do not improvise. If a step requires capability not available in this thread, send a Pushover SYSTEM_ERROR (1) and stop.
+```
+
+---
+
+## After swap — verification
+
+Next morning after you swap any of these, watch the Pushover for the run. The body should match the `## Output` section in the corresponding SKILL.md verbatim. If the format drifts, that's a sign the prompt didn't take or claude.ai cached the old one — re-paste and confirm.
+
+For the daily ones (1–5), give it 24h. For the weekly/monthly ones, the next firing is the verification window.
+
+## When the URL changes (don't, but if you have to)
+
+These prompts hardcode the `main` branch. If you ever need to test a SKILL.md change before merge, point a single Automation's prompt at your branch:
+
+```
+Fetch https://raw.githubusercontent.com/blucsigma05/tbm-apps-script/<branch>/.claude/scheduled-tasks/<name>/SKILL.md via the GitHub connector and execute it exactly. ...
+```
+
+Swap back to `main` after the branch merges. Don't leave a non-main pointer in production — once the branch deletes, the URL 404s and the Automation breaks silently.


### PR DESCRIPTION
Closes #452

## Summary
claude.ai web-app Automations have no local filesystem access. They run with connector-only tooling (GitHub / Notion / Drive). Without a single source of truth, every fire improvises and outputs drift run-to-run. Fix: every Automation prompt becomes one line that fetches a versioned SKILL.md from the repo and executes it exactly.

## What landed

| File | Role |
|---|---|
| \`ops/automations/AUTOMATION-TEMPLATE.md\` | Canonical schema for SKILL.md (frontmatter + Steps + Output + On error). Destination Tier Table. One-line prompt template. Validation checklist. Audit snapshot of all 10 existing SKILL.md. |
| \`ops/automations/CLAUDE-AI-PROMPTS.md\` | 10 copy-paste one-liners. LT pastes each into the claude.ai Automations UI to replace improvised prompts. |
| \`CLAUDE.md\` | New \"Scheduled Automations (claude.ai)\" section between GAS Triggers and Context Management. |

## Audit results — 10/10 SKILL.md surveyed

| # | Folder | Cadence | Output tier(s) | Conforms? |
|---|---|---|---|---|
| 1 | morning-health-check | Daily 6am | Alert | ✓ |
| 2 | stale-pr-check | Daily 8am | Alert | ✓ |
| 3 | version-drift-check | Daily 7am | Alert + Persistent | ✓ |
| 4 | sheet-schema-drift | Daily 6:30am | Alert + Persistent | ✓ |
| 5 | spec-quality-gate | Daily 8:30am | Alert | ✓ |
| 6 | issue-pr-deploy-traceability | Sat 6am | Alert + Persistent | ✓ multi-part |
| 7 | monday-drift-sweep | Mon 6am | Digest | ✓ multi-part |
| 8 | monthly-health-and-structure | 1st 6am | Digest + Archive | ✓ multi-part |
| 9 | weekly-notion-cleanup | Weekly | Archive | ✓ |
| 10 | claude-md-review | Periodic | Archive | ⚠️ inline numbered list, no \`## Steps\` / \`## Output\` headers |

9 of 10 conform. The 1 drift case (\`claude-md-review\`) functions today but breaks pattern-matching when an agent reads multiple SKILL.md in one fire. Filing a follow-up Issue for normalization — out of scope here so this PR lands the template first.

## Action for LT (after merge)

Paste each of the 10 one-liners from \`ops/automations/CLAUDE-AI-PROMPTS.md\` into the matching Automation in claude.ai. The next firing (≤24h for daily, next cycle for weekly/monthly) will use the SKILL.md verbatim. Watch the first Pushover from each — body should match the SKILL.md \`## Output\` section exactly.

## Hot-file note
Touches CLAUDE.md (hot-file). No other CLAUDE.md PR currently in flight (verified). Adds 19 lines as a new bottom-of-file section, no edits to existing content. Should not conflict with anything.

## Non-conflicts
- #487 (#321 Amazon enrichment) — different files
- #489 (#486 fixture fix) — different files
- All today's earlier merges (#481/#482/#484) already on main

## Out of scope
- Adding new automations (5 empty slots in claude.ai UI)
- Editing claude.ai prompts directly (only LT can do that — this PR delivers the strings to paste)
- Rewriting the 1 non-conforming SKILL.md (separate follow-up Issue)